### PR TITLE
test(core,adapter-server): rule-effects unit + full-stack rule-effect e2e + write-path smoke

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-advanced.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-advanced.test.ts
@@ -147,10 +147,12 @@ const createAuditEntryAction: ActionDefinition = {
 
 // ── Server setup (DB-free — InMemoryStore) ─────────────────────────────────
 
-const PORT = 32140;
-const REST_URL = `http://localhost:${PORT}/api/actions`;
-const APPROVALS_URL = `http://localhost:${PORT}/api/approvals`;
-const GQL_URL = `http://localhost:${PORT}/graphql`;
+// In-process, port-free: these URLs only supply a path to `new Request(...)` for
+// `app.handle` — no socket is bound, so a dummy domain is used (no real port).
+const BASE_URL = "http://local.test";
+const REST_URL = `${BASE_URL}/api/actions`;
+const APPROVALS_URL = `${BASE_URL}/api/approvals`;
+const GQL_URL = `${BASE_URL}/graphql`;
 
 let store: InMemoryStore;
 let approvalStore: InMemoryApprovalStore;
@@ -361,8 +363,8 @@ describe("E2E rule effect: require_approval", () => {
     // Retrieve the pending approval ID.
     const approvalsList = await getApprovals("pending");
     const req = approvalsList.data.items.find((r) => r.action === "submit_order");
-    expect(req).toBeDefined();
-    const approvalId = req?.id;
+    if (!req) throw new Error("expected a pending approval request for submit_order");
+    const approvalId = req.id;
 
     // Approve the request — should re-execute submit_order and write status = "submitted".
     const approveResult = await approveRequest(approvalId);

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-advanced.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-advanced.test.ts
@@ -1,0 +1,499 @@
+/**
+ * E2E Test: Advanced rule effects — enrich, require_approval, execute_action
+ *
+ * Extends e2e-rules.test.ts (block + warn) with three more effect types:
+ *
+ * - enrich: sets fields on effectiveInput before the write; asserted via GraphQL read.
+ * - require_approval: suspends the action into a pending ApprovalRequest when an
+ *   ApprovalEngine is wired. The action REST endpoint returns 422 + success:false.
+ *   Approval ID is retrieved via GET /api/approvals; POST /api/approvals/:id/approve
+ *   re-executes and completes the write (asserted via a follow-up GraphQL read).
+ *   NOTE: the raw ApprovalPendingResult is wrapped into an error envelope by the
+ *   action-api route and is NOT surfaced as a success body.
+ * - execute_action: triggers a second action post-commit; asserted by querying the
+ *   side-effect record (audit_log) after the primary submit.
+ *
+ * Setup: DB-free — uses InMemoryStore. Tests PASS without any database connection.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { ActionDefinition, EntityDefinition, RuleDefinition } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createApprovalEngine,
+  InMemoryApprovalStore,
+  InMemoryStore,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema, generateCrudActions } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Entity definition ──────────────────────────────────────────────────────
+
+const orderSchema: EntityDefinition = {
+  name: "order",
+  label: "Order",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+    amount: { type: "number", required: true, label: "Amount" },
+    category: { type: "string", label: "Category" },
+    status: { type: "string", default: "draft" },
+    // Enriched by the auto-category rule (set by the enrich effect).
+    autoCategory: { type: "string", label: "Auto Category" },
+  },
+};
+
+// A lightweight audit-log entity used by the execute_action cascade test.
+const auditLogSchema: EntityDefinition = {
+  name: "audit_log",
+  label: "Audit Log",
+  fields: {
+    sourceOrderId: { type: "string", required: true, label: "Source Order ID" },
+    event: { type: "string", required: true, label: "Event" },
+  },
+};
+
+// ── Rule definitions ───────────────────────────────────────────────────────
+
+/**
+ * enrich rule: when an order has no explicit category, automatically set
+ * autoCategory to "general" on the effective input before the write.
+ */
+const enrichAutoCategoryRule: RuleDefinition = {
+  name: "enrich_auto_category",
+  label: "Enrich Auto Category",
+  description: "Set autoCategory to 'general' when category is absent",
+  trigger: { action: "submit_order" },
+  condition: { field: "target.category", operator: "is_null" },
+  effect: { type: "enrich", setFields: { autoCategory: "general" } },
+};
+
+/**
+ * require_approval rule: orders over 50,000 require director-level approval.
+ */
+const requireApprovalLargeOrderRule: RuleDefinition = {
+  name: "require_approval_large_order",
+  label: "Require Approval for Large Orders",
+  description: "Orders over 50,000 require director approval",
+  trigger: { action: "submit_order" },
+  condition: { field: "target.amount", operator: "gt", value: 50000 },
+  effect: {
+    type: "require_approval",
+    level: "director",
+    message: "Large order requires director approval.",
+  },
+};
+
+/**
+ * execute_action rule: after an order is submitted, fire create_audit_entry as a
+ * post-commit side effect. Explicit params override the default effectiveInput.
+ */
+const executeActionAuditRule: RuleDefinition = {
+  name: "execute_action_audit",
+  label: "Audit on Submit",
+  description: "Create an audit log entry after every order submission",
+  trigger: { action: "submit_order" },
+  condition: { field: "target.amount", operator: "gt", value: 0 },
+  effect: {
+    type: "execute_action",
+    action: "create_audit_entry",
+    // params override the default effectiveInput so the audit action gets
+    // a stable shape rather than the full order payload.
+    params: { event: "order.submitted" },
+  },
+};
+
+// ── Action definitions ─────────────────────────────────────────────────────
+
+/**
+ * submit_order: writes status = "submitted".
+ * Rule enrich fires BEFORE this handler runs, so ctx.input.autoCategory will
+ * already be set (if the enrich rule fired).
+ */
+const submitOrderAction: ActionDefinition = {
+  name: "submit_order",
+  entity: "order",
+  label: "Submit Order",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    const id = ctx.input.id as string;
+    // Persist the enriched + status fields.  Rule enrich merged autoCategory
+    // into ctx.input before this handler ran.
+    const updates: Record<string, unknown> = { status: "submitted" };
+    if (ctx.input.autoCategory !== undefined) {
+      updates.autoCategory = ctx.input.autoCategory as string;
+    }
+    return ctx.update("order", id, updates);
+  },
+};
+
+/**
+ * create_audit_entry: write an audit_log record.
+ * Invoked as a post-commit execute_action side effect.
+ * The rule passes { event: "order.submitted" } as explicit params.
+ */
+const createAuditEntryAction: ActionDefinition = {
+  name: "create_audit_entry",
+  entity: "audit_log",
+  label: "Create Audit Entry",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    const sourceOrderId = (ctx.input.id as string | undefined) ?? "unknown";
+    const event = (ctx.input.event as string | undefined) ?? "unknown";
+    return ctx.create("audit_log", { sourceOrderId, event });
+  },
+};
+
+// ── Server setup (DB-free — InMemoryStore) ─────────────────────────────────
+
+const PORT = 32140;
+const REST_URL = `http://localhost:${PORT}/api/actions`;
+const APPROVALS_URL = `http://localhost:${PORT}/api/approvals`;
+const GQL_URL = `http://localhost:${PORT}/graphql`;
+
+let store: InMemoryStore;
+let approvalStore: InMemoryApprovalStore;
+let app: ReturnType<typeof createServer>;
+
+beforeAll(() => {
+  store = new InMemoryStore();
+  approvalStore = new InMemoryApprovalStore();
+
+  // Rules must be passed to createActionExecutor so the engine evaluates them
+  // automatically on every action execution (enrich, require_approval, execute_action).
+  const rules: RuleDefinition[] = [
+    enrichAutoCategoryRule,
+    requireApprovalLargeOrderRule,
+    executeActionAuditRule,
+  ];
+
+  const executor = createActionExecutor({ dataProvider: store, rules });
+
+  // Register CRUD actions for both entities + the custom actions.
+  for (const action of generateCrudActions(orderSchema)) executor.registry.register(action);
+  for (const action of generateCrudActions(auditLogSchema)) executor.registry.register(action);
+  executor.registry.register(submitOrderAction);
+  executor.registry.register(createAuditEntryAction);
+
+  // Wire the approval engine via setApprovalEngine (late-binding seam).
+  // createApprovalEngine needs the executor for re-execution on approve().
+  const approvalEngine = createApprovalEngine({ store: approvalStore, executor });
+  executor.setApprovalEngine(approvalEngine);
+
+  // Build GraphQL schema with all entities.
+  const graphqlSchema = buildGraphQLSchema([orderSchema, auditLogSchema], {
+    executor,
+    dataProvider: store,
+    actions: [submitOrderAction, createAuditEntryAction],
+  });
+
+  // Pass rules + approvalEngine to createServer for /api/rules and /api/approvals endpoints.
+  app = createServer(graphqlSchema, { executor, approvalEngine, rules });
+});
+
+beforeEach(() => {
+  store.clear();
+  approvalStore.clear();
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+// Requests are dispatched in-process via `app.handle(new Request(...))` — no port
+// is bound. Binding a real socket per suite (`app.listen`) crashes the batched
+// `addons` run (a Bun segfault accumulates across the many server suites in one
+// process); the repo's other server tests are likewise port-free.
+async function restAction(name: string, body: Record<string, unknown> = {}) {
+  const res = await app.handle(
+    new Request(`${REST_URL}/${name}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+async function gql(query: string) {
+  const res = await app.handle(
+    new Request(GQL_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    }),
+  );
+  return res.json() as Promise<{ data: Record<string, unknown>; errors?: unknown[] }>;
+}
+
+async function getApprovals(status = "pending") {
+  const res = await app.handle(
+    new Request(`${APPROVALS_URL}?status=${status}`, {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+  return res.json() as Promise<{
+    success: boolean;
+    data: { items: Array<{ id: string; level: string; status: string; action: string }> };
+  }>;
+}
+
+async function approveRequest(approvalId: string) {
+  const res = await app.handle(
+    new Request(`${APPROVALS_URL}/${approvalId}/approve`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ note: "approved by test" }),
+    }),
+  );
+  return res.json() as Promise<{ success: boolean; data?: unknown; error?: { message: string } }>;
+}
+
+// ── Tests: enrich effect ───────────────────────────────────────────────────
+
+describe("E2E rule effect: enrich", () => {
+  test("1. enrich rule sets autoCategory on the persisted record when category is absent", async () => {
+    // Create an order without a category — the enrich rule should fire on submit.
+    const createResult = await restAction("create_order", {
+      title: "Uncategorized Supplies",
+      amount: 500,
+      // no category — triggers the enrich rule
+    });
+    expect(createResult.status).toBe(200);
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    // Submit — enrich rule fires, setting autoCategory = "general" in effectiveInput.
+    const submitResult = await restAction("submit_order", { id: orderId });
+    expect(submitResult.status).toBe(200);
+    expect(submitResult.body.success).toBe(true);
+
+    // Read via GraphQL: autoCategory must be "general" on the persisted record.
+    const gqlResult = await gql(`
+      query { order(id: "${orderId}") { id status autoCategory } }
+    `);
+    expect(gqlResult.errors).toBeUndefined();
+    const order = gqlResult.data.order as Record<string, unknown>;
+    expect(order.status).toBe("submitted");
+    expect(order.autoCategory).toBe("general");
+  });
+
+  test("2. enrich rule does NOT fire when category is already set (condition miss)", async () => {
+    // Create an order WITH a category — the is_null condition should not match.
+    const createResult = await restAction("create_order", {
+      title: "Hardware Tools",
+      amount: 1200,
+      category: "hardware",
+    });
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    // Submit — enrich rule should not fire.
+    const submitResult = await restAction("submit_order", { id: orderId });
+    expect(submitResult.status).toBe(200);
+    expect(submitResult.body.success).toBe(true);
+
+    // autoCategory should remain null/undefined — the enrich was not applied.
+    const gqlResult = await gql(`
+      query { order(id: "${orderId}") { id status autoCategory } }
+    `);
+    expect(gqlResult.errors).toBeUndefined();
+    const order = gqlResult.data.order as Record<string, unknown>;
+    expect(order.status).toBe("submitted");
+    // autoCategory was never set by the enrich rule.
+    expect(order.autoCategory == null).toBe(true);
+  });
+});
+
+// ── Tests: require_approval effect ────────────────────────────────────────
+
+describe("E2E rule effect: require_approval", () => {
+  test("3. require_approval suspends the action and surfaces a pending request over HTTP", async () => {
+    // Create a large order (> 50,000) — the require_approval rule fires on submit.
+    const createResult = await restAction("create_order", {
+      title: "Enterprise License",
+      amount: 75000,
+      category: "software",
+    });
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    // Submit — should suspend, NOT write.
+    const submitResult = await restAction("submit_order", { id: orderId });
+
+    // The action REST endpoint returns 422 + success:false when the action is
+    // suspended into an approval request (the ApprovalPendingResult is not
+    // surfaced as a success body — the executor returns success:false).
+    expect(submitResult.status).toBe(422);
+    expect(submitResult.body.success).toBe(false);
+
+    // The status must NOT be "submitted" — the write was suspended, not committed.
+    // (The CRUD create action does not apply schema defaults, so status may be
+    // null rather than "draft"; what matters is that submit_order did NOT write.)
+    const gqlResult = await gql(`
+      query { order(id: "${orderId}") { id status } }
+    `);
+    expect(gqlResult.errors).toBeUndefined();
+    const order = gqlResult.data.order as Record<string, unknown>;
+    expect(order.status).not.toBe("submitted");
+
+    // A pending approval request must exist in the store, accessible via REST.
+    const approvalsList = await getApprovals("pending");
+    expect(approvalsList.success).toBe(true);
+    const items = approvalsList.data.items;
+    expect(items.length).toBeGreaterThanOrEqual(1);
+
+    const req = items.find((r) => r.action === "submit_order");
+    expect(req).toBeDefined();
+    expect(req?.level).toBe("director");
+    expect(req?.status).toBe("pending");
+  });
+
+  test("4. approving a pending request re-executes the action and completes the write", async () => {
+    // Create a large order.
+    const createResult = await restAction("create_order", {
+      title: "Data Center Lease",
+      amount: 100000,
+      category: "infrastructure",
+    });
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    // Submit — suspended into approval.
+    await restAction("submit_order", { id: orderId });
+
+    // Retrieve the pending approval ID.
+    const approvalsList = await getApprovals("pending");
+    const req = approvalsList.data.items.find((r) => r.action === "submit_order");
+    expect(req).toBeDefined();
+    const approvalId = req?.id;
+
+    // Approve the request — should re-execute submit_order and write status = "submitted".
+    const approveResult = await approveRequest(approvalId);
+    expect(approveResult.success).toBe(true);
+
+    // Verify the record is now "submitted".
+    const gqlResult = await gql(`
+      query { order(id: "${orderId}") { id status } }
+    `);
+    expect(gqlResult.errors).toBeUndefined();
+    const order = gqlResult.data.order as Record<string, unknown>;
+    expect(order.status).toBe("submitted");
+
+    // The approval request must transition to "approved".
+    const approvedList = await getApprovals("approved");
+    const approvedReq = approvedList.data.items.find((r) => r.id === approvalId);
+    expect(approvedReq?.status).toBe("approved");
+  });
+
+  test("5. small order does NOT trigger require_approval (condition miss)", async () => {
+    // Create an order below the 50,000 threshold.
+    const createResult = await restAction("create_order", {
+      title: "Office Chairs",
+      amount: 1500,
+      category: "furniture",
+    });
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    // Submit — no approval rule should fire (amount <= 50,000).
+    const submitResult = await restAction("submit_order", { id: orderId });
+    expect(submitResult.status).toBe(200);
+    expect(submitResult.body.success).toBe(true);
+
+    // No pending approvals should be created.
+    const approvalsList = await getApprovals("pending");
+    const orderApprovals = approvalsList.data.items.filter((r) => r.action === "submit_order");
+    expect(orderApprovals.length).toBe(0);
+
+    // The record should be submitted immediately.
+    const gqlResult = await gql(`
+      query { order(id: "${orderId}") { id status } }
+    `);
+    const order = gqlResult.data.order as Record<string, unknown>;
+    expect(order.status).toBe("submitted");
+  });
+});
+
+// ── Tests: execute_action effect ──────────────────────────────────────────
+
+describe("E2E rule effect: execute_action", () => {
+  test("6. execute_action rule creates an audit_log record as a post-commit side effect", async () => {
+    // Create an order.
+    const createResult = await restAction("create_order", {
+      title: "Server Rack",
+      amount: 8000,
+      category: "hardware",
+    });
+    expect(createResult.status).toBe(200);
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    // Submit — the execute_action rule fires post-commit, running create_audit_entry.
+    const submitResult = await restAction("submit_order", { id: orderId });
+    expect(submitResult.status).toBe(200);
+    expect(submitResult.body.success).toBe(true);
+
+    // The primary write must have happened.
+    const orderGql = await gql(`
+      query { order(id: "${orderId}") { id status } }
+    `);
+    expect((orderGql.data.order as Record<string, unknown>).status).toBe("submitted");
+
+    // The audit_log record created by the execute_action side effect must exist.
+    const auditGql = await gql(`
+      query { auditLogList { items { id sourceOrderId event } } }
+    `);
+    expect(auditGql.errors).toBeUndefined();
+    const auditItems = (auditGql.data.auditLogList as Record<string, unknown>).items as Array<
+      Record<string, unknown>
+    >;
+    expect(auditItems.length).toBeGreaterThanOrEqual(1);
+
+    const auditEntry = auditItems.find((a) => a.event === "order.submitted");
+    expect(auditEntry).toBeDefined();
+  });
+
+  test("7. execute_action fires AFTER the primary write (post-commit ordering)", async () => {
+    // Submit two distinct orders and verify both get individual audit entries.
+    const createA = await restAction("create_order", {
+      title: "Order A",
+      amount: 1000,
+      category: "test",
+    });
+    const createB = await restAction("create_order", {
+      title: "Order B",
+      amount: 2000,
+      category: "test",
+    });
+
+    const idA = (createA.body.data as Record<string, unknown>).id as string;
+    const idB = (createB.body.data as Record<string, unknown>).id as string;
+
+    await restAction("submit_order", { id: idA });
+    await restAction("submit_order", { id: idB });
+
+    // Each submit must have produced one audit entry (execute_action fired per submit).
+    const auditGql = await gql(`
+      query { auditLogList { items { id event } } }
+    `);
+    const auditItems = (auditGql.data.auditLogList as Record<string, unknown>).items as Array<
+      Record<string, unknown>
+    >;
+    // Two submits → two audit_log entries.
+    expect(auditItems.length).toBe(2);
+  });
+
+  test("8. primary action result is unaffected when execute_action side effect succeeds", async () => {
+    // The execute_action effect is post-commit best-effort; the primary response
+    // must not be altered by the side effect's outcome.
+    const createResult = await restAction("create_order", {
+      title: "Peripherals Bundle",
+      amount: 300,
+      category: "peripherals",
+    });
+    const orderId = (createResult.body.data as Record<string, unknown>).id as string;
+
+    const submitResult = await restAction("submit_order", { id: orderId });
+    expect(submitResult.status).toBe(200);
+    expect(submitResult.body.success).toBe(true);
+
+    // The primary data payload must reflect the updated order, not the audit log.
+    const data = submitResult.body.data as Record<string, unknown>;
+    expect(data).toBeDefined();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/smoke-action-roundtrip.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/smoke-action-roundtrip.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Action round-trip SMOKE test.
+ *
+ * Complements `dev-server-http-boot.test.ts` (which covers read-path HTTP wiring)
+ * by exercising the WRITE path: a full create → read round-trip through the
+ * CommandLayer → Action engine → InMemoryStore persistence pipeline.
+ *
+ * Guards the class of regression where everything compiles and reads work, but
+ * writing an entity through the full action pipeline is silently broken.
+ *
+ * Setup mirrors `dev-server-http-boot.test.ts` exactly:
+ *  - Same `createDevApp(capabilities, { cors: false })` bootstrap.
+ *  - Same synthetic business capability (smoke_project + smoke_milestone).
+ *  - Requests dispatched in-process via `app.handle(new Request(...))`.
+ *  - DB-free: no Postgres — InMemoryStore is the fallback when no dataProvider.
+ *  - Port-free: no `listen()`, no socket, no real network.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { capChatter } from "@linchkit/cap-chatter";
+import type {
+  ActionDefinition,
+  CapabilityDefinition,
+  EntityDefinition,
+  RelationDefinition,
+  StateDefinition,
+} from "@linchkit/core";
+import { defineCapability, defineRelation } from "@linchkit/core";
+import { capAdapterServer } from "../src/capability";
+import { createDevApp } from "../src/dev-app";
+
+// ── Synthetic business capability (inline, matches boot test) ──────────────
+//
+// Keeps the published package dependency-surface clean — no imports from
+// the private demo. Contributes two entities, one custom action, a relation,
+// and a state machine, identical to `dev-server-http-boot.test.ts`.
+
+const projectEntity: EntityDefinition = {
+  name: "smoke_project",
+  label: "Smoke Project",
+  description: "Synthetic project entity for the action round-trip smoke test",
+  presentation: {
+    titleField: "name",
+    badgeField: "status",
+    summaryFields: ["owner"],
+    icon: "folder",
+  },
+  fields: {
+    name: { type: "string", required: true, label: "Name", ui: { importance: "primary" } },
+    owner: { type: "string", label: "Owner", ui: { importance: "primary" } },
+    status: {
+      type: "state",
+      machine: "smoke_project_lifecycle",
+      default: "open",
+      ui: { importance: "primary", display: "badge" },
+    },
+  },
+};
+
+const milestoneEntity: EntityDefinition = {
+  name: "smoke_milestone",
+  label: "Smoke Milestone",
+  description: "Synthetic milestone entity — relation target of a project",
+  presentation: {
+    titleField: "title",
+    summaryFields: ["due_at"],
+    icon: "flag",
+  },
+  fields: {
+    title: { type: "string", required: true, label: "Title", ui: { importance: "primary" } },
+    due_at: { type: "datetime", label: "Due At", ui: { importance: "detail" } },
+  },
+};
+
+const archiveProjectAction: ActionDefinition = {
+  name: "archive_smoke_project",
+  entity: "smoke_project",
+  label: "Archive Project",
+  description: "Drives the project state machine to archived",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  stateTransition: { from: "open", to: "archived" },
+};
+
+const projectToMilestones: RelationDefinition = defineRelation({
+  name: "smoke_project_to_milestones",
+  from: "smoke_project",
+  to: "smoke_milestone",
+  cardinality: "one_to_many",
+  fromName: "milestones",
+  toName: "project",
+  cascade: "delete",
+  label: { from: "Milestones", to: "Project" },
+});
+
+const projectState: StateDefinition = {
+  name: "smoke_project_lifecycle",
+  entity: "smoke_project",
+  field: "status",
+  initial: "open",
+  states: ["open", "archived"],
+  transitions: [{ from: "open", to: "archived", action: "archive_smoke_project" }],
+  meta: {
+    open: { label: "Open", color: "green" },
+    archived: { label: "Archived", color: "gray" },
+  },
+};
+
+const capSmokeBusiness: CapabilityDefinition = defineCapability({
+  name: "cap-smoke-business",
+  label: "Smoke Business",
+  description:
+    "Synthetic business capability (inline) — contributes entities + action + relation + state",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [projectEntity, milestoneEntity],
+  actions: [archiveProjectAction],
+  states: [projectState],
+  relations: [projectToMilestones],
+});
+
+// ── App factory ────────────────────────────────────────────────────────────
+
+/** Build the in-process dev app (DB-free, port-free). One per test suite is fine. */
+function buildApp(): ReturnType<typeof createDevApp>["app"] {
+  return createDevApp([capAdapterServer, capChatter, capSmokeBusiness], { cors: false }).app;
+}
+
+// ── Request helpers ────────────────────────────────────────────────────────
+
+/** POST a GraphQL operation through `app.handle` (no port, no network). */
+async function postGraphQL(
+  app: ReturnType<typeof createDevApp>["app"],
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<Response> {
+  return app.handle(
+    new Request("http://local.test/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query, variables }),
+    }),
+  );
+}
+
+/** POST to a REST action endpoint through `app.handle`. */
+async function postAction(
+  app: ReturnType<typeof createDevApp>["app"],
+  name: string,
+  input: Record<string, unknown> = {},
+): Promise<Response> {
+  return app.handle(
+    new Request(`http://local.test/api/actions/${name}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    }),
+  );
+}
+
+// ── Type helpers (no `any`) ────────────────────────────────────────────────
+
+interface ActionResponseSuccess {
+  success: true;
+  data: Record<string, unknown>;
+  meta: { executionId: string };
+}
+
+interface ActionResponseError {
+  success: false;
+  error: { code: string; message: string };
+  meta?: { executionId?: string };
+}
+
+type ActionResponse = ActionResponseSuccess | ActionResponseError;
+
+interface GraphQLResponse<T = Record<string, unknown>> {
+  data: T;
+  errors?: Array<{ message: string }>;
+}
+
+interface RecordRow {
+  id: string;
+  name: string;
+  owner?: string | null;
+  status?: string | null;
+}
+
+interface ListResult {
+  items: RecordRow[];
+  total: number;
+  pageInfo: { limit: number; offset: number; hasMore: boolean };
+}
+
+// ── Smoke suite ────────────────────────────────────────────────────────────
+
+describe("action round-trip smoke (in-process, DB-free, port-free)", () => {
+  // ── Smoke 1: REST write path ─────────────────────────────────────────────
+  //
+  // POST /api/actions/create_smoke_project → assert 2xx + id + fields →
+  // GET /api/entities/smoke_project (metadata confirms entity is live) →
+  // GraphQL list query to prove the written record persists.
+  //
+  // Note: each `buildApp()` call creates a fresh in-memory store, so
+  // Smoke 1 and Smoke 2 are fully isolated even when run in one process.
+
+  it("Smoke 1 (REST): create via POST /api/actions/:name → record persists in list", async () => {
+    const app = buildApp();
+
+    // Step 1: create a smoke_project via the auto-generated CRUD action
+    const createRes = await postAction(app, "create_smoke_project", {
+      name: "Atlas",
+      owner: "alice",
+    });
+    expect(createRes.status).toBe(200);
+
+    const createBody = (await createRes.json()) as ActionResponse;
+    expect(createBody.success).toBe(true);
+
+    const created = (createBody as ActionResponseSuccess).data;
+    expect(typeof created.id).toBe("string");
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe("Atlas");
+    expect(created.owner).toBe("alice");
+
+    const createdId = created.id as string;
+
+    // Step 2: list via GraphQL — the newly created record must appear
+    const listRes = await postGraphQL(
+      app,
+      `{
+        smokeProjectList {
+          items { id name owner status }
+          total
+          pageInfo { limit offset hasMore }
+        }
+      }`,
+    );
+    expect(listRes.status).toBe(200);
+
+    const listBody = (await listRes.json()) as GraphQLResponse<{
+      smokeProjectList: ListResult;
+    }>;
+    expect(listBody.errors).toBeUndefined();
+
+    const list = listBody.data.smokeProjectList;
+    expect(list.total).toBe(1);
+    expect(list.items).toHaveLength(1);
+    expect(list.pageInfo.hasMore).toBe(false);
+
+    const row = list.items[0];
+    expect(row.id).toBe(createdId);
+    expect(row.name).toBe("Atlas");
+    expect(row.owner).toBe("alice");
+    // status field should default to the state machine's initial value
+    expect(row.status).toBeTruthy();
+  });
+
+  // ── Smoke 2: GraphQL write path ──────────────────────────────────────────
+  //
+  // GraphQL createSmokeProject mutation → assert success + id + fields →
+  // GraphQL single-entity query to prove the record round-trips correctly.
+
+  it("Smoke 2 (GraphQL): createSmokeProject mutation → record queryable by id", async () => {
+    const app = buildApp();
+
+    // Step 1: create via the auto-generated GraphQL CRUD mutation
+    const createRes = await postGraphQL(
+      app,
+      `mutation CreateProject($input: SmokeProjectInput!) {
+        createSmokeProject(input: $input) {
+          id name owner status _version created_at
+        }
+      }`,
+      { input: { name: "Orion", owner: "bob" } },
+    );
+    expect(createRes.status).toBe(200);
+
+    const createBody = (await createRes.json()) as GraphQLResponse<{
+      createSmokeProject: RecordRow & { _version: number; created_at: string };
+    }>;
+    expect(createBody.errors).toBeUndefined();
+
+    const created = createBody.data.createSmokeProject;
+    expect(typeof created.id).toBe("string");
+    expect(created.id).toBeTruthy();
+    expect(created.name).toBe("Orion");
+    expect(created.owner).toBe("bob");
+    // _version starts at 1 for a freshly created record
+    expect(created._version).toBe(1);
+    expect(created.created_at).toBeTruthy();
+
+    const createdId = created.id;
+
+    // Step 2: query the record back by id — proves persistence, not just
+    // return-value correctness
+    const getRes = await postGraphQL(
+      app,
+      `query GetProject($id: ID!) {
+        smokeProject(id: $id) {
+          id name owner status _version
+        }
+      }`,
+      { id: createdId },
+    );
+    expect(getRes.status).toBe(200);
+
+    const getBody = (await getRes.json()) as GraphQLResponse<{
+      smokeProject: (RecordRow & { _version: number }) | null;
+    }>;
+    expect(getBody.errors).toBeUndefined();
+
+    const fetched = getBody.data.smokeProject;
+    expect(fetched).not.toBeNull();
+    expect(fetched?.id).toBe(createdId);
+    expect(fetched?.name).toBe("Orion");
+    expect(fetched?.owner).toBe("bob");
+    expect(fetched?._version).toBe(1);
+  });
+
+  // ── Smoke 3: server boots with full autoInstall capability set ───────────
+  //
+  // The boot smoke test in `dev-server-http-boot.test.ts` already verifies
+  // this for the read path; this smoke asserts it is also true when the write
+  // path is assembled (executor + commandLayer present), providing a guard
+  // against the "server boots for reads but crashes on first write setup" case.
+
+  it("Smoke 3 (boot): app assembles with write pipeline without throwing", () => {
+    // If createDevApp throws, this test fails and the error surfaces clearly.
+    expect(() => buildApp()).not.toThrow();
+  });
+});

--- a/packages/core/__tests__/action-rule-effects.test.ts
+++ b/packages/core/__tests__/action-rule-effects.test.ts
@@ -1,0 +1,494 @@
+/**
+ * Unit tests for runPostCommitRuleEffects (packages/core/src/engine/action-rule-effects.ts).
+ *
+ * These tests exercise the post-commit best-effort side-effect runner directly,
+ * using minimal fakes so no database or full executor is needed.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { ActionFlowStarter, ExecuteOptions } from "../src/engine/action-engine-types";
+import { runPostCommitRuleEffects } from "../src/engine/action-rule-effects";
+import type { ActionResult, Actor } from "../src/types/action";
+import type { ExecutionMeta } from "../src/types/execution-meta";
+import { createExecutionMeta } from "../src/types/execution-meta";
+import type { Logger } from "../src/types/logger";
+import type { ExecuteActionEffect, TriggerFlowEffect } from "../src/types/rule";
+
+// ── Test fixtures ────────────────────────────────────────────
+
+const actor: Actor = { type: "human", id: "user-1", groups: ["staff"] };
+
+function makeResolvedMeta(): ExecutionMeta {
+  return createExecutionMeta({
+    systemKeys: { _channel: "http", _execution_id: "exec-root", _depth: 0 },
+  });
+}
+
+// ── Fake logger ──────────────────────────────────────────────
+
+interface LogCapture {
+  warns: string[];
+  errors: string[];
+}
+
+function makeLogger(cap: LogCapture): Logger {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: (msg) => cap.warns.push(msg),
+    error: (msg) => cap.errors.push(msg),
+  };
+}
+
+// ── Fake execute function ────────────────────────────────────
+
+interface ExecuteCall {
+  actionName: string;
+  input: Record<string, unknown>;
+  actor: Actor;
+  options: ExecuteOptions | undefined;
+}
+
+type FakeExecuteResult = { success: boolean; data?: unknown; executionId: string };
+
+/**
+ * Build a fake `execute` function that captures calls and either returns a
+ * provided result or throws when the action name appears in `throwOn`.
+ */
+function makeFakeExecute(
+  cap: ExecuteCall[],
+  opts: {
+    result?: FakeExecuteResult;
+    throwOn?: string[];
+  } = {},
+): (
+  actionName: string,
+  input: Record<string, unknown>,
+  actor: Actor,
+  options?: ExecuteOptions,
+) => Promise<ActionResult> {
+  return async (actionName, input, callerActor, options) => {
+    if (opts.throwOn?.includes(actionName)) {
+      throw new Error(`simulated failure in ${actionName}`);
+    }
+    cap.push({ actionName, input, actor: callerActor, options });
+    return opts.result ?? { success: true, executionId: "child-exec-1" };
+  };
+}
+
+// ── Fake flow starter ────────────────────────────────────────
+
+interface FlowCall {
+  flowName: string;
+  input: Record<string, unknown>;
+  tenantId: string | undefined;
+  actor: Actor | undefined;
+}
+
+function makeFakeFlowStarter(
+  cap: FlowCall[],
+  opts: { throwOn?: string[] } = {},
+): ActionFlowStarter {
+  return {
+    startFlow: async (flowName, input, options) => {
+      if (opts.throwOn?.includes(flowName)) {
+        throw new Error(`simulated flow failure for ${flowName}`);
+      }
+      cap.push({
+        flowName,
+        input,
+        tenantId: options?.tenantId,
+        actor: options?.actor,
+      });
+      return { id: "flow-1" };
+    },
+  };
+}
+
+// ── Helper: build minimal args ───────────────────────────────
+
+function baseArgs(overrides: Partial<Parameters<typeof runPostCommitRuleEffects>[0]> = {}) {
+  return {
+    pendingActions: [] as ExecuteActionEffect[],
+    pendingFlows: [] as TriggerFlowEffect[],
+    execute: makeFakeExecute([]),
+    flowEngine: undefined as ActionFlowStarter | undefined,
+    logger: makeLogger({ warns: [], errors: [] }),
+    actionName: "submit_order",
+    actor,
+    effectiveInput: { orderId: "o-1", amount: 100 },
+    resolvedMeta: makeResolvedMeta(),
+    currentDepth: 0,
+    tenantId: "tenant-abc",
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("runPostCommitRuleEffects", () => {
+  describe("execute_action effects", () => {
+    it("invokes the executor once for a single execute_action effect", async () => {
+      const calls: ExecuteCall[] = [];
+      const effect: ExecuteActionEffect = {
+        type: "execute_action",
+        action: "notify_user",
+        params: { userId: "u-99", channel: "email" },
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [effect],
+          execute: makeFakeExecute(calls),
+        }),
+      );
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].actionName).toBe("notify_user");
+      expect(calls[0].input).toEqual({ userId: "u-99", channel: "email" });
+    });
+
+    it("defaults params to effectiveInput when the effect omits params", async () => {
+      const calls: ExecuteCall[] = [];
+      const effectiveInput = { orderId: "o-1", amount: 200 };
+      const effect: ExecuteActionEffect = {
+        type: "execute_action",
+        action: "archive_order",
+        // params deliberately omitted
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [effect],
+          execute: makeFakeExecute(calls),
+          effectiveInput,
+        }),
+      );
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].input).toEqual(effectiveInput);
+    });
+
+    it("forwards the actor unchanged to child executions", async () => {
+      const calls: ExecuteCall[] = [];
+      const childActor: Actor = { type: "service", id: "svc-42", groups: [] };
+      const effect: ExecuteActionEffect = {
+        type: "execute_action",
+        action: "log_event",
+        params: { event: "created" },
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [effect],
+          execute: makeFakeExecute(calls),
+          actor: childActor,
+        }),
+      );
+
+      expect(calls[0].actor).toEqual(childActor);
+    });
+
+    it("forwards tenantId to child executions", async () => {
+      const calls: ExecuteCall[] = [];
+      const effect: ExecuteActionEffect = {
+        type: "execute_action",
+        action: "send_receipt",
+        params: {},
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [effect],
+          execute: makeFakeExecute(calls),
+          tenantId: "tenant-xyz",
+        }),
+      );
+
+      expect(calls[0].options?.tenantId).toBe("tenant-xyz");
+    });
+
+    it("forwards incremented depth to child executions via options._depth", async () => {
+      const calls: ExecuteCall[] = [];
+      const effect: ExecuteActionEffect = {
+        type: "execute_action",
+        action: "cascade_action",
+        params: { foo: "bar" },
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [effect],
+          execute: makeFakeExecute(calls),
+          currentDepth: 2,
+        }),
+      );
+
+      // Child should receive depth = currentDepth + 1 = 3
+      expect(calls[0].options?._depth).toBe(3);
+    });
+
+    it("stamps _depth and _source_action in the child meta", async () => {
+      const calls: ExecuteCall[] = [];
+      const effect: ExecuteActionEffect = {
+        type: "execute_action",
+        action: "side_effect_action",
+        params: {},
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [effect],
+          execute: makeFakeExecute(calls),
+          actionName: "submit_order",
+          currentDepth: 1,
+        }),
+      );
+
+      const childMeta = calls[0].options?.meta as ExecutionMeta | undefined;
+      expect(childMeta).toBeDefined();
+      // The child meta must carry the incremented depth and source action.
+      // extendExecutionMeta stamps them as system overrides, so they appear in toJSON().
+      const json = (childMeta as ExecutionMeta).toJSON();
+      expect(json._depth).toBe(2);
+      expect(json._source_action).toBe("submit_order");
+    });
+  });
+
+  describe("trigger_flow effects", () => {
+    it("invokes the flow starter once for a single trigger_flow effect", async () => {
+      const flowCalls: FlowCall[] = [];
+      const effect: TriggerFlowEffect = {
+        type: "trigger_flow",
+        flow: "onboarding_flow",
+        input: { userId: "u-1" },
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingFlows: [effect],
+          flowEngine: makeFakeFlowStarter(flowCalls),
+        }),
+      );
+
+      expect(flowCalls).toHaveLength(1);
+      expect(flowCalls[0].flowName).toBe("onboarding_flow");
+      expect(flowCalls[0].input).toEqual({ userId: "u-1" });
+    });
+
+    it("defaults flow input to effectiveInput when the effect omits input", async () => {
+      const flowCalls: FlowCall[] = [];
+      const effectiveInput = { orderId: "o-2", region: "eu" };
+      const effect: TriggerFlowEffect = {
+        type: "trigger_flow",
+        flow: "fulfillment_flow",
+        // input deliberately omitted
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingFlows: [effect],
+          flowEngine: makeFakeFlowStarter(flowCalls),
+          effectiveInput,
+        }),
+      );
+
+      expect(flowCalls[0].input).toEqual(effectiveInput);
+    });
+
+    it("forwards tenantId and actor to the flow starter", async () => {
+      const flowCalls: FlowCall[] = [];
+      const flowActor: Actor = { type: "human", id: "u-9", groups: ["admin"] };
+      const effect: TriggerFlowEffect = {
+        type: "trigger_flow",
+        flow: "approval_flow",
+        input: {},
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingFlows: [effect],
+          flowEngine: makeFakeFlowStarter(flowCalls),
+          tenantId: "tenant-T1",
+          actor: flowActor,
+        }),
+      );
+
+      expect(flowCalls[0].tenantId).toBe("tenant-T1");
+      expect(flowCalls[0].actor).toEqual(flowActor);
+    });
+
+    it("logs a warning and skips when flowEngine is undefined", async () => {
+      const warns: string[] = [];
+      const effect: TriggerFlowEffect = {
+        type: "trigger_flow",
+        flow: "missing_engine_flow",
+        input: {},
+      };
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingFlows: [effect],
+          flowEngine: undefined,
+          logger: makeLogger({ warns, errors: [] }),
+          actionName: "submit_order",
+        }),
+      );
+
+      // The function should NOT throw and should emit exactly one warning.
+      expect(warns).toHaveLength(1);
+      expect(warns[0]).toContain("missing_engine_flow");
+      expect(warns[0]).toContain("submit_order");
+    });
+  });
+
+  describe("multiple effects — ordering", () => {
+    it("runs all execute_action effects in order", async () => {
+      const calls: ExecuteCall[] = [];
+      const effects: ExecuteActionEffect[] = [
+        { type: "execute_action", action: "alpha", params: { step: 1 } },
+        { type: "execute_action", action: "beta", params: { step: 2 } },
+        { type: "execute_action", action: "gamma", params: { step: 3 } },
+      ];
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: effects,
+          execute: makeFakeExecute(calls),
+        }),
+      );
+
+      expect(calls).toHaveLength(3);
+      expect(calls.map((c) => c.actionName)).toEqual(["alpha", "beta", "gamma"]);
+    });
+
+    it("runs all trigger_flow effects in order", async () => {
+      const flowCalls: FlowCall[] = [];
+      const effects: TriggerFlowEffect[] = [
+        { type: "trigger_flow", flow: "flow_a", input: { n: 1 } },
+        { type: "trigger_flow", flow: "flow_b", input: { n: 2 } },
+      ];
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingFlows: effects,
+          flowEngine: makeFakeFlowStarter(flowCalls),
+        }),
+      );
+
+      expect(flowCalls).toHaveLength(2);
+      expect(flowCalls.map((f) => f.flowName)).toEqual(["flow_a", "flow_b"]);
+    });
+  });
+
+  describe("best-effort error isolation", () => {
+    it("does not propagate a thrown error from execute_action and still runs subsequent effects", async () => {
+      const calls: ExecuteCall[] = [];
+      const warns: string[] = [];
+      // "failing_action" throws; "succeeding_action" must still run.
+      const effects: ExecuteActionEffect[] = [
+        { type: "execute_action", action: "failing_action", params: {} },
+        { type: "execute_action", action: "succeeding_action", params: { after: "fail" } },
+      ];
+
+      await expect(
+        runPostCommitRuleEffects(
+          baseArgs({
+            pendingActions: effects,
+            execute: makeFakeExecute(calls, { throwOn: ["failing_action"] }),
+            logger: makeLogger({ warns, errors: [] }),
+          }),
+        ),
+      ).resolves.toBeUndefined(); // must not throw
+
+      // The second effect must have run.
+      expect(calls.map((c) => c.actionName)).toEqual(["succeeding_action"]);
+      // A warning must have been emitted for the failing effect.
+      expect(warns.some((w) => w.includes("failing_action"))).toBe(true);
+    });
+
+    it("does not propagate a failure result from execute_action and still runs subsequent effects", async () => {
+      const calls: ExecuteCall[] = [];
+      const warns: string[] = [];
+      // First action returns { success: false }, second should still run.
+      const failResult: ActionResult = {
+        success: false,
+        data: { error: "constraint_violation" },
+        executionId: "child-fail-1",
+      };
+      let callCount = 0;
+      const execute = async (
+        actionName: string,
+        input: Record<string, unknown>,
+        callerActor: Actor,
+        options?: ExecuteOptions,
+      ): Promise<ActionResult> => {
+        callCount++;
+        calls.push({ actionName, input, actor: callerActor, options });
+        if (callCount === 1) return failResult;
+        return { success: true, executionId: "child-ok-2" };
+      };
+
+      const effects: ExecuteActionEffect[] = [
+        { type: "execute_action", action: "check_stock", params: {} },
+        { type: "execute_action", action: "reserve_stock", params: {} },
+      ];
+
+      await expect(
+        runPostCommitRuleEffects(
+          baseArgs({
+            pendingActions: effects,
+            execute,
+            logger: makeLogger({ warns, errors: [] }),
+          }),
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(calls).toHaveLength(2);
+      // A warning should have been emitted for the unsuccessful first call.
+      expect(warns.some((w) => w.includes("check_stock"))).toBe(true);
+    });
+
+    it("does not propagate a thrown error from trigger_flow and still runs subsequent flow effects", async () => {
+      const flowCalls: FlowCall[] = [];
+      const warns: string[] = [];
+      const effects: TriggerFlowEffect[] = [
+        { type: "trigger_flow", flow: "exploding_flow", input: {} },
+        { type: "trigger_flow", flow: "safe_flow", input: { ok: true } },
+      ];
+
+      await expect(
+        runPostCommitRuleEffects(
+          baseArgs({
+            pendingFlows: effects,
+            flowEngine: makeFakeFlowStarter(flowCalls, { throwOn: ["exploding_flow"] }),
+            logger: makeLogger({ warns, errors: [] }),
+          }),
+        ),
+      ).resolves.toBeUndefined();
+
+      // "safe_flow" must have run despite "exploding_flow" throwing.
+      expect(flowCalls.map((f) => f.flowName)).toEqual(["safe_flow"]);
+      expect(warns.some((w) => w.includes("exploding_flow"))).toBe(true);
+    });
+  });
+
+  describe("empty effect lists", () => {
+    it("is a no-op when both pendingActions and pendingFlows are empty", async () => {
+      const calls: ExecuteCall[] = [];
+      const flowCalls: FlowCall[] = [];
+
+      await runPostCommitRuleEffects(
+        baseArgs({
+          pendingActions: [],
+          pendingFlows: [],
+          execute: makeFakeExecute(calls),
+          flowEngine: makeFakeFlowStarter(flowCalls),
+        }),
+      );
+
+      expect(calls).toHaveLength(0);
+      expect(flowCalls).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## What
Three independent **test-coverage** additions (no production code change), filling
real gaps around the rule-engine wiring (#460–#472):

| Type | File | Gap closed |
|------|------|-----------|
| **Unit** | `packages/core/__tests__/action-rule-effects.test.ts` | `runPostCommitRuleEffects` (#468) had only indirect coverage |
| **E2E** | `addons/.../e2e-rules-advanced.test.ts` | the existing `e2e-rules` covers only `block`/`warn` |
| **Smoke** | `addons/.../smoke-action-roundtrip.test.ts` | the boot test is read-only; no write round-trip |

## Details
- **Unit (16 tests):** `runPostCommitRuleEffects` directly — `execute_action` /
  `trigger_flow` dispatch, param/input defaulting to `effectiveInput`, actor +
  tenant + incremented `_depth` + `_source_action` propagation, best-effort error
  isolation (a thrown/failed effect is logged and the rest still run), empty-list
  no-op.
- **E2E (8 tests, DB-free):** full-stack rule effects beyond block/warn over the
  in-process server (`app.handle`): `enrich` (persisted field), `require_approval`
  (suspend over HTTP → `GET /api/approvals` → `POST /approve` → re-execute
  completes), `execute_action` (post-commit audit cascade).
- **Smoke (3 tests, DB-free):** cold-boot **write** round-trip via `createDevApp`
  — REST `POST /api/actions/:name` → list, GraphQL action mutation → query, and
  the full write pipeline assembles without throwing.

## Notes
- All three are **DB-free** and **port-free** (`app.handle`, never `app.listen`).
  A bound socket per suite segfaults the batched `addons` run — caught by
  `bun run test` (the canonical batched runner) where it crashed mid-run, then
  fixed by switching the e2e to `app.handle`. (Isolated `bun test` masked it.)
- The e2e wires `createActionExecutor({ rules })` + `createServer` directly to drive
  the real HTTP→CommandLayer→executor→rules→effect path; capability→rules
  aggregation via `createDevApp` is covered by the smoke test (boot) and #460's
  integration tests.

## Quality gates
`bun run check` ✓ · `bun run typecheck` ✓ · `bun run test` (full batched suite, incl. addons) ✓

Cross-model review: tests-only change — no production code touched (per maintainer direction, codex review reserved for the production PR #474).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
