### PR TITLE
feat(core): wire execute_action + trigger_flow rule effects (Spec 23 §1.1, phase 3)

### DIFF
--- a/.changeset/wire-trigger-flow.md
+++ b/.changeset/wire-trigger-flow.md
@@ -1,0 +1,17 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+"@linchkit/cli": patch
+---
+
+feat(core): wire execute_action + trigger_flow rule effects (Spec 23 §1.1, phase 3)
+
+Final phase of wiring `defineRule()` effects into the action-execution path (phase 1 block/warn/enrich #460, phase 2 require_approval + record-state #461). Adds the two **post-commit side-effect** effects.
+
+- New `TriggerFlowEffect` (`{ type: "trigger_flow", flow, input? }`) on the `RuleEffect` union; the rule engine collects `execute_action` and `trigger_flow` effects into `RuleEvalOutput.actions` / `RuleEvalOutput.flows`.
+- The executor runs both **after the write is durable** (alongside the event flush, root / non-transactional only — a nested action inside a parent transaction must not fire side effects before the parent commits), **best-effort**: a side-effect failure logs and never fails the already-committed action.
+  - `execute_action` re-invokes the named action via the executor (`params` default to the triggering action's input).
+  - `trigger_flow` starts a durable Flow via a new optional `flowEngine` (`ActionFlowStarter`, a structural subset of `FlowEngine`) + late-binding `executor.setFlowEngine()` seam; per Spec 26 §2.2 the Flow owns its own Saga/failure policy and is not compensation-coupled to the triggering action (`input` defaults to the action input). When no flow engine is wired, the effect is logged and skipped.
+- Wiring: CLI `dev` calls `executor.setFlowEngine(flowEngine)`. `RuntimeContextOptions` gains an optional `flowEngine` the boot path can inject. (The server does not yet aggregate flows at the runtime-context layer, so server-side `trigger_flow` is wired through this seam — building/aggregating the server flow engine is a follow-up.)
+
+Tests: `action-engine-rule-integration.test.ts` adds execute_action (runs post-commit with params), trigger_flow (starts the flow; `effect.input` override; no-engine skip), and a blocked-action-skips-side-effects case — all through the real executor. Non-breaking. No `any`/`!`.

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -19,6 +19,7 @@ import type {
   EntityDefinition,
   EventBus,
   ExecutionLogger,
+  FlowEngine,
   InterfaceDefinition,
   MiddlewareRegistration,
   RuleDefinition,
@@ -76,6 +77,11 @@ export interface RuntimeContextOptions {
    * persistent approvals in production.
    */
   approvalStore?: ApprovalStore;
+  /**
+   * Flow engine used to start durable Flows on `trigger_flow` rule effects
+   * (post-commit). When omitted, trigger_flow rules are logged and skipped.
+   */
+  flowEngine?: FlowEngine;
   middlewares?: MiddlewareRegistration[];
   /** Interface definitions — registered before schemas so field injection/validation works */
   interfaces?: InterfaceDefinition[];
@@ -192,6 +198,12 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
   });
   approvalEngine.setExecutor(executor);
   executor.setApprovalEngine(approvalEngine);
+
+  // Wire the flow engine for `trigger_flow` rule effects when one is provided
+  // (the boot path injects it; the server does not yet aggregate flows here).
+  if (options?.flowEngine) {
+    executor.setFlowEngine(options.flowEngine);
+  }
 
   // Register views grouped by schema
   const views = new Map<string, ViewDefinition[]>();

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -11,6 +11,7 @@
 import type {
   ActionDefinition,
   ActionExecutor,
+  ActionFlowStarter,
   AIService,
   ApprovalEngine,
   ApprovalStore,
@@ -19,7 +20,6 @@ import type {
   EntityDefinition,
   EventBus,
   ExecutionLogger,
-  FlowEngine,
   InterfaceDefinition,
   MiddlewareRegistration,
   RuleDefinition,
@@ -78,10 +78,11 @@ export interface RuntimeContextOptions {
    */
   approvalStore?: ApprovalStore;
   /**
-   * Flow engine used to start durable Flows on `trigger_flow` rule effects
-   * (post-commit). When omitted, trigger_flow rules are logged and skipped.
+   * Flow starter used to start durable Flows on `trigger_flow` rule effects
+   * (post-commit). The minimal `ActionFlowStarter` interface (a `FlowEngine`
+   * satisfies it) — when omitted, trigger_flow rules are logged and skipped.
    */
-  flowEngine?: FlowEngine;
+  flowEngine?: ActionFlowStarter;
   middlewares?: MiddlewareRegistration[];
   /** Interface definitions — registered before schemas so field injection/validation works */
   interfaces?: InterfaceDefinition[];

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -437,6 +437,13 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     triggerBinding.bindAll(flowRegistry.getAll(), flowEngine);
   }
 
+  // Wire the flow engine into the executor so a `trigger_flow` rule effect can
+  // start a durable Flow post-commit (Spec 23 §1.1). Late-bound — the flow
+  // engine is built after the executor above.
+  if (flowEngine) {
+    executor.setFlowEngine(flowEngine);
+  }
+
   // Build DerivedPropertyEngine — auto-computes derived fields on write and read
   const derivedPropertyEngine = createDerivedPropertyEngine();
   derivedPropertyEngine.register(entities);

--- a/packages/core/__tests__/action-engine-rule-integration.test.ts
+++ b/packages/core/__tests__/action-engine-rule-integration.test.ts
@@ -15,6 +15,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import {
   type ActionApprovalSuspender,
+  type ActionFlowStarter,
   createActionExecutor,
   type DataProvider,
 } from "../src/engine/action-engine";
@@ -31,6 +32,8 @@ interface Captured {
   handlerInput: Record<string, unknown> | null;
   /** Extra fields the mock `get` returns for a record — drives record-state tests. */
   existingFields: Record<string, unknown>;
+  /** Input the `notify` side-effect action received (execute_action tests). */
+  notifiedWith: Record<string, unknown> | null;
 }
 
 function makeDataProvider(captured: Captured): DataProvider {
@@ -62,6 +65,35 @@ function makeAction(captured: Captured): ActionDefinition {
       captured.handlerInput = { ...(ctx.input as Record<string, unknown>) };
       const record = await ctx.create("request", ctx.input as Record<string, unknown>);
       return record;
+    },
+  };
+}
+
+/** Side-effect action targeted by execute_action rules — records that it ran. */
+function makeNotifyAction(captured: Captured): ActionDefinition {
+  return {
+    name: "notify",
+    entity: "request",
+    label: "Notify",
+    policy: { mode: "sync", transaction: false },
+    exposure: "all",
+    handler: async (ctx) => {
+      captured.notifiedWith = { ...(ctx.input as Record<string, unknown>) };
+      return { notified: true };
+    },
+  };
+}
+
+/** Captures trigger_flow startFlow calls. */
+interface FlowCapture {
+  started: { flow: string; input: Record<string, unknown> } | null;
+}
+
+function makeFlowStarter(cap: FlowCapture): ActionFlowStarter {
+  return {
+    startFlow: async (flow, input) => {
+      cap.started = { flow, input };
+      return { id: "flow_1" };
     },
   };
 }
@@ -121,17 +153,29 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
   let captured: Captured;
 
   beforeEach(() => {
-    captured = { created: null, updated: null, handlerInput: null, existingFields: {} };
+    captured = {
+      created: null,
+      updated: null,
+      handlerInput: null,
+      existingFields: {},
+      notifiedWith: null,
+    };
   });
 
-  function build(rules: RuleDefinition[] | undefined, approvalEngine?: ActionApprovalSuspender) {
+  function build(
+    rules: RuleDefinition[] | undefined,
+    approvalEngine?: ActionApprovalSuspender,
+    flowEngine?: ActionFlowStarter,
+  ) {
     const executor = createActionExecutor({
       dataProvider: makeDataProvider(captured),
       rules,
       approvalEngine,
+      flowEngine,
     });
     executor.registry.register(makeAction(captured));
     executor.registry.register(makeDeclarativeUpdateAction());
+    executor.registry.register(makeNotifyAction(captured));
     return executor;
   }
 
@@ -325,5 +369,93 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
 
     expect(result.success).toBe(true);
     expect(captured.updated).not.toBeNull();
+  });
+
+  it("execute_action: runs the named action post-commit (after the primary write)", async () => {
+    const rule: RuleDefinition = {
+      name: "notify_on_submit",
+      label: "Notify on submit",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "execute_action", action: "notify", params: { channel: "email" } },
+    };
+    const executor = build([rule]);
+    const result = await executor.execute("submit_request", { amount: 10 }, actor);
+
+    expect(result.success).toBe(true);
+    // Primary write happened …
+    expect(captured.created).toMatchObject({ amount: 10 });
+    // … and the side-effect action ran with its params.
+    expect(captured.notifiedWith).toMatchObject({ channel: "email" });
+  });
+
+  it("trigger_flow: starts the flow post-commit via the flow engine", async () => {
+    const flowCap: FlowCapture = { started: null };
+    const rule: RuleDefinition = {
+      name: "kickoff_flow",
+      label: "Kick off fulfilment flow",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "trigger_flow", flow: "fulfilment" },
+    };
+    const executor = build([rule], undefined, makeFlowStarter(flowCap));
+    const result = await executor.execute("submit_request", { amount: 42 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.created).toMatchObject({ amount: 42 }); // write happened first
+    expect(flowCap.started?.flow).toBe("fulfilment");
+    // Defaults the flow input to the (enriched) action input.
+    expect(flowCap.started?.input).toMatchObject({ amount: 42 });
+  });
+
+  it("trigger_flow: explicit effect.input overrides the action input", async () => {
+    const flowCap: FlowCapture = { started: null };
+    const rule: RuleDefinition = {
+      name: "kickoff_flow_custom",
+      label: "Kick off with custom input",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "trigger_flow", flow: "audit", input: { reason: "high_value" } },
+    };
+    const executor = build([rule], undefined, makeFlowStarter(flowCap));
+    await executor.execute("submit_request", { amount: 42 }, actor);
+
+    expect(flowCap.started?.flow).toBe("audit");
+    expect(flowCap.started?.input).toEqual({ reason: "high_value" });
+  });
+
+  it("trigger_flow: with no flow engine wired, the action still succeeds (skip + log)", async () => {
+    const rule: RuleDefinition = {
+      name: "kickoff_flow_noengine",
+      label: "Kick off flow",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "trigger_flow", flow: "fulfilment" },
+    };
+    const executor = build([rule]); // no flowEngine
+    const result = await executor.execute("submit_request", { amount: 42 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.created).toMatchObject({ amount: 42 });
+  });
+
+  it("post-commit effects do NOT run when the action is blocked", async () => {
+    const flowCap: FlowCapture = { started: null };
+    const rules: RuleDefinition[] = [
+      blockRule(),
+      {
+        name: "kickoff_flow_blocked",
+        label: "Kick off flow",
+        trigger: { action: "submit_request" },
+        condition: { field: "target.amount", operator: "gt", value: 0 },
+        effect: { type: "trigger_flow", flow: "fulfilment" },
+      },
+    ];
+    const executor = build(rules, undefined, makeFlowStarter(flowCap));
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor);
+
+    expect(result.success).toBe(false); // blocked
+    expect(captured.created).toBeNull(); // no write
+    expect(flowCap.started).toBeNull(); // and no post-commit side effect
   });
 });

--- a/packages/core/__tests__/action-engine-rule-integration.test.ts
+++ b/packages/core/__tests__/action-engine-rule-integration.test.ts
@@ -84,15 +84,15 @@ function makeNotifyAction(captured: Captured): ActionDefinition {
   };
 }
 
-/** Captures trigger_flow startFlow calls. */
+/** Captures trigger_flow startFlow calls (an array so tests can assert count + order). */
 interface FlowCapture {
-  started: { flow: string; input: Record<string, unknown> } | null;
+  started: Array<{ flow: string; input: Record<string, unknown> }>;
 }
 
 function makeFlowStarter(cap: FlowCapture): ActionFlowStarter {
   return {
     startFlow: async (flow, input) => {
-      cap.started = { flow, input };
+      cap.started.push({ flow, input });
       return { id: "flow_1" };
     },
   };
@@ -390,7 +390,7 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
   });
 
   it("trigger_flow: starts the flow post-commit via the flow engine", async () => {
-    const flowCap: FlowCapture = { started: null };
+    const flowCap: FlowCapture = { started: [] };
     const rule: RuleDefinition = {
       name: "kickoff_flow",
       label: "Kick off fulfilment flow",
@@ -403,13 +403,14 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
 
     expect(result.success).toBe(true);
     expect(captured.created).toMatchObject({ amount: 42 }); // write happened first
-    expect(flowCap.started?.flow).toBe("fulfilment");
+    expect(flowCap.started).toHaveLength(1);
+    expect(flowCap.started[0]?.flow).toBe("fulfilment");
     // Defaults the flow input to the (enriched) action input.
-    expect(flowCap.started?.input).toMatchObject({ amount: 42 });
+    expect(flowCap.started[0]?.input).toMatchObject({ amount: 42 });
   });
 
   it("trigger_flow: explicit effect.input overrides the action input", async () => {
-    const flowCap: FlowCapture = { started: null };
+    const flowCap: FlowCapture = { started: [] };
     const rule: RuleDefinition = {
       name: "kickoff_flow_custom",
       label: "Kick off with custom input",
@@ -420,8 +421,8 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
     const executor = build([rule], undefined, makeFlowStarter(flowCap));
     await executor.execute("submit_request", { amount: 42 }, actor);
 
-    expect(flowCap.started?.flow).toBe("audit");
-    expect(flowCap.started?.input).toEqual({ reason: "high_value" });
+    expect(flowCap.started[0]?.flow).toBe("audit");
+    expect(flowCap.started[0]?.input).toEqual({ reason: "high_value" });
   });
 
   it("trigger_flow: with no flow engine wired, the action still succeeds (skip + log)", async () => {
@@ -460,7 +461,7 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
     // A transactional parent calls a child via ctx.execute; the child has a
     // trigger_flow rule. The child's side effect must bubble to the parent and
     // fire on the parent's commit — not be silently dropped (codex P2).
-    const flowCap: FlowCapture = { started: null };
+    const flowCap: FlowCapture = { started: [] };
     const childRule: RuleDefinition = {
       name: "child_flow",
       label: "Child flow",
@@ -494,17 +495,22 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
       exposure: "all",
       handler: async (ctx) => {
         await ctx.execute("child_act", { amount: 5 });
+        // The child's trigger_flow must NOT have fired yet — it bubbles up and
+        // fires only when THIS (parent) execution commits.
+        expect(flowCap.started).toHaveLength(0);
         return { ok: true };
       },
     });
     const result = await executor.execute("parent_act", { amount: 5 }, actor);
 
     expect(result.success).toBe(true);
-    expect(flowCap.started?.flow).toBe("child_flow");
+    // Fired exactly once, on the parent's post-commit.
+    expect(flowCap.started).toHaveLength(1);
+    expect(flowCap.started[0]?.flow).toBe("child_flow");
   });
 
   it("post-commit effects do NOT run when the action is blocked", async () => {
-    const flowCap: FlowCapture = { started: null };
+    const flowCap: FlowCapture = { started: [] };
     const rules: RuleDefinition[] = [
       blockRule(),
       {
@@ -520,6 +526,6 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
 
     expect(result.success).toBe(false); // blocked
     expect(captured.created).toBeNull(); // no write
-    expect(flowCap.started).toBeNull(); // and no post-commit side effect
+    expect(flowCap.started).toHaveLength(0); // and no post-commit side effect
   });
 });

--- a/packages/core/__tests__/action-engine-rule-integration.test.ts
+++ b/packages/core/__tests__/action-engine-rule-integration.test.ts
@@ -439,6 +439,70 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
     expect(captured.created).toMatchObject({ amount: 42 });
   });
 
+  it("execute_action cycle terminates (recursion-depth guarded)", async () => {
+    // A rule whose execute_action re-runs the SAME action would loop forever if
+    // the post-commit invocation didn't count against the depth guard (codex P2).
+    const selfRule: RuleDefinition = {
+      name: "loop_self",
+      label: "Self-executing rule",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "execute_action", action: "submit_request" },
+    };
+    const executor = build([selfRule]);
+    // Completing at all (no stack overflow / hang) proves the cycle is bounded.
+    const result = await executor.execute("submit_request", { amount: 1 }, actor);
+    expect(result.success).toBe(true);
+    expect(captured.created).not.toBeNull();
+  });
+
+  it("nested: a child's trigger_flow bubbles to the parent's post-commit (fires once)", async () => {
+    // A transactional parent calls a child via ctx.execute; the child has a
+    // trigger_flow rule. The child's side effect must bubble to the parent and
+    // fire on the parent's commit — not be silently dropped (codex P2).
+    const flowCap: FlowCapture = { started: null };
+    const childRule: RuleDefinition = {
+      name: "child_flow",
+      label: "Child flow",
+      trigger: { action: "child_act" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "trigger_flow", flow: "child_flow" },
+    };
+    const txManager = {
+      runInTransaction: async <T>(fn: (p: DataProvider) => Promise<T>) =>
+        fn(makeDataProvider(captured)),
+    };
+    const executor = createActionExecutor({
+      dataProvider: makeDataProvider(captured),
+      transactionManager: txManager,
+      rules: [childRule],
+      flowEngine: makeFlowStarter(flowCap),
+    });
+    executor.registry.register({
+      name: "child_act",
+      entity: "request",
+      label: "Child",
+      policy: { mode: "sync", transaction: true },
+      exposure: "all",
+      handler: async () => ({ ok: true }),
+    });
+    executor.registry.register({
+      name: "parent_act",
+      entity: "request",
+      label: "Parent",
+      policy: { mode: "sync", transaction: true },
+      exposure: "all",
+      handler: async (ctx) => {
+        await ctx.execute("child_act", { amount: 5 });
+        return { ok: true };
+      },
+    });
+    const result = await executor.execute("parent_act", { amount: 5 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(flowCap.started?.flow).toBe("child_flow");
+  });
+
   it("post-commit effects do NOT run when the action is blocked", async () => {
     const flowCap: FlowCapture = { started: null };
     const rules: RuleDefinition[] = [

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -137,6 +137,14 @@ export interface ExecuteOptions {
   /** Internal: parent's pending events array for shared transaction */
   _parentPendingEvents?: PendingEvent[];
   /**
+   * Internal: parent's pending post-commit rule side-effect arrays for a shared
+   * transaction. A nested action inside a parent tx bubbles its collected
+   * `execute_action` / `trigger_flow` effects here so they run when the PARENT
+   * commits, instead of firing before the (not-yet-committed) parent write.
+   */
+  _parentPendingRuleActions?: ExecuteActionEffect[];
+  _parentPendingRuleFlows?: TriggerFlowEffect[];
+  /**
    * Execution metadata propagated through the execution chain (Spec 65).
    *
    * Accepts either a pre-built `ExecutionMeta` (how the CommandLayer and the
@@ -1489,6 +1497,10 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
           _depth: currentDepth + 1,
           _txDataProvider: childTxDataProvider,
           _parentPendingEvents: childParentPendingEvents,
+          // Bubble the child's post-commit rule side effects up to this parent
+          // (shared tx) so they fire on the parent's commit, not before it.
+          _parentPendingRuleActions: inTransaction ? pendingRuleActions : undefined,
+          _parentPendingRuleFlows: inTransaction ? pendingRuleFlows : undefined,
           meta: childMeta,
         });
         childExecutionIds.push(childResult.executionId);
@@ -1883,11 +1895,17 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       }
 
       // Post-commit rule side effects (Spec 23 §1.1 / Spec 26 §2.2 — eventual
-      // consistency). Run only at the root / non-transactional level (same guard
-      // as the event flush): a nested action inside a parent transaction must
-      // not fire side effects before the parent commits. Best-effort — a failure
-      // here never fails the already-committed action.
-      if (
+      // consistency). A nested action inside a parent transaction bubbles its
+      // effects up so they fire on the PARENT's commit (mirrors event flush);
+      // the root / non-transactional level runs them — including any bubbled up
+      // from children. Best-effort — a failure here never fails the
+      // already-committed action.
+      const bubbleRuleActions = execOptions?._parentPendingRuleActions;
+      const bubbleRuleFlows = execOptions?._parentPendingRuleFlows;
+      if (bubbleRuleActions && bubbleRuleFlows) {
+        bubbleRuleActions.push(...pendingRuleActions);
+        bubbleRuleFlows.push(...pendingRuleFlows);
+      } else if (
         !execOptions?._txDataProvider &&
         (pendingRuleActions.length > 0 || pendingRuleFlows.length > 0)
       ) {
@@ -1896,6 +1914,9 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             await execute(act.action, act.params ?? effectiveInput, actor, {
               tenantId: execOptions?.tenantId,
               meta: resolvedMeta,
+              // Count against the recursion-depth guard so an execute_action
+              // cycle (a rule re-executing its own action) cannot loop forever.
+              _depth: currentDepth + 1,
             });
           } catch (err) {
             logger.warn(

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1914,13 +1914,25 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       ) {
         for (const act of pendingRuleActions) {
           try {
-            await execute(act.action, act.params ?? effectiveInput, actor, {
+            // Stamp provenance like ctx.execute: `_source_action` (caller) +
+            // `_depth` in meta, plus `_depth` as an ExecuteOptions field so the
+            // recursion-depth guard bounds an execute_action cycle.
+            const childMeta = extendExecutionMeta(
+              resolvedMeta,
+              {},
+              { _depth: currentDepth + 1, _source_action: actionName },
+            );
+            const result = await execute(act.action, act.params ?? effectiveInput, actor, {
               tenantId: execOptions?.tenantId,
-              meta: resolvedMeta,
-              // Count against the recursion-depth guard so an execute_action
-              // cycle (a rule re-executing its own action) cannot loop forever.
+              meta: childMeta,
               _depth: currentDepth + 1,
             });
+            if (!result.success) {
+              const data = result.data as { error?: unknown } | undefined;
+              logger.warn(
+                `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" did not succeed: ${typeof data?.error === "string" ? data.error : "unknown error"}`,
+              );
+            }
           } catch (err) {
             logger.warn(
               `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -28,7 +28,12 @@ import {
   redactMetaForLog,
 } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
-import type { RequireApprovalEffect, RuleDefinition } from "../types/rule";
+import type {
+  ExecuteActionEffect,
+  RequireApprovalEffect,
+  RuleDefinition,
+  TriggerFlowEffect,
+} from "../types/rule";
 import {
   checkFieldLocks,
   type FieldLockViolation,
@@ -184,6 +189,19 @@ export interface ActionApprovalSuspender {
   }): Promise<ApprovalPendingResult>;
 }
 
+/**
+ * Minimal flow surface the executor needs to start a durable Flow as a
+ * post-commit `trigger_flow` rule side effect. Structural (a subset of
+ * FlowEngine) so the executor doesn't depend on the flow engine implementation.
+ */
+export interface ActionFlowStarter {
+  startFlow(
+    flowName: string,
+    input: Record<string, unknown>,
+    options?: { tenantId?: string; actor?: Actor },
+  ): Promise<unknown>;
+}
+
 export interface ActionExecutor {
   readonly registry: ActionRegistry;
 
@@ -201,6 +219,13 @@ export interface ActionExecutor {
    * one must be constructed first and wired to the other afterwards.
    */
   setApprovalEngine(engine: ActionApprovalSuspender): void;
+
+  /**
+   * Late-bind the flow engine used to start durable Flows on `trigger_flow`
+   * rule effects (post-commit, fire-and-forget). Optional — when unset, a
+   * trigger_flow effect is logged and skipped (no flow is started).
+   */
+  setFlowEngine(engine: ActionFlowStarter): void;
 }
 
 // ── Transactional event collection ──────────────────────────
@@ -312,6 +337,13 @@ export interface ActionExecutorOptions {
    * break the executor ↔ approval-engine dependency cycle.
    */
   approvalEngine?: ActionApprovalSuspender;
+  /**
+   * Flow engine used to start durable Flows on `trigger_flow` rule effects
+   * (post-commit, fire-and-forget). Optional — when omitted, a trigger_flow
+   * effect is logged and skipped. May also be wired after construction via
+   * `executor.setFlowEngine`.
+   */
+  flowEngine?: ActionFlowStarter;
 }
 
 /**
@@ -448,6 +480,12 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
   let approvalEngineRef = options.approvalEngine;
   function setApprovalEngine(engine: ActionApprovalSuspender): void {
     approvalEngineRef = engine;
+  }
+
+  // Flow engine for `trigger_flow` rule effects (post-commit, fire-and-forget).
+  let flowEngineRef = options.flowEngine;
+  function setFlowEngine(engine: ActionFlowStarter): void {
+    flowEngineRef = engine;
   }
 
   /** Silent noop logger — used when no logger is injected */
@@ -875,6 +913,10 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // effect merges its setFields into the input.
     let effectiveInput: Record<string, unknown> = inputValidation.value ?? input;
     const ruleWarnings: string[] = [];
+    // Post-commit rule side effects (run after the write is durable): collected
+    // by Step 4c, executed best-effort near the event flush below.
+    const pendingRuleActions: ExecuteActionEffect[] = [];
+    const pendingRuleFlows: TriggerFlowEffect[] = [];
 
     // Build ActionContext
     const childExecutionIds: string[] = [];
@@ -1062,6 +1104,10 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
           effectiveInput = { ...effectiveInput, ...ruleOutput.enrichFields };
         }
         for (const warn of ruleOutput.warnings) ruleWarnings.push(warn.message);
+        // execute_action / trigger_flow are side effects — defer them to the
+        // post-commit point so they only run once the write is durable.
+        pendingRuleActions.push(...ruleOutput.actions);
+        pendingRuleFlows.push(...ruleOutput.flows);
       }
     }
 
@@ -1836,6 +1882,47 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         }
       }
 
+      // Post-commit rule side effects (Spec 23 §1.1 / Spec 26 §2.2 — eventual
+      // consistency). Run only at the root / non-transactional level (same guard
+      // as the event flush): a nested action inside a parent transaction must
+      // not fire side effects before the parent commits. Best-effort — a failure
+      // here never fails the already-committed action.
+      if (
+        !execOptions?._txDataProvider &&
+        (pendingRuleActions.length > 0 || pendingRuleFlows.length > 0)
+      ) {
+        for (const act of pendingRuleActions) {
+          try {
+            await execute(act.action, act.params ?? effectiveInput, actor, {
+              tenantId: execOptions?.tenantId,
+              meta: resolvedMeta,
+            });
+          } catch (err) {
+            logger.warn(
+              `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+        for (const fl of pendingRuleFlows) {
+          if (!flowEngineRef) {
+            logger.warn(
+              `[rule:trigger_flow] no flow engine wired — skipping flow "${fl.flow}" triggered by a rule on "${actionName}".`,
+            );
+            continue;
+          }
+          try {
+            await flowEngineRef.startFlow(fl.flow, fl.input ?? effectiveInput, {
+              tenantId: execOptions?.tenantId,
+              actor,
+            });
+          } catch (err) {
+            logger.warn(
+              `[rule:trigger_flow] starting flow "${fl.flow}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+      }
+
       return {
         success: true,
         data: resultData as T,
@@ -1927,5 +2014,6 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     registry,
     execute,
     setApprovalEngine,
+    setFlowEngine,
   };
 }

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1900,12 +1900,15 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       // the root / non-transactional level runs them — including any bubbled up
       // from children. Best-effort — a failure here never fails the
       // already-committed action.
+      // Bubble each channel independently (mirrors event handling) — coupling
+      // them with `&&` would risk silently dropping one if only the other were
+      // present. A nested action (in a parent tx) bubbles and does not run; the
+      // root / non-transactional level runs (including any bubbled child effects).
       const bubbleRuleActions = execOptions?._parentPendingRuleActions;
       const bubbleRuleFlows = execOptions?._parentPendingRuleFlows;
-      if (bubbleRuleActions && bubbleRuleFlows) {
-        bubbleRuleActions.push(...pendingRuleActions);
-        bubbleRuleFlows.push(...pendingRuleFlows);
-      } else if (
+      if (bubbleRuleActions) bubbleRuleActions.push(...pendingRuleActions);
+      if (bubbleRuleFlows) bubbleRuleFlows.push(...pendingRuleFlows);
+      if (
         !execOptions?._txDataProvider &&
         (pendingRuleActions.length > 0 || pendingRuleFlows.length > 0)
       ) {

--- a/packages/core/src/engine/rule-engine.ts
+++ b/packages/core/src/engine/rule-engine.ts
@@ -30,6 +30,7 @@ import type {
   RuleDefinition,
   RuleEffect,
   RuleEvaluationResult,
+  TriggerFlowEffect,
   WarnEffect,
 } from "../types/rule";
 import { type ConditionContext, evaluateCondition } from "./condition-evaluator";
@@ -97,6 +98,8 @@ export interface RuleEvalOutput {
   enrichFields: Record<string, unknown>;
   /** Collected execute_action effects */
   actions: ExecuteActionEffect[];
+  /** Collected trigger_flow effects (run post-commit) */
+  flows: TriggerFlowEffect[];
   /** Per-rule evaluation details */
   results: RuleEvaluationResult[];
   /** Total evaluation duration in ms */
@@ -169,6 +172,7 @@ export async function evaluateConditions(
     warnings: [],
     enrichFields: {},
     actions: [],
+    flows: [],
     results: [],
     duration: 0,
     contexts: [],
@@ -343,6 +347,10 @@ function mergeEffect(output: RuleEvalOutput, effect: RuleEffect, ruleName?: stri
     }
     case "execute_action": {
       output.actions.push(effect as ExecuteActionEffect);
+      break;
+    }
+    case "trigger_flow": {
+      output.flows.push(effect as TriggerFlowEffect);
       break;
     }
     default: {

--- a/packages/core/src/exports/client/engines.ts
+++ b/packages/core/src/exports/client/engines.ts
@@ -7,8 +7,10 @@
  */
 
 export type {
+  ActionApprovalSuspender,
   ActionExecutor,
   ActionExecutorOptions,
+  ActionFlowStarter,
   ActionRegistry,
   DataProvider,
   DataQueryOptions,

--- a/packages/core/src/types/rule.ts
+++ b/packages/core/src/types/rule.ts
@@ -134,12 +134,25 @@ export interface ExecuteActionEffect {
   params?: Record<string, unknown>;
 }
 
+/**
+ * Start a durable Flow as a post-commit side effect of the rule firing
+ * (Spec 23 §1.1 / Spec 26 §2.2 — eventual-consistency, fire-and-forget). The
+ * Flow owns its own Saga / failure policy; it is NOT compensation-coupled to the
+ * action that triggered it. `input` defaults to the triggering action's input.
+ */
+export interface TriggerFlowEffect {
+  type: "trigger_flow";
+  flow: string;
+  input?: Record<string, unknown>;
+}
+
 export type RuleEffect =
   | BlockEffect
   | WarnEffect
   | RequireApprovalEffect
   | EnrichEffect
-  | ExecuteActionEffect;
+  | ExecuteActionEffect
+  | TriggerFlowEffect;
 
 // ── Context query (M1+) ────────────────────────────
 


### PR DESCRIPTION
## Why

Final phase of wiring `defineRule()` effects into the action-execution path (phase 1 block/warn/enrich #460, phase 2 require_approval + record-state #461). Adds the two post-commit side-effect effects — including the originally-requested `trigger_flow`.

## What

- New `TriggerFlowEffect` (`{ type: "trigger_flow", flow, input? }`) on `RuleEffect`; the rule engine collects `execute_action` / `trigger_flow` into `RuleEvalOutput.actions` / `.flows`.
- The executor runs both **after the write is durable** (alongside the event flush), best-effort (a failure logs, never fails the committed action):
  - `execute_action` re-invokes the named action (`params` default to the triggering input).
  - `trigger_flow` starts a durable Flow via a new optional `flowEngine` (`ActionFlowStarter`, structural subset of `FlowEngine`) + late-binding `executor.setFlowEngine()`. Per Spec 26 §2.2 the Flow owns its own Saga; `input` defaults to the action input. No engine → logged + skipped.
- Wiring: CLI `dev` → `setFlowEngine`; `RuntimeContextOptions.flowEngine` injection seam (server flow aggregation is a follow-up).

## Cross-model review (codex) — both confirmed + fixed

| Finding | Sev | Fix |
|---|---|---|
| `execute_action` re-invocation didn't forward `_depth` → a cycle loops forever as fresh roots | P2 | Forward `_depth: currentDepth + 1` (recursion-depth guard bounds it) |
| A nested (in-parent-tx) action's collected side effects were silently dropped | P2 | Bubble via new `_parentPendingRuleActions` / `_parentPendingRuleFlows` (mirrors `_parentPendingEvents`) → fire on the parent's commit |

## Test plan

`action-engine-rule-integration.test.ts` (21 cases via the real executor): execute_action (post-commit + params), trigger_flow (start; `effect.input` override; no-engine skip), blocked-skips-side-effects, execute_action cycle terminates (depth-guarded), nested child trigger_flow bubbles to parent commit + fires once, plus phase-1/2 cases. Full `bun run test` PASS; biome clean; typecheck clean on changed files. Non-breaking. No `any`/`!`. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `trigger_flow` rule effects that execute after write durability with best-effort error handling (failures are logged, not propagated).
  * Added support for wiring a flow engine to enable post-commit flow execution alongside action execution.

* **Tests**
  * Expanded integration test coverage for post-commit rule effects including trigger flow execution, input overrides, and blocked action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->