### PR TITLE
feat(core): extend in-transaction record-state guard row-locking to nested actions (#473)

### DIFF
--- a/.changeset/nested-toctou-row-lock.md
+++ b/.changeset/nested-toctou-row-lock.md
@@ -1,0 +1,18 @@
+---
+"@linchkit/core": patch
+---
+
+Extend in-transaction record-state guard row-locking to nested actions (#473).
+
+PR #472 (#470) closed the record-state guard TOCTOU window for top-level
+transactional actions by acquiring a `SELECT … FOR UPDATE` row lock during the
+in-transaction guard re-check, gated on `useTransaction && !parentTxProvider`.
+Nested transactional actions (running inside a parent transaction) were excluded:
+their Step 4c guard read already uses the parent's transactional provider (so the
+snapshot is fresh) but it is a plain unlocked `SELECT`, leaving a residual
+read→write race under READ COMMITTED.
+
+The re-check gate is now `inTransaction`, so nested transactional actions also
+lock-pin their guarded row from the in-transaction re-check until the parent
+commits — uniform with top-level (Step 4c = unlocked preflight, in-tx re-check =
+authoritative locked decision). No change for non-transactional actions.

--- a/packages/core/__tests__/action-engine-rule-toctou-nested.test.ts
+++ b/packages/core/__tests__/action-engine-rule-toctou-nested.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Record-state guard rules are re-evaluated inside the write transaction for
+ * NESTED transactional actions too (#473), extending the #462 / #466 / #470
+ * top-level guarantee.
+ *
+ * A NESTED action — invoked via `ctx.execute(child)` from a parent handler that
+ * is itself inside an open transaction — already reads its guarded record
+ * through the parent's transactional provider at Step 4c, so its snapshot is
+ * fresh/in-transaction. The remaining gap is purely the LOCK: that Step 4c read
+ * is a plain `SELECT` (no `FOR UPDATE`), so under READ COMMITTED a concurrent
+ * external commit can still race between the nested guard read and the nested
+ * write. The in-transaction re-check now runs for nested actions as well and
+ * issues the guard read with `forUpdate: true`, pinning the row in the parent's
+ * transaction until commit.
+ *
+ * These tests model the nesting with a transactional PARENT action whose handler
+ * calls `ctx.execute("child_approve", ...)`. The engine forwards the parent's
+ * transactional provider as the child's `_txDataProvider`, so the child runs
+ * with `parentTxProvider` set — i.e. the nested path. We capture the read
+ * options on the provider the child reads through to prove the lock now extends
+ * to nested.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createActionExecutor,
+  type DataProvider,
+  type DataQueryOptions,
+  type PendingEvent,
+  type TransactionManager,
+} from "../src/engine/action-engine";
+import type { ActionDefinition, Actor } from "../src/types/action";
+import type { RuleDefinition } from "../src/types/rule";
+
+const actor: Actor = { type: "human", id: "u1", groups: [] };
+
+interface Cap {
+  updated: boolean;
+}
+
+/**
+ * Provider that always reads `record` and records whether `update` ran. When a
+ * `getOptionsLog` is supplied, every `get()` call appends the options it received
+ * so a test can assert how the read was issued (e.g. `forUpdate`).
+ */
+function makeProvider(
+  record: Record<string, unknown>,
+  cap: Cap,
+  getOptionsLog?: Array<DataQueryOptions | undefined>,
+): DataProvider {
+  return {
+    get: async (_entity, id, options) => {
+      getOptionsLog?.push(options);
+      return { id, ...record };
+    },
+    query: async () => [],
+    create: async (_entity, data) => ({ id: "r1", ...data }),
+    update: async (_entity, id, data) => {
+      cap.updated = true;
+      return { id, ...record, ...data };
+    },
+    delete: async () => {},
+    count: async () => 0,
+  };
+}
+
+/** A TransactionManager whose transactional provider exposes the FRESH snapshot. */
+function makeTxManager(txProvider: DataProvider): TransactionManager {
+  return {
+    runInTransaction: <T>(fn: (tx: DataProvider) => Promise<T>, _events: PendingEvent[]) =>
+      fn(txProvider),
+  };
+}
+
+/** block when the CURRENT record state is already "approved" — a record-state guard. */
+function blockIfApproved(): RuleDefinition {
+  return {
+    name: "block_if_already_approved",
+    label: "Block double approval",
+    trigger: { action: "child_approve" },
+    condition: { field: "target.status", operator: "eq", value: "approved" },
+    effect: { type: "block", message: "Already approved", reason: "already_approved" },
+  };
+}
+
+/**
+ * CHILD transactional update action carrying the record-state guard — writes via
+ * ctx.update so a write is detectable.
+ */
+function childApproveAction(): ActionDefinition {
+  return {
+    name: "child_approve",
+    entity: "thing",
+    label: "Approve (child)",
+    policy: { mode: "sync", transaction: true },
+    exposure: "all",
+    handler: async (ctx) => {
+      const input = ctx.input as { id: string };
+      return ctx.update("thing", input.id, { status: "done" });
+    },
+  };
+}
+
+/**
+ * PARENT transactional action with NO guard rules. Its handler invokes the child
+ * via ctx.execute, which forwards the parent's transactional provider so the
+ * child runs nested (parentTxProvider set). Returns the child's result so the
+ * test can inspect it.
+ */
+function parentApproveAction(): ActionDefinition {
+  return {
+    name: "parent_approve",
+    entity: "thing",
+    label: "Approve (parent)",
+    policy: { mode: "sync", transaction: true },
+    exposure: "all",
+    handler: async (ctx) => {
+      const child = await ctx.execute("child_approve", { id: "c1" });
+      return { child };
+    },
+  };
+}
+
+describe("nested transactional record-state guard re-check (#473 row-lock)", () => {
+  it("the NESTED child's in-tx guard re-check reads FOR UPDATE through the parent tx provider", async () => {
+    const baseGetOptions: Array<DataQueryOptions | undefined> = [];
+    const txGetOptions: Array<DataQueryOptions | undefined> = [];
+    const baseCap: Cap = { updated: false };
+    const txCap: Cap = { updated: false };
+    // Neither snapshot is "approved" → the guard does not fire and the write
+    // proceeds, so the nested in-tx read is exercised without the block
+    // short-circuiting. The child reads through the parent's tx provider, so the
+    // `forUpdate` lock must appear on `txGetOptions`.
+    const baseProvider = makeProvider({ status: "pending" }, baseCap, baseGetOptions);
+    const txProvider = makeProvider({ status: "pending" }, txCap, txGetOptions);
+
+    const executor = createActionExecutor({
+      dataProvider: baseProvider,
+      transactionManager: makeTxManager(txProvider),
+      rules: [blockIfApproved()],
+    });
+    executor.registry.register(childApproveAction());
+    executor.registry.register(parentApproveAction());
+
+    const result = await executor.execute("parent_approve", { id: "p1" }, actor);
+    expect(result.success).toBe(true);
+    // The child's nested write went through the parent's tx provider.
+    expect(txCap.updated).toBe(true);
+
+    // The nested child's in-tx guard re-check pinned the guarded row with a
+    // `FOR UPDATE` lock so a concurrent writer can't flip its state before the
+    // nested write (#473). Before the gate extension this would be absent — the
+    // re-check was scoped to top-level transactional actions only.
+    expect(txGetOptions.length).toBeGreaterThan(0);
+    expect(txGetOptions.some((o) => o?.forUpdate === true)).toBe(true);
+    // The parent is top-level transactional with no guard rules, so its only
+    // read of the base (pre-tx) provider is the parent's pre-write Step 4c pass,
+    // which runs OUTSIDE the transaction and must NOT request a row lock.
+    expect(baseGetOptions.every((o) => !o?.forUpdate)).toBe(true);
+  });
+
+  it("a NESTED record-state block fires on the IN-TX snapshot and no child write occurs", async () => {
+    const baseCap: Cap = { updated: false };
+    const txCap: Cap = { updated: false };
+    // Pre-tx base reads STALE "pending" → an old pre-tx-only read would NOT block.
+    const baseProvider = makeProvider({ status: "pending" }, baseCap);
+    // The transaction sees FRESH "approved" → the nested guard must block on this
+    // in-tx snapshot, locked via FOR UPDATE.
+    const txProvider = makeProvider({ status: "approved" }, txCap);
+
+    const executor = createActionExecutor({
+      dataProvider: baseProvider,
+      transactionManager: makeTxManager(txProvider),
+      rules: [blockIfApproved()],
+    });
+    executor.registry.register(childApproveAction());
+    executor.registry.register(parentApproveAction());
+
+    const result = await executor.execute("parent_approve", { id: "p1" }, actor);
+
+    // The nested child is blocked on the fresh in-tx snapshot. The block throws
+    // InTxRuleBlockError, the transaction rolls back, and the child surfaces to
+    // the parent as childResult.success === false (its `data` is the rule_block
+    // failure that ctx.execute returns to the parent handler).
+    const child = (result.data as { child?: { context?: { constraint?: string } } }).child;
+    expect(child?.context?.constraint).toBe("rule_block");
+    // No write happened on either provider.
+    expect(baseCap.updated).toBe(false);
+    expect(txCap.updated).toBe(false);
+  });
+
+  it("control: when the in-tx snapshot is NOT approved, the nested child proceeds and writes", async () => {
+    const baseCap: Cap = { updated: false };
+    const txCap: Cap = { updated: false };
+    const baseProvider = makeProvider({ status: "pending" }, baseCap);
+    const txProvider = makeProvider({ status: "pending" }, txCap);
+
+    const executor = createActionExecutor({
+      dataProvider: baseProvider,
+      transactionManager: makeTxManager(txProvider),
+      rules: [blockIfApproved()],
+    });
+    executor.registry.register(childApproveAction());
+    executor.registry.register(parentApproveAction());
+
+    const result = await executor.execute("parent_approve", { id: "p1" }, actor);
+
+    expect(result.success).toBe(true);
+    // The nested write went through the (shared) transactional provider.
+    expect(txCap.updated).toBe(true);
+    expect(baseCap.updated).toBe(false);
+  });
+});

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1411,38 +1411,55 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       const runHandler = async (dp: DataProvider): Promise<void> => {
         activeProvider = dp;
 
-        // In-transaction record-state rule re-check (#462 / #466). For a
-        // TOP-LEVEL transactional action, re-evaluate the `block` /
-        // `require_approval` guards against the transactional provider `dp`,
-        // inside the write transaction, before any write. A record-state guard
-        // that did not fire on the pre-write Step 4c snapshot but DOES fire on
-        // the in-transaction snapshot now blocks/suspends the action instead of
-        // letting a stale-but-valid-looking write through. Throwing rolls the
-        // transaction back; the catch maps it to the same blocked / pending
-        // result Step 4c produces. Scoped to the top-level-tx case because that
-        // is the only one whose Step 4c read (`baseProvider`) differs from the
-        // write snapshot: nested actions already read the parent tx, and
-        // non-transactional actions read `baseProvider == dp`. Mirrors the in-tx
-        // field-lock check (#203).
+        // In-transaction record-state rule re-check (#462 / #466 / #473). For
+        // ANY transactional action — TOP-LEVEL (this execution opened the tx)
+        // OR NESTED (it runs inside the parent's open tx via `parentTxProvider`)
+        // — re-evaluate the `block` / `require_approval` guards against the
+        // transactional provider `dp`, inside the write transaction, before any
+        // write. A record-state guard that did not fire on the pre-write Step 4c
+        // snapshot but DOES fire on the in-transaction snapshot now
+        // blocks/suspends the action instead of letting a stale-but-valid-looking
+        // write through. Throwing rolls the transaction back; the catch maps it
+        // to the same blocked / pending result Step 4c produces (for a nested
+        // action that surfaces to the parent as `childResult.success === false`,
+        // the existing nested-failure contract). Mirrors the in-tx field-lock
+        // check (#203).
+        //
+        // Why this now covers nested actions too (#473). The two transactional
+        // cases reach the write through different Step 4c reads, but BOTH leave
+        // the guarded row unlocked until this re-check:
+        //   - TOP-LEVEL: Step 4c reads `baseProvider` (the pre-transaction
+        //     snapshot), which differs from the write snapshot, so the re-check
+        //     supplies BOTH a fresh in-tx snapshot AND the lock.
+        //   - NESTED: Step 4c already reads through `parentTxProvider` (see the
+        //     `readProvider: parentTxProvider ?? baseProvider` Step 4c read), so
+        //     its snapshot is already fresh/in-transaction — but that read is a
+        //     plain `SELECT` with no row lock. Under READ COMMITTED a concurrent
+        //     external commit can still slip a state change between that unlocked
+        //     guard read and the nested write. The re-check adds the missing
+        //     `FOR UPDATE` lock, making nested UNIFORM with top-level: Step 4c is
+        //     a (non-locked) preflight and this in-tx re-check is the
+        //     authoritative locked decision.
         //
         // Scope of the guarantee. This collapses the pre-write window — Step 4c
         // runs before validation, the state-machine check, and handler setup, so
         // the old read→write gap spanned all of those. The re-check moves the
         // guard read inside the transaction, adjacent to the write, AND acquires a
         // row-level lock on it (`forUpdate`, #470): the guarded row is pinned from
-        // this read until commit, so a concurrent writer blocks rather than
-        // slipping a state change between the guard read and the write under
-        // READ COMMITTED. The lock is honored by providers that implement it (the
-        // Drizzle provider issues `SELECT … FOR UPDATE`); the InMemoryStore is
-        // single-threaded and already serialized, so it no-ops the flag and is
-        // closed by construction. Residual not covered here: the handler may read
-        // OTHER rows that aren't lock-pinned — only the guarded record is — and a
-        // higher isolation level would be needed to make the whole handler
-        // snapshot-stable. The reverse direction (a guard that fired on a
-        // now-stale Step 4c snapshot but would NOT on the fresh one) still
+        // this read until commit (the parent's commit for a nested action, since
+        // `dp` is the parent's transactional provider), so a concurrent writer
+        // blocks rather than slipping a state change between the guard read and
+        // the write under READ COMMITTED. The lock is honored by providers that
+        // implement it (the Drizzle provider issues `SELECT … FOR UPDATE`); the
+        // InMemoryStore is single-threaded and already serialized, so it no-ops
+        // the flag and is closed by construction. Residual not covered here: the
+        // handler may read OTHER rows that aren't lock-pinned — only the guarded
+        // record is — and a higher isolation level would be needed to make the
+        // whole handler snapshot-stable. The reverse direction (a guard that fired
+        // on a now-stale Step 4c snapshot but would NOT on the fresh one) still
         // early-returns at Step 4c — a retryable false-rejection, not a
         // write-integrity violation, matching field-lock's pre-tx preflight.
-        if (useTransaction && !parentTxProvider) {
+        if (inTransaction) {
           // Only `block` / `require_approval` outcomes can change the in-tx
           // decision — enrich / warn / execute_action / trigger_flow were
           // already handled by the pre-write Step 4c pass. Re-evaluate ONLY the


### PR DESCRIPTION
## What
Closes #473 — the nested-action follow-up from #472 (#470).

#472 closed the record-state guard read→write TOCTOU window for **top-level**
transactional actions by acquiring a `SELECT … FOR UPDATE` row lock during the
in-transaction guard re-check, gated on `useTransaction && !parentTxProvider`.
**Nested** transactional actions (running inside a parent tx) were excluded:
their Step 4c guard read already uses the parent's transactional provider (so the
snapshot is fresh) but it is a plain unlocked `SELECT`, leaving a residual
read→write race under READ COMMITTED (raised by gemini on #472).

## How
Change the in-tx guard re-check gate from `useTransaction && !parentTxProvider` to
`inTransaction`, so nested transactional actions also acquire the `FOR UPDATE`
lock and hold it until the parent commits. This makes nested **uniform** with
top-level: Step 4c is an unlocked preflight, the in-tx re-check is the
authoritative locked decision. For a nested action `dp` is the parent's tx
provider, so the lock lives in (and releases with) the parent transaction. A
nested block/approval surfaces to the parent as `childResult.success === false`
(the existing nested-failure contract — unchanged). Non-transactional actions are
unaffected. The surrounding comment block is updated to document the nested case.

## Tests
`action-engine-rule-toctou-nested.test.ts` (a parent tx action invokes a child via
`ctx.execute`):
- **wiring** — the nested child's guard read now requests `forUpdate` (fail-first
  verified: absent under the old gate);
- **behavior** — a nested record-state block fires on the in-tx snapshot, no child
  write;
- **control** — non-blocking state → the nested child proceeds and writes.

## Quality gates
`bun run check` ✓ · `bun run typecheck` ✓ · `bun run test` (full batched suite) ✓

## Cross-model review
codex (`codex review --commit main..HEAD`): **no actionable findings** — "correctly
extends the in-transaction guard re-check to nested transactional executions; the
added tests cover the new row-lock behavior; no introduced correctness issues."

Follow-up to #470 / #472. Precedent: #469, field-lock #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended record-state guard protection to nested transactional actions, ensuring consistent row-level locking and data integrity across transaction hierarchies.

* **Tests**
  * Added test suite for nested transactional scenarios, validating guard behavior, lock enforcement, and data consistency across transaction boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->