### PR TITLE
fix(core): fail closed when a record-state guard rule can't read its row (#462)

### DIFF
--- a/.changeset/rule-eval-fail-closed-read.md
+++ b/.changeset/rule-eval-fail-closed-read.md
@@ -1,0 +1,17 @@
+---
+"@linchkit/core": patch
+---
+
+Fail closed when a record-state guard rule can't read its row. Previously, when
+the record read inside action rule evaluation threw (transient / infra /
+partial-access error), evaluation silently degraded to input-only — which let a
+record-state `block` / `require_approval` rule be bypassed and the write proceed.
+
+Now a thrown read aborts the action when the applicable rule set contains a
+`block` or `require_approval` gate (the action fails with a clear
+"could not read … to evaluate guard rules" error). A read that *returns* a falsy
+record (the row is genuinely absent — e.g. create-shaped input) is unchanged and
+still evaluates input-only; rule sets with only non-gate effects
+(`enrich` / `warn` / `execute_action` / `trigger_flow`) also keep the lenient
+input-only degrade. This is the first half of issue #462 Part 1; the
+in-transaction record-state evaluation (TOCTOU) hardening is tracked separately.

--- a/packages/core/__tests__/action-rule-eval.test.ts
+++ b/packages/core/__tests__/action-rule-eval.test.ts
@@ -371,6 +371,33 @@ describe("evaluateActionRules", () => {
     expect(d.blocked?.reason).toContain("connection reset");
   });
 
+  test("code-less infra error that only MENTIONS 'record not found' mid-message fails CLOSED", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    // The not-found message heuristic is anchored to the START of the message,
+    // so an unrelated failure that merely mentions the phrase mid-message is a
+    // real read failure → fail closed, not treated as an absent row.
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            // Phrase appears mid-message (with spaces) — an UNanchored regex
+            // would wrongly match it; the anchored one must not.
+            throw new Error("Connection failed: record not found in replica cache");
+          }),
+        },
+      ),
+    );
+    expect(d.blocked).not.toBeNull();
+  });
+
   test("infra read throw with the ONLY gate rule in skipRules does not block", async () => {
     const rule: RuleDefinition = {
       name: "no_edit_shipped",

--- a/packages/core/__tests__/action-rule-eval.test.ts
+++ b/packages/core/__tests__/action-rule-eval.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from "bun:test";
 import type { DataProvider } from "../src/engine/action-engine";
 import { type EvaluateActionRulesArgs, evaluateActionRules } from "../src/engine/action-rule-eval";
 import { collectRules } from "../src/engine/rule-engine";
+import { NotFoundError } from "../src/errors";
 import { noopMetricsCollector } from "../src/observability/metrics";
 import type { Actor } from "../src/types/action";
 import { createExecutionMeta } from "../src/types/execution-meta";
@@ -160,7 +161,7 @@ describe("evaluateActionRules", () => {
     expect(d.blocked).toBeNull();
   });
 
-  test("read failure degrades to input-only evaluation (no throw)", async () => {
+  test("read throw with only NON-gate rules degrades to input-only (lenient)", async () => {
     const rule: RuleDefinition = {
       name: "warn_draft",
       label: "Warn draft",
@@ -179,9 +180,191 @@ describe("evaluateActionRules", () => {
         },
       ),
     );
-    // The read threw, so evaluation falls back to input-only — input has
-    // status:"draft", so the warn still fires.
+    // The read threw but the only effect is `warn` (not a security gate), so we
+    // preserve the lenient input-only degrade — input has status:"draft", so
+    // the warn still fires and nothing is blocked.
+    expect(d.blocked).toBeNull();
     expect(d.warnings).toEqual(["still draft"]);
+  });
+
+  test("read throw with a block-gate rule fails CLOSED (aborts, not bypassed)", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            throw new Error("db down");
+          }),
+        },
+      ),
+    );
+    // A record-state `block` rule could not read its row → fail closed rather
+    // than silently degrade to input-only (which would let the write through).
+    expect(d.blocked).not.toBeNull();
+    expect(d.blocked?.reason).toContain('Could not read order "o1"');
+    expect(d.blocked?.reason).toContain("db down");
+    expect(d.requiredApproval).toBeNull();
+  });
+
+  test("read throw with a require_approval-gate rule fails CLOSED", async () => {
+    const rule: RuleDefinition = {
+      name: "needs_signoff_when_shipped",
+      label: "Sign-off when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "require_approval", level: "manager" },
+    };
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            throw new Error("timeout");
+          }),
+        },
+      ),
+    );
+    // An approval gate that can't read its row also fails closed (aborts), so
+    // the approval can't be silently skipped.
+    expect(d.blocked).not.toBeNull();
+    expect(d.blocked?.reason).toContain("timeout");
+  });
+
+  test("record ABSENT (read returns falsy) is NOT a failure even with a gate rule", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    // get returns null (record genuinely absent) — distinct from a throw. The
+    // condition evaluates against input-only (status:"draft" ≠ "shipped"), so
+    // the action proceeds; absence must NOT trip the fail-closed path.
+    const d = await evaluateActionRules(
+      args([rule], { id: "o1", status: "draft" }, { readProvider: fakeProvider(null) }),
+    );
+    expect(d.blocked).toBeNull();
+  });
+
+  test("read NOT_FOUND throw with a gate rule degrades to input-only (absence ≠ read failure)", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    // Real providers throw on absent rows (the InMemory store / Drizzle / test
+    // fakes throw "Record not found: …"). A not-found throw is absence, NOT an
+    // infra failure, so even with a block gate it must degrade to input-only —
+    // condition is false on input (status:"draft"), so the action proceeds.
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            throw new Error("Record not found: order/o1");
+          }),
+        },
+      ),
+    );
+    expect(d.blocked).toBeNull();
+  });
+
+  test("typed NotFoundError throw with a gate rule also degrades to input-only", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            throw new NotFoundError({
+              code: "data.record.not_found",
+              message: "Record not found",
+              resource: "order",
+              resourceId: "o1",
+            });
+          }),
+        },
+      ),
+    );
+    expect(d.blocked).toBeNull();
+  });
+
+  test("NotFoundError with a NON-record code (schema/provider failure) fails CLOSED", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    // A NotFoundError can also signal a provider/schema problem (e.g. a missing
+    // id column) — that is NOT an absent row, so a guard rule must fail closed
+    // rather than silently proceed on input-only data.
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            throw new NotFoundError({
+              code: "data.schema.no_id_column",
+              message: 'Table for schema "order" has no "id" column',
+              resource: "order",
+              resourceId: "o1",
+            });
+          }),
+        },
+      ),
+    );
+    expect(d.blocked).not.toBeNull();
+    expect(d.blocked?.reason).toContain('Could not read order "o1"');
+    expect(d.blocked?.reason).toContain('has no "id" column');
+  });
+
+  test("infra read throw with the ONLY gate rule in skipRules does not block", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    // The gate is intentionally disabled for this run (e.g. an approved
+    // re-execution). An infra read error must NOT resurrect it as a fail-closed
+    // block, since evaluateRules would skip the rule anyway.
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            throw new Error("db down");
+          }),
+          skipRules: ["no_edit_shipped"],
+        },
+      ),
+    );
+    expect(d.blocked).toBeNull();
   });
 
   test("no entity / no id → no record read, input-only", async () => {

--- a/packages/core/__tests__/action-rule-eval.test.ts
+++ b/packages/core/__tests__/action-rule-eval.test.ts
@@ -341,6 +341,36 @@ describe("evaluateActionRules", () => {
     expect(d.blocked?.reason).toContain('has no "id" column');
   });
 
+  test("coded infra error (non-string code) is NOT treated as not-found via its message", async () => {
+    const rule: RuleDefinition = {
+      name: "no_edit_shipped",
+      label: "No edit when shipped",
+      trigger: { action: "update_order" },
+      condition: { field: "target.status", operator: "eq", value: "shipped" },
+      effect: { type: "block", message: "Order already shipped" },
+    };
+    // A DB driver error can carry a numeric `code` AND a message that happens to
+    // contain "record not found". Because it is coded (and not the record-miss
+    // code), it must fail closed — NOT fall through to the message heuristic.
+    const d = await evaluateActionRules(
+      args(
+        [rule],
+        { id: "o1", status: "draft" },
+        {
+          readProvider: fakeProvider(() => {
+            const e = new Error("record not found in shard (connection reset)") as Error & {
+              code: number;
+            };
+            e.code = 23505;
+            throw e;
+          }),
+        },
+      ),
+    );
+    expect(d.blocked).not.toBeNull();
+    expect(d.blocked?.reason).toContain("connection reset");
+  });
+
   test("infra read throw with the ONLY gate rule in skipRules does not block", async () => {
     const rule: RuleDefinition = {
       name: "no_edit_shipped",

--- a/packages/core/src/engine/action-rule-eval.ts
+++ b/packages/core/src/engine/action-rule-eval.ts
@@ -60,9 +60,11 @@ function isRecordNotFound(err: unknown): boolean {
     // failure — never reach the message heuristic for it.
     if (code !== undefined) return code === "data.record.not_found";
   }
-  // Code-less errors (in-memory store + test fakes) throw a plain Error with
-  // this message shape on an absent row.
-  return err instanceof Error && /record not found/i.test(err.message);
+  // Code-less errors (in-memory store + test fakes) throw a plain Error whose
+  // message STARTS with "Record not found" (e.g. "Record not found: order/o1")
+  // on an absent row. Anchor the match so an unrelated failure that merely
+  // mentions the phrase mid-message is not misclassified as absence.
+  return err instanceof Error && /^record not found\b/i.test(err.message);
 }
 
 /** Inputs for {@link evaluateActionRules}. */
@@ -210,7 +212,7 @@ export async function evaluateActionRules(
             blocked: {
               reason: `Could not read ${entity} "${recordId}" to evaluate guard rules: ${detail}`,
               suggestion:
-                "A record-state guard rule could not be evaluated because the current record read failed; the action was blocked instead of proceeding on incomplete data. Retry once the data store is reachable.",
+                "A record-state guard rule could not be evaluated because the current record read failed; the action was blocked instead of proceeding on incomplete data. Resolve the underlying read failure (data-store availability, access/permissions, or schema configuration) and retry.",
             },
             requiredApproval: null,
             recordId,

--- a/packages/core/src/engine/action-rule-eval.ts
+++ b/packages/core/src/engine/action-rule-eval.ts
@@ -45,15 +45,22 @@ import { evaluateRules } from "./rule-engine";
  * present. So we key on the specific `data.record.not_found` code, plus the
  * plain `Error("Record not found: …")` message the in-memory store and the test
  * fakes (which carry no `code`) throw on a miss.
+ *
+ * Any error that carries a `code` is decided purely on that code — we do NOT
+ * fall back to the message heuristic for it. Otherwise a coded infra error
+ * (e.g. a DB driver error with a numeric `code`) whose message happened to
+ * contain "record not found" could be misclassified as absence and bypass the
+ * gate. The message heuristic is reserved for genuinely code-less errors.
  */
 function isRecordNotFound(err: unknown): boolean {
   if (typeof err === "object" && err !== null) {
     const code = (err as { code?: unknown }).code;
-    // A coded provider error: ONLY the record-miss code is "absence". Any other
-    // coded NotFoundError (schema / entity / config) is a genuine failure.
-    if (typeof code === "string") return code === "data.record.not_found";
+    // A coded error: ONLY the record-miss code is "absence". Any other code
+    // (a non-record NotFoundError, or a driver's numeric code) is a genuine
+    // failure — never reach the message heuristic for it.
+    if (code !== undefined) return code === "data.record.not_found";
   }
-  // Untyped providers (in-memory store + test fakes) throw a plain Error with
+  // Code-less errors (in-memory store + test fakes) throw a plain Error with
   // this message shape on an absent row.
   return err instanceof Error && /record not found/i.test(err.message);
 }

--- a/packages/core/src/engine/action-rule-eval.ts
+++ b/packages/core/src/engine/action-rule-eval.ts
@@ -29,6 +29,35 @@ import type {
 import type { DataProvider, DataQueryOptions } from "./action-engine";
 import { evaluateRules } from "./rule-engine";
 
+/**
+ * Did a record read throw because the row is genuinely ABSENT (not found /
+ * soft-deleted / tenant-filtered) rather than because of a provider/schema or
+ * transient infra failure? Providers signal "absent" by throwing, not by
+ * returning falsy. An absent row is a legitimate outcome (e.g. create-shaped
+ * input with a caller-supplied id) the write path handles, so it must NOT trip
+ * the fail-closed gate.
+ *
+ * Detection is deliberately NARROW: only the record-miss signal counts as
+ * absence. The Drizzle provider throws a typed `NotFoundError` for record
+ * misses (`code: "data.record.not_found"`) but ALSO for provider/schema
+ * problems (`data.schema.no_id_column`, `data.entity.not_registered`, …) — those
+ * are real failures, not an empty row, and must fail closed when a guard rule is
+ * present. So we key on the specific `data.record.not_found` code, plus the
+ * plain `Error("Record not found: …")` message the in-memory store and the test
+ * fakes (which carry no `code`) throw on a miss.
+ */
+function isRecordNotFound(err: unknown): boolean {
+  if (typeof err === "object" && err !== null) {
+    const code = (err as { code?: unknown }).code;
+    // A coded provider error: ONLY the record-miss code is "absence". Any other
+    // coded NotFoundError (schema / entity / config) is a genuine failure.
+    if (typeof code === "string") return code === "data.record.not_found";
+  }
+  // Untyped providers (in-memory store + test fakes) throw a plain Error with
+  // this message shape on an absent row.
+  return err instanceof Error && /record not found/i.test(err.message);
+}
+
 /** Inputs for {@link evaluateActionRules}. */
 export interface EvaluateActionRulesArgs {
   /**
@@ -67,8 +96,11 @@ export interface EvaluateActionRulesArgs {
 /** What the executor should do after rule evaluation. */
 export interface ActionRuleEvalDecision {
   /**
-   * Non-null when a `block` effect fired. The executor logs a `blocked`
-   * execution and returns a failure result; no write happens.
+   * Non-null when the action must be aborted before any write — either a
+   * `block` effect fired, OR the record-state read threw while the rule set
+   * contains a `block` / `require_approval` gate (fail-closed: a guard that
+   * can't read its row blocks rather than silently degrading to input-only).
+   * The executor logs a `blocked` execution and returns a failure result.
    */
   blocked: { reason: string; suggestion: string } | null;
   /**
@@ -106,6 +138,13 @@ export interface ActionRuleEvalDecision {
  * pre-collected + priority-sorted rule set, and folds the resulting effects
  * into a {@link ActionRuleEvalDecision}.
  *
+ * Record read outcomes:
+ *  - returns a row → conditions see `{ ...record, ...input }` (input wins);
+ *  - returns falsy → the record is absent → input-only (not a failure);
+ *  - THROWS → fail closed when the rule set has a `block` / `require_approval`
+ *    gate (abort rather than let a record-state guard be bypassed on a read
+ *    error); degrade to input-only only when no gate effect is present.
+ *
  * Effect precedence mirrors the previous inline logic exactly:
  *  - `block` short-circuits (the executor aborts before any write); the
  *    returned `effectiveInput`/`warnings`/pending arrays are empty.
@@ -128,15 +167,54 @@ export async function evaluateActionRules(
     typeof recordIdRaw === "string" && recordIdRaw.length > 0 ? recordIdRaw : undefined;
 
   // Record-state context: for an update (input carries an id), read the current
-  // record so conditions can reference existing field values. A read failure
-  // (not found / access) degrades to input-only evaluation.
+  // record so conditions can reference existing field values.
   let ruleTarget: Record<string, unknown> = effectiveInput;
   if (entity && recordId) {
     try {
       const existing = await readProvider.get(entity, recordId, queryOptions);
+      // A falsy result = the record is genuinely absent (create-shaped input, a
+      // soft-deleted / missing row). Evaluating against input only is correct
+      // here — it is not a read failure.
       if (existing) ruleTarget = { ...existing, ...effectiveInput };
-    } catch {
-      // Not readable — fall back to input-only evaluation.
+    } catch (err) {
+      // A "record not found" read = the row is genuinely absent (create-shaped
+      // input with a caller id, a deleted / tenant-filtered row). That is a
+      // legitimate outcome the write path handles, NOT a guard-read failure, so
+      // degrade to input-only exactly as before — never fail closed on absence.
+      //
+      // Any OTHER throw is a transient / infra / access read failure: we could
+      // not establish the record state. Fail CLOSED for security-relevant
+      // gates — if any applicable, NON-skipped rule can `block` or
+      // `require_approval`, abort rather than silently degrade to input-only and
+      // let the write proceed (which would let a record-state guard be bypassed
+      // on a read error). `skipRules` gates are intentionally disabled (e.g. an
+      // already-approved re-execution) and must not re-block. Non-gate effects
+      // (enrich / warn / execute_action / trigger_flow) are not security
+      // boundaries, so a rule set with no live gate keeps the lenient degrade.
+      if (!isRecordNotFound(err)) {
+        const hasLiveGate = applicableRules.some(
+          (r) =>
+            !skipRules?.includes(r.name) &&
+            (r.effect.type === "block" || r.effect.type === "require_approval"),
+        );
+        if (hasLiveGate) {
+          const detail = err instanceof Error ? err.message : String(err);
+          return {
+            blocked: {
+              reason: `Could not read ${entity} "${recordId}" to evaluate guard rules: ${detail}`,
+              suggestion:
+                "A record-state guard rule could not be evaluated because the current record read failed; the action was blocked instead of proceeding on incomplete data. Retry once the data store is reachable.",
+            },
+            requiredApproval: null,
+            recordId,
+            effectiveInput,
+            warnings: [],
+            pendingActions: [],
+            pendingFlows: [],
+          };
+        }
+      }
+      // Absent row, or no live gate effect — degrade to input-only evaluation.
     }
   }
 


### PR DESCRIPTION
## What

Closes the **first half of #462 Part 1**: a record-state guard rule can no
longer be silently bypassed when its row read fails.

Inside `evaluateActionRules`, a record read that **threw** (transient / infra /
partial-access error) previously degraded to input-only evaluation — which let a
record-state `block` / `require_approval` rule be skipped while the write
proceeded (CodeRabbit Major on #464).

## Behavior — read-outcome classification

`evaluateActionRules` now classifies the read:

| Read outcome | Behavior |
|---|---|
| returns a row | conditions see `{ ...record, ...input }` (unchanged) |
| returns falsy | record absent → input-only (unchanged; not a failure) |
| throws **"record not found"** | row genuinely absent (create-shaped input with a caller id, deleted / tenant-filtered row) → input-only, exactly as before; the write path handles absence |
| throws **anything else** | infra / access failure → **fail CLOSED** when the rule set has a **live** (non-`skipRules`) `block` / `require_approval` gate; abort with a clear *"could not read … to evaluate guard rules"* error |

Rule sets with only non-gate effects (`enrich` / `warn` / `execute_action` /
`trigger_flow`) keep the lenient input-only degrade — they are not security
boundaries.

## Not-found detection (narrow, on purpose)

`isRecordNotFound` keys on the **specific** record-miss signal so a provider
failure is never mistaken for an empty row:
- typed provider error with `code === "data.record.not_found"` (Drizzle), and
- the plain `Error("Record not found: …")` message the in-memory store + test
  fakes throw (no `code`).

Other `NotFoundError` codes (`data.schema.no_id_column`,
`data.entity.not_registered`, …) are provider/schema failures → they fail closed,
not degrade.

## Out of scope

The **in-transaction record-state evaluation (TOCTOU)** hardening — the second
half of #462 Part 1 — is tracked separately as a focused design (it restructures
the executor's critical write path).

## Tests

8 new unit tests in `action-rule-eval.test.ts` covering every branch of the
classification: non-gate degrade, block-gate fail-closed, approval-gate
fail-closed, absent-falsy, not-found-throw degrade, typed `NotFoundError`
(record-miss) degrade, non-record-code `NotFoundError` fail-closed, and
`skipRules`-excluded gate. The existing 20 `action-engine-rule-integration`
tests still pass. `bun run check` / `typecheck` / `test` all green.

## Cross-model review

codex reviewed iteratively (3 rounds): R1 flagged 2 P2s (not-found
misclassification, `skipRules` not honored), R2 flagged 1 P1 (not-found
detection too broad), R3 clean. All addressed.

Refs #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for action rule evaluation when the system cannot read records. Actions with blocking or approval gates now abort with clear error messages instead of silently degrading, improving transparency and preventing unexpected behavior.
  * Refined record-not-found detection to distinguish between absent records and other read failures.

* **Tests**
  * Extended test coverage for read-error handling and fail-closed behavior scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->