### PR TITLE
refactor(core): extract post-commit rule side-effect runner (#462)

### DIFF
--- a/.changeset/extract-post-commit-rule-effects.md
+++ b/.changeset/extract-post-commit-rule-effects.md
@@ -1,0 +1,10 @@
+---
+"@linchkit/core": patch
+---
+
+refactor(core): extract the post-commit rule side-effect runner
+(`execute_action` / `trigger_flow`) out of `createActionExecutor` into a new
+`engine/action-rule-effects.ts` (`runPostCommitRuleEffects`). It pairs with
+`action-rule-eval.ts` (decide) as the run-the-collected-effects half, and is
+the lowest-coupling slice of the executor body (best-effort, fires only after
+the write is durable). Pure code movement — zero behavior change (part of #462).

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -70,6 +70,7 @@ import {
   validateInput,
 } from "./action-helpers";
 import { ActionRegistry } from "./action-registry";
+import { runPostCommitRuleEffects } from "./action-rule-effects";
 import { evaluateActionRules } from "./action-rule-eval";
 import { hashBehaviorAffectingMeta } from "./meta-keys";
 import { collectRules } from "./rule-engine";
@@ -1536,51 +1537,19 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         !execOptions?._txDataProvider &&
         (pendingRuleActions.length > 0 || pendingRuleFlows.length > 0)
       ) {
-        for (const act of pendingRuleActions) {
-          try {
-            // Stamp provenance like ctx.execute: `_source_action` (caller) +
-            // `_depth` in meta, plus `_depth` as an ExecuteOptions field so the
-            // recursion-depth guard bounds an execute_action cycle.
-            const childMeta = extendExecutionMeta(
-              resolvedMeta,
-              {},
-              { _depth: currentDepth + 1, _source_action: actionName },
-            );
-            const result = await execute(act.action, act.params ?? effectiveInput, actor, {
-              tenantId: execOptions?.tenantId,
-              meta: childMeta,
-              _depth: currentDepth + 1,
-            });
-            if (!result.success) {
-              const data = result.data as { error?: unknown } | undefined;
-              logger.warn(
-                `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" did not succeed: ${typeof data?.error === "string" ? data.error : "unknown error"}`,
-              );
-            }
-          } catch (err) {
-            logger.warn(
-              `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-        }
-        for (const fl of pendingRuleFlows) {
-          if (!flowEngineRef) {
-            logger.warn(
-              `[rule:trigger_flow] no flow engine wired — skipping flow "${fl.flow}" triggered by a rule on "${actionName}".`,
-            );
-            continue;
-          }
-          try {
-            await flowEngineRef.startFlow(fl.flow, fl.input ?? effectiveInput, {
-              tenantId: execOptions?.tenantId,
-              actor,
-            });
-          } catch (err) {
-            logger.warn(
-              `[rule:trigger_flow] starting flow "${fl.flow}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-        }
+        await runPostCommitRuleEffects({
+          pendingActions: pendingRuleActions,
+          pendingFlows: pendingRuleFlows,
+          execute,
+          flowEngine: flowEngineRef,
+          logger,
+          actionName,
+          actor,
+          effectiveInput,
+          resolvedMeta,
+          currentDepth,
+          tenantId: execOptions?.tenantId,
+        });
       }
 
       return {

--- a/packages/core/src/engine/action-rule-effects.ts
+++ b/packages/core/src/engine/action-rule-effects.ts
@@ -1,0 +1,119 @@
+/**
+ * Post-commit rule side effects (Spec 23 §1.1 / Spec 26 §2.2).
+ *
+ * The pre-write decision (see {@link evaluateActionRules} in
+ * `action-rule-eval.ts`) collects `execute_action` / `trigger_flow` effects but
+ * does NOT run them — they are deferred to this point so they only fire once the
+ * triggering action's write is durable (eventual consistency). This runner is
+ * best-effort: a failure here is logged and never fails the already-committed
+ * action. Only the root / non-transactional execution level calls it; a nested
+ * action inside a parent transaction bubbles its collected effects up so they
+ * run on the PARENT's commit instead.
+ */
+
+import type { ActionResult, Actor } from "../types/action";
+import type { ExecutionMeta } from "../types/execution-meta";
+import { extendExecutionMeta } from "../types/execution-meta";
+import type { Logger } from "../types/logger";
+import type { ExecuteActionEffect, TriggerFlowEffect } from "../types/rule";
+import type { ActionFlowStarter, ExecuteOptions } from "./action-engine-types";
+
+/** The executor's own `execute` method, threaded in so an `execute_action`
+ *  effect re-invokes through the same executor (depth-bounded). */
+type ActionExecuteFn = (
+  actionName: string,
+  input: Record<string, unknown>,
+  actor: Actor,
+  options?: ExecuteOptions,
+) => Promise<ActionResult>;
+
+export interface PostCommitRuleEffectsArgs {
+  /** `execute_action` effects collected by the rule evaluation, in order. */
+  pendingActions: ExecuteActionEffect[];
+  /** `trigger_flow` effects collected by the rule evaluation, in order. */
+  pendingFlows: TriggerFlowEffect[];
+  /** The executor's `execute` method (re-invokes child actions). */
+  execute: ActionExecuteFn;
+  /** Flow engine for `trigger_flow`; when undefined, flows are logged + skipped. */
+  flowEngine: ActionFlowStarter | undefined;
+  logger: Logger;
+  /** Name of the action whose rules produced these effects (for provenance + logs). */
+  actionName: string;
+  actor: Actor;
+  /** The (enriched) input of the triggering action — the default child input. */
+  effectiveInput: Record<string, unknown>;
+  /** The triggering action's resolved meta — extended with child provenance. */
+  resolvedMeta: ExecutionMeta;
+  /** The triggering action's recursion depth (child runs at depth + 1). */
+  currentDepth: number;
+  /** Tenant of the triggering action, forwarded to child actions / flows. */
+  tenantId: string | undefined;
+}
+
+/**
+ * Run the post-commit `execute_action` / `trigger_flow` side effects collected
+ * during rule evaluation. Best-effort: each effect's failure is logged and
+ * swallowed so it never fails the already-committed triggering action.
+ */
+export async function runPostCommitRuleEffects(args: PostCommitRuleEffectsArgs): Promise<void> {
+  const {
+    pendingActions,
+    pendingFlows,
+    execute,
+    flowEngine,
+    logger,
+    actionName,
+    actor,
+    effectiveInput,
+    resolvedMeta,
+    currentDepth,
+    tenantId,
+  } = args;
+
+  for (const act of pendingActions) {
+    try {
+      // Stamp provenance like ctx.execute: `_source_action` (caller) +
+      // `_depth` in meta, plus `_depth` as an ExecuteOptions field so the
+      // recursion-depth guard bounds an execute_action cycle.
+      const childMeta = extendExecutionMeta(
+        resolvedMeta,
+        {},
+        { _depth: currentDepth + 1, _source_action: actionName },
+      );
+      const result = await execute(act.action, act.params ?? effectiveInput, actor, {
+        tenantId,
+        meta: childMeta,
+        _depth: currentDepth + 1,
+      });
+      if (!result.success) {
+        const data = result.data as { error?: unknown } | undefined;
+        logger.warn(
+          `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" did not succeed: ${typeof data?.error === "string" ? data.error : "unknown error"}`,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        `[rule:execute_action] "${act.action}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  for (const fl of pendingFlows) {
+    if (!flowEngine) {
+      logger.warn(
+        `[rule:trigger_flow] no flow engine wired — skipping flow "${fl.flow}" triggered by a rule on "${actionName}".`,
+      );
+      continue;
+    }
+    try {
+      await flowEngine.startFlow(fl.flow, fl.input ?? effectiveInput, {
+        tenantId,
+        actor,
+      });
+    } catch (err) {
+      logger.warn(
+        `[rule:trigger_flow] starting flow "${fl.flow}" triggered by a rule on "${actionName}" failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Continues the #462 `action-engine.ts` split (increment 3, after #464 + #467). Extracts the **post-commit rule side-effect runner** out of the `createActionExecutor` closure into a new `engine/action-rule-effects.ts`:

- `runPostCommitRuleEffects(...)` runs the collected `execute_action` / `trigger_flow` effects **after the write is durable** — best-effort (every effect wrapped in try/catch, a failure is logged and never fails the already-committed action).
- Conceptual pair with `action-rule-eval.ts`: **decide** (`evaluateActionRules`, collects the pending effects) → **run** (`runPostCommitRuleEffects`, fires them post-commit).
- This is the **lowest-coupling slice** of the executor body — it runs after the durable write, off the transaction/critical path — so it's the safe next increment.

`action-engine.ts`: **1679 → 1648 lines**. The bubble-to-parent line (a nested action in a parent tx defers its effects to the parent's commit) stays inline at the call site. Pure code movement — **zero behavior change**.

## Quality gates

| Gate | Status |
|------|--------|
| `bun run typecheck` | ✅ clean |
| `bun run check` (Biome) | ✅ clean |
| `bun test packages/core/` | ✅ 3976 pass, 0 fail |
| rule-integration `execute_action`/`trigger_flow` tests | ✅ pass unchanged |
| `bun run test` (full batched) | ✅ all batches PASS |
| codex review (`main..HEAD`) | ✅ "straightforward extraction … equivalent control flow and arguments … no behavior-changing issues" |

## Notes

- New dependencies: none. Security surfaces: none touched. Changeset: `@linchkit/core` patch.
- Behavior equivalence: the runner is still `await`ed at the same position inside the same outer try/catch; `tenantId`, `flowEngine`, and the execute-then-flow loop order are all preserved.

Part of #462. Remaining: `createActionExecutor` body still ~1.6k lines (further incremental extractions have diminishing ROI — see #462 thread) + rule-integration test split + in-tx TOCTOU (#466, deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
