### PR TITLE
feat(core): lock record-state guard rows with FOR UPDATE to close the residual TOCTOU window (#470)

### DIFF
--- a/.changeset/in-tx-guard-row-lock.md
+++ b/.changeset/in-tx-guard-row-lock.md
@@ -1,0 +1,16 @@
+---
+"@linchkit/core": minor
+---
+
+Close the residual record-state guard TOCTOU window with a row-level lock (#470).
+
+#469 moved `block` / `require_approval` guard-rule evaluation inside the write
+transaction, but under PostgreSQL READ COMMITTED a plain `SELECT` guard read +
+the write were still not atomic — a concurrent commit could land between them.
+
+`DataQueryOptions` gains an opt-in `forUpdate` flag. The Drizzle provider honors
+it with `SELECT … FOR UPDATE`, and the in-transaction guard re-check now sets it
+so the guarded row is pinned from the read until commit: a concurrent writer
+blocks instead of slipping a state change past the guard. The InMemoryStore is
+single-threaded and already serialized, so it no-ops the flag. No behavior change
+for existing callers — `forUpdate` defaults to off.

--- a/.changeset/in-tx-guard-row-lock.md
+++ b/.changeset/in-tx-guard-row-lock.md
@@ -4,7 +4,7 @@
 
 Close the residual record-state guard TOCTOU window with a row-level lock (#470).
 
-#469 moved `block` / `require_approval` guard-rule evaluation inside the write
+PR #469 moved `block` / `require_approval` guard-rule evaluation inside the write
 transaction, but under PostgreSQL READ COMMITTED a plain `SELECT` guard read +
 the write were still not atomic — a concurrent commit could land between them.
 

--- a/packages/core/__tests__/action-engine-rule-toctou.test.ts
+++ b/packages/core/__tests__/action-engine-rule-toctou.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "bun:test";
 import {
   createActionExecutor,
   type DataProvider,
+  type DataQueryOptions,
   type PendingEvent,
   type TransactionManager,
 } from "../src/engine/action-engine";
@@ -29,10 +30,21 @@ interface Cap {
   updated: boolean;
 }
 
-/** Provider that always reads `record` and records whether `update` ran. */
-function makeProvider(record: Record<string, unknown>, cap: Cap): DataProvider {
+/**
+ * Provider that always reads `record` and records whether `update` ran. When a
+ * `getOptionsLog` is supplied, every `get()` call appends the options it received
+ * so a test can assert how the read was issued (e.g. `forUpdate`).
+ */
+function makeProvider(
+  record: Record<string, unknown>,
+  cap: Cap,
+  getOptionsLog?: Array<DataQueryOptions | undefined>,
+): DataProvider {
   return {
-    get: async (_entity, id) => ({ id, ...record }),
+    get: async (_entity, id, options) => {
+      getOptionsLog?.push(options);
+      return { id, ...record };
+    },
     query: async () => [],
     create: async (_entity, data) => ({ id: "r1", ...data }),
     update: async (_entity, id, data) => {
@@ -159,5 +171,35 @@ describe("record-state rules read inside the write transaction (#462 / #466 TOCT
     // The write went through the transactional provider, not the base one.
     expect(txCap.updated).toBe(true);
     expect(baseCap.updated).toBe(false);
+  });
+
+  it("the in-tx guard re-check reads FOR UPDATE; the pre-write Step 4c read does not (#470 row-lock)", async () => {
+    const baseGetOptions: Array<DataQueryOptions | undefined> = [];
+    const txGetOptions: Array<DataQueryOptions | undefined> = [];
+    const baseCap: Cap = { updated: false };
+    const txCap: Cap = { updated: false };
+    // Neither snapshot is "approved" → the guard does not fire and the write
+    // proceeds, so the in-tx read is exercised without the block short-circuiting.
+    const baseProvider = makeProvider({ status: "pending" }, baseCap, baseGetOptions);
+    const txProvider = makeProvider({ status: "pending" }, txCap, txGetOptions);
+
+    const executor = createActionExecutor({
+      dataProvider: baseProvider,
+      transactionManager: makeTxManager(txProvider),
+      rules: [blockIfApproved()],
+    });
+    executor.registry.register(approveAction());
+
+    const result = await executor.execute("approve_thing", { id: "r1" }, actor);
+    expect(result.success).toBe(true);
+
+    // The in-tx guard re-check pinned the guarded row with a `FOR UPDATE` lock so
+    // a concurrent writer can't flip its state before the write (#470).
+    expect(txGetOptions.length).toBeGreaterThan(0);
+    expect(txGetOptions.some((o) => o?.forUpdate === true)).toBe(true);
+    // The pre-write Step 4c read runs OUTSIDE the transaction, where a row lock is
+    // pointless (acquired and released at statement end), so it must NOT request one.
+    expect(baseGetOptions.length).toBeGreaterThan(0);
+    expect(baseGetOptions.every((o) => !o?.forUpdate)).toBe(true);
   });
 });

--- a/packages/core/__tests__/drizzle-data-provider.integration.test.ts
+++ b/packages/core/__tests__/drizzle-data-provider.integration.test.ts
@@ -16,7 +16,7 @@ import {
   generateDrizzleTable,
   TableRegistry,
 } from "@linchkit/core/server";
-import { sql } from "drizzle-orm";
+import { eq, getTableColumns, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Test configuration ───────────────────────────────────────
@@ -155,6 +155,56 @@ describe.skipIf(!dbAvailable)("DrizzleDataProvider (integration)", () => {
 
   test("get not found — throws NotFoundError for non-existent id", async () => {
     await expect(provider.get(SCHEMA_NAME, "non-existent-id")).rejects.toThrow(NotFoundError);
+  });
+
+  // ── 3b. get with forUpdate — row-level locking (#470) ──
+
+  /**
+   * Probe whether `id`'s row is lockable from a SEPARATE pooled connection.
+   * `FOR UPDATE NOWAIT` fails immediately (SQLSTATE 55P03) when the row is
+   * already locked, so this is a deterministic test of lock state with no sleeps.
+   */
+  const probeRowLockable = async (id: string): Promise<boolean> => {
+    const table = tableRegistry.getTable(SCHEMA_NAME);
+    const idCol = getTableColumns(table).id;
+    try {
+      await (db as NonNullable<typeof db>)
+        .select()
+        .from(table)
+        .where(eq(idCol, id))
+        .for("update", { noWait: true });
+      return true; // acquired the lock → the row was free
+    } catch {
+      return false; // 55P03 lock_not_available → the row is locked elsewhere
+    }
+  };
+
+  test("get with forUpdate — pins the row with a lock that blocks a concurrent writer", async () => {
+    const created = await provider.create(SCHEMA_NAME, { title: "Lockable", status: "pending" });
+    const id = created.id as string;
+
+    await (db as NonNullable<typeof db>).transaction(async (tx) => {
+      const txProvider = provider.withConnection(tx as unknown as PostgresJsDatabase);
+      const locked = await txProvider.get(SCHEMA_NAME, id, { forUpdate: true });
+      expect(locked.id).toBe(id);
+      // While the transaction holds the FOR UPDATE lock, a separate session can't lock it.
+      expect(await probeRowLockable(id)).toBe(false);
+    });
+
+    // The lock is released once the transaction commits.
+    expect(await probeRowLockable(id)).toBe(true);
+  });
+
+  test("get without forUpdate — takes no row lock (opt-in)", async () => {
+    const created = await provider.create(SCHEMA_NAME, { title: "Unlocked", status: "pending" });
+    const id = created.id as string;
+
+    await (db as NonNullable<typeof db>).transaction(async (tx) => {
+      const txProvider = provider.withConnection(tx as unknown as PostgresJsDatabase);
+      await txProvider.get(SCHEMA_NAME, id); // plain read — no lock requested
+      // A plain read leaves the row free, so another session can still lock it.
+      expect(await probeRowLockable(id)).toBe(true);
+    });
   });
 
   // ── 4. query ──────────────────────────────────────────

--- a/packages/core/__tests__/drizzle-data-provider.integration.test.ts
+++ b/packages/core/__tests__/drizzle-data-provider.integration.test.ts
@@ -16,7 +16,7 @@ import {
   generateDrizzleTable,
   TableRegistry,
 } from "@linchkit/core/server";
-import { eq, getTableColumns, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 // ── Test configuration ───────────────────────────────────────
@@ -155,56 +155,6 @@ describe.skipIf(!dbAvailable)("DrizzleDataProvider (integration)", () => {
 
   test("get not found — throws NotFoundError for non-existent id", async () => {
     await expect(provider.get(SCHEMA_NAME, "non-existent-id")).rejects.toThrow(NotFoundError);
-  });
-
-  // ── 3b. get with forUpdate — row-level locking (#470) ──
-
-  /**
-   * Probe whether `id`'s row is lockable from a SEPARATE pooled connection.
-   * `FOR UPDATE NOWAIT` fails immediately (SQLSTATE 55P03) when the row is
-   * already locked, so this is a deterministic test of lock state with no sleeps.
-   */
-  const probeRowLockable = async (id: string): Promise<boolean> => {
-    const table = tableRegistry.getTable(SCHEMA_NAME);
-    const idCol = getTableColumns(table).id;
-    try {
-      await (db as NonNullable<typeof db>)
-        .select()
-        .from(table)
-        .where(eq(idCol, id))
-        .for("update", { noWait: true });
-      return true; // acquired the lock → the row was free
-    } catch {
-      return false; // 55P03 lock_not_available → the row is locked elsewhere
-    }
-  };
-
-  test("get with forUpdate — pins the row with a lock that blocks a concurrent writer", async () => {
-    const created = await provider.create(SCHEMA_NAME, { title: "Lockable", status: "pending" });
-    const id = created.id as string;
-
-    await (db as NonNullable<typeof db>).transaction(async (tx) => {
-      const txProvider = provider.withConnection(tx as unknown as PostgresJsDatabase);
-      const locked = await txProvider.get(SCHEMA_NAME, id, { forUpdate: true });
-      expect(locked.id).toBe(id);
-      // While the transaction holds the FOR UPDATE lock, a separate session can't lock it.
-      expect(await probeRowLockable(id)).toBe(false);
-    });
-
-    // The lock is released once the transaction commits.
-    expect(await probeRowLockable(id)).toBe(true);
-  });
-
-  test("get without forUpdate — takes no row lock (opt-in)", async () => {
-    const created = await provider.create(SCHEMA_NAME, { title: "Unlocked", status: "pending" });
-    const id = created.id as string;
-
-    await (db as NonNullable<typeof db>).transaction(async (tx) => {
-      const txProvider = provider.withConnection(tx as unknown as PostgresJsDatabase);
-      await txProvider.get(SCHEMA_NAME, id); // plain read — no lock requested
-      // A plain read leaves the row free, so another session can still lock it.
-      expect(await probeRowLockable(id)).toBe(true);
-    });
   });
 
   // ── 4. query ──────────────────────────────────────────

--- a/packages/core/__tests__/drizzle-data-provider.row-lock.integration.test.ts
+++ b/packages/core/__tests__/drizzle-data-provider.row-lock.integration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration tests for DrizzleDataProvider row-level locking (`forUpdate`, #470).
+ *
+ * Split out of drizzle-data-provider.integration.test.ts to keep both files under
+ * the 500-line limit. Requires a running PostgreSQL instance — set
+ * DATABASE_TEST_URL (default postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test).
+ * Skips gracefully when no database is available (CI without PG won't fail).
+ *
+ * Uses a `FOR UPDATE NOWAIT` probe from a SEPARATE pooled connection, so the lock
+ * state is asserted deterministically with no sleeps: NOWAIT fails immediately
+ * (SQLSTATE 55P03) when the row is already locked, and succeeds when it is free.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { defineEntity } from "@linchkit/core";
+import {
+  closeDatabase,
+  createDatabase,
+  DrizzleDataProvider,
+  generateDrizzleTable,
+  TableRegistry,
+} from "@linchkit/core/server";
+import { eq, getTableColumns, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+
+const DATABASE_URL =
+  process.env.DATABASE_TEST_URL ??
+  "postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test";
+
+// Distinct table name from the sibling integration suite so the two files never
+// clobber each other's fixture table if they ever run against the same database.
+const testSchema = defineEntity({
+  name: "row_lock_test_item",
+  label: "Row Lock Test Item",
+  fields: {
+    title: { type: "string", required: true },
+    status: { type: "string" },
+  },
+});
+
+const SCHEMA_NAME = testSchema.name;
+
+let db: PostgresJsDatabase | null = null;
+let tableRegistry: TableRegistry;
+let provider: DrizzleDataProvider;
+
+async function canConnect(): Promise<boolean> {
+  try {
+    const testDb = createDatabase({ url: DATABASE_URL });
+    await testDb.execute(sql`SELECT 1`);
+    await closeDatabase();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dbAvailable = await canConnect();
+
+if (!dbAvailable) {
+  console.warn("PostgreSQL not available, skipping DrizzleDataProvider row-lock tests");
+}
+
+describe.skipIf(!dbAvailable)("DrizzleDataProvider row-level locking (#470)", () => {
+  beforeAll(async () => {
+    db = createDatabase({ url: DATABASE_URL });
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS "${SCHEMA_NAME}" CASCADE`));
+
+    tableRegistry = new TableRegistry();
+    tableRegistry.register(SCHEMA_NAME, generateDrizzleTable(testSchema));
+
+    // Create test table via raw SQL (test fixture — not production DDL)
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE IF NOT EXISTS "${SCHEMA_NAME}" (
+        "id" varchar(128) PRIMARY KEY NOT NULL,
+        "tenant_id" varchar(128),
+        "created_at" timestamp DEFAULT now() NOT NULL,
+        "updated_at" timestamp DEFAULT now() NOT NULL,
+        "created_by" varchar(128),
+        "updated_by" varchar(128),
+        "_version" integer DEFAULT 1 NOT NULL,
+        "deleted_at" timestamp,
+        "_extensions" jsonb,
+        "title" varchar(255) NOT NULL,
+        "status" varchar(50)
+      )
+    `),
+    );
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS "${SCHEMA_NAME}" CASCADE`));
+      await closeDatabase();
+    }
+  });
+
+  beforeEach(() => {
+    provider = new DrizzleDataProvider(db as NonNullable<typeof db>, tableRegistry);
+  });
+
+  afterEach(async () => {
+    if (db) {
+      await db.execute(sql.raw(`TRUNCATE TABLE "${SCHEMA_NAME}"`));
+    }
+  });
+
+  /**
+   * Probe whether `id`'s row is lockable from a SEPARATE pooled connection.
+   * `FOR UPDATE NOWAIT` fails immediately (SQLSTATE 55P03) when the row is
+   * already locked, so this is a deterministic test of lock state with no sleeps.
+   */
+  const probeRowLockable = async (id: string): Promise<boolean> => {
+    const table = tableRegistry.getTable(SCHEMA_NAME);
+    const idCol = getTableColumns(table).id;
+    try {
+      await (db as NonNullable<typeof db>)
+        .select()
+        .from(table)
+        .where(eq(idCol, id))
+        .for("update", { noWait: true });
+      return true; // acquired the lock → the row was free
+    } catch {
+      return false; // 55P03 lock_not_available → the row is locked elsewhere
+    }
+  };
+
+  test("get with forUpdate — pins the row with a lock that blocks a concurrent writer", async () => {
+    const created = await provider.create(SCHEMA_NAME, { title: "Lockable", status: "pending" });
+    const id = created.id as string;
+
+    await (db as NonNullable<typeof db>).transaction(async (tx) => {
+      const txProvider = provider.withConnection(tx as unknown as PostgresJsDatabase);
+      const locked = await txProvider.get(SCHEMA_NAME, id, { forUpdate: true });
+      expect(locked.id).toBe(id);
+      // While the transaction holds the FOR UPDATE lock, a separate session can't lock it.
+      expect(await probeRowLockable(id)).toBe(false);
+    });
+
+    // The lock is released once the transaction commits.
+    expect(await probeRowLockable(id)).toBe(true);
+  });
+
+  test("get without forUpdate — takes no row lock (opt-in)", async () => {
+    const created = await provider.create(SCHEMA_NAME, { title: "Unlocked", status: "pending" });
+    const id = created.id as string;
+
+    await (db as NonNullable<typeof db>).transaction(async (tx) => {
+      const txProvider = provider.withConnection(tx as unknown as PostgresJsDatabase);
+      await txProvider.get(SCHEMA_NAME, id); // plain read — no lock requested
+      // A plain read leaves the row free, so another session can still lock it.
+      expect(await probeRowLockable(id)).toBe(true);
+    });
+  });
+});

--- a/packages/core/__tests__/drizzle-data-provider.row-lock.integration.test.ts
+++ b/packages/core/__tests__/drizzle-data-provider.row-lock.integration.test.ts
@@ -121,8 +121,16 @@ describe.skipIf(!dbAvailable)("DrizzleDataProvider row-level locking (#470)", ()
         .where(eq(idCol, id))
         .for("update", { noWait: true });
       return true; // acquired the lock → the row was free
-    } catch {
-      return false; // 55P03 lock_not_available → the row is locked elsewhere
+    } catch (err) {
+      // Only "lock not available" (SQLSTATE 55P03) means the row is locked
+      // elsewhere. Surface any other failure instead of masking it as "locked",
+      // which would let an unrelated query/setup error pass as a green test.
+      // drizzle wraps the driver error in DrizzleQueryError, so the Postgres
+      // SQLSTATE is on the wrapped `cause`.
+      const code =
+        (err as { code?: string }).code ?? (err as { cause?: { code?: string } }).cause?.code;
+      if (code === "55P03") return false;
+      throw err;
     }
   };
 

--- a/packages/core/src/engine/action-engine-types.ts
+++ b/packages/core/src/engine/action-engine-types.ts
@@ -36,6 +36,19 @@ export interface DataQueryOptions {
   includeDeleted?: boolean;
   /** Locale for resolving translatable fields (e.g., "zh-CN", "en") */
   locale?: string;
+  /**
+   * Acquire a row-level write lock (`SELECT … FOR UPDATE`) on the matched row.
+   *
+   * Only meaningful when the read runs inside a transaction: it pins the row
+   * from read to commit, closing the read→write TOCTOU window left open by a
+   * plain `SELECT` under READ COMMITTED (see #470). Used by the in-transaction
+   * record-state guard re-check (#466/#469). Outside a transaction the lock is
+   * acquired and released at statement end, so it has no lasting effect.
+   *
+   * No-op for stores without row-level locking — the InMemoryStore is
+   * single-threaded and already serialized, so it ignores this flag.
+   */
+  forUpdate?: boolean;
 }
 
 /** Abstraction for data access — injected into the executor for testability */

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1428,20 +1428,20 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         // Scope of the guarantee. This collapses the pre-write window — Step 4c
         // runs before validation, the state-machine check, and handler setup, so
         // the old read→write gap spanned all of those. The re-check moves the
-        // guard read inside the transaction, adjacent to the write. It does NOT,
-        // by itself, make read+write atomic under PostgreSQL READ COMMITTED: a
-        // concurrent commit landing between this read and the write (or while a
-        // long handler runs) is still possible. Full closure needs row-level
-        // locking (`SELECT … FOR UPDATE`) or a snapshot-stable isolation level,
-        // neither of which the DataProvider interface exposes today — tracked as
-        // follow-up (#466). The same residual applies to field-lock #203 and to
-        // #466's option-(b) design alike. It is fully closed for the
-        // InMemoryStore (no concurrency) and under serializable isolation.
-        //
-        // (The reverse direction — a guard that fired on a now-stale Step 4c
-        // snapshot but would NOT on the fresh one — still early-returns at
-        // Step 4c; that is a retryable false-rejection, not a write-integrity
-        // violation, and matches field-lock's pre-tx preflight.)
+        // guard read inside the transaction, adjacent to the write, AND acquires a
+        // row-level lock on it (`forUpdate`, #470): the guarded row is pinned from
+        // this read until commit, so a concurrent writer blocks rather than
+        // slipping a state change between the guard read and the write under
+        // READ COMMITTED. The lock is honored by providers that implement it (the
+        // Drizzle provider issues `SELECT … FOR UPDATE`); the InMemoryStore is
+        // single-threaded and already serialized, so it no-ops the flag and is
+        // closed by construction. Residual not covered here: the handler may read
+        // OTHER rows that aren't lock-pinned — only the guarded record is — and a
+        // higher isolation level would be needed to make the whole handler
+        // snapshot-stable. The reverse direction (a guard that fired on a
+        // now-stale Step 4c snapshot but would NOT on the fresh one) still
+        // early-returns at Step 4c — a retryable false-rejection, not a
+        // write-integrity violation, matching field-lock's pre-tx preflight.
         if (useTransaction && !parentTxProvider) {
           // Only `block` / `require_approval` outcomes can change the in-tx
           // decision — enrich / warn / execute_action / trigger_flow were
@@ -1469,7 +1469,13 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
               actor,
               meta: resolvedMeta,
               readProvider: dp,
-              queryOptions,
+              // Lock the row with `SELECT … FOR UPDATE` for the duration of the
+              // write transaction (#470). `dp` is the transactional provider, so
+              // the lock is held to commit — a concurrent writer can't flip the
+              // guarded state between this read and the write, closing the residual
+              // READ COMMITTED TOCTOU window left by #469. Constructed inline so the
+              // lock never leaks to the non-transactional Step 4c pre-write read.
+              queryOptions: { ...queryOptions, forUpdate: true },
               skipRules: execOptions?.skipRules,
               // The pre-write Step 4c pass already counted rule metrics for this
               // execution — use a noop collector to avoid double-counting.

--- a/packages/core/src/persistence/drizzle-data-provider.ts
+++ b/packages/core/src/persistence/drizzle-data-provider.ts
@@ -355,12 +355,16 @@ export class DrizzleDataProvider implements DataProvider {
     // #466/#469), the lock is held until commit, closing the read→write TOCTOU
     // window under READ COMMITTED (#470). `this.db` is the transactional handle
     // here because the executor reads through the tx-scoped provider copy.
-    const baseQuery = this.db
+    let query = this.db
       .select()
       .from(table)
       .where(and(...conditions))
-      .limit(1);
-    const rows = await (options?.forUpdate ? baseQuery.for("update") : baseQuery);
+      .limit(1)
+      .$dynamic();
+    if (options?.forUpdate) {
+      query = query.for("update");
+    }
+    const rows = await query;
 
     if (rows.length === 0) {
       throw new NotFoundError({

--- a/packages/core/src/persistence/drizzle-data-provider.ts
+++ b/packages/core/src/persistence/drizzle-data-provider.ts
@@ -350,11 +350,17 @@ export class DrizzleDataProvider implements DataProvider {
 
     const conditions = [eq(idCol, id), ...this.buildBaseConditions(table, options)];
 
-    const rows = await this.db
+    // `forUpdate` pins the row with a `SELECT … FOR UPDATE` row lock. When this
+    // read runs inside a transaction (e.g. the in-tx record-state guard re-check,
+    // #466/#469), the lock is held until commit, closing the read→write TOCTOU
+    // window under READ COMMITTED (#470). `this.db` is the transactional handle
+    // here because the executor reads through the tx-scoped provider copy.
+    const baseQuery = this.db
       .select()
       .from(table)
       .where(and(...conditions))
       .limit(1);
+    const rows = await (options?.forUpdate ? baseQuery.for("update") : baseQuery);
 
     if (rows.length === 0) {
       throw new NotFoundError({


### PR DESCRIPTION
## What

Closes #470 — the residual TOCTOU window left by #469.

#469 (closing #466) moved `block` / `require_approval` record-state guard-rule
evaluation **inside the write transaction**, collapsing the wide pre-write gap.
But under PostgreSQL **READ COMMITTED**, a plain `SELECT` guard read + the write
are still not atomic: a concurrent commit can land between them (codex R2 on #469).

This PR closes that window with **row-level locking** (#470 Option 1).

## How

- **`DataQueryOptions.forUpdate?: boolean`** — opt-in, documented. Defaults off, so
  no behavior change for existing callers.
- **Drizzle `get()`** honors it with `SELECT … FOR UPDATE` (same builder API already
  used by `outbox-worker`’s `.for("update", { skipLocked })`).
- **In-transaction guard re-check** sets `forUpdate: true` (constructed inline so the
  lock never leaks to the non-transactional Step 4c pre-write read). `dp` is the
  transactional provider, so the row is pinned from the guard read until commit — a
  concurrent writer blocks instead of slipping a state change past the guard.
- **InMemoryStore** is single-threaded / already serialized → no-ops the flag.

### Scope of the guarantee
The guarded record is lock-pinned read→commit. Not covered (documented in-code):
the handler may read *other* rows that aren’t pinned — full handler
snapshot-stability would need a higher isolation level. The reverse-direction
false-rejection (stale Step 4c snapshot) remains an intentional retryable, matching
field-lock’s pre-tx preflight.

## Tests

- **DB-free wiring** (`action-engine-rule-toctou.test.ts`): asserts the in-tx guard
  read requests `forUpdate: true` while the pre-write Step 4c read does not.
- **Real-Postgres lock semantics** (`drizzle-data-provider.integration.test.ts`):
  a `FOR UPDATE NOWAIT` probe from a separate session deterministically proves the
  lock blocks a concurrent writer, and that it is opt-in (plain read takes no lock).
  Verified locally against `postgres:16-alpine` (28/28 integration tests green);
  runs in CI via the existing `DATABASE_TEST_URL` postgres service.

## Quality gates
`bun run check` ✓ · `bun run typecheck` ✓ · `bun run test` (full batched suite) ✓

## Cross-model review
codex (`codex review --commit main..HEAD`): **no actionable findings** —
"correctly adds an opt-in row-level lock applied only to the transactional guard
re-check path; no introduced correctness, security, or maintainability issues."

Follow-up to #462 / #466 / #469. Precedent: field-lock #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a concurrency issue in guard evaluation that could allow state changes to slip past checks during simultaneous operations. The system now applies row-level locking during guard re-evaluation within transactions to ensure data consistency.

* **New Features**
  * Added optional row-locking support for database queries. This is an opt-in feature with no impact on existing code—enabled when needed for stricter concurrency guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->