### PR TITLE
fix(adapter-server): wire in-process flow engine so trigger_flow rules fire (#476)

### DIFF
--- a/.changeset/in-process-trigger-flow.md
+++ b/.changeset/in-process-trigger-flow.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cap-adapter-server": minor
+---
+
+Wire an in-process `SyncFlowEngine` into the `createDevApp` / `createRuntimeContext` boot path so a `trigger_flow` rule effect actually starts its flow. Previously this DB-free, in-process path never aggregated capability flows nor built a flow engine, so the effect silently logged + skipped. `createRuntimeContext` now accepts `flows` and builds a default sync engine from them; `assembleDevSchema` / `extractCapabilities` aggregate `cap.flows`. An externally injected `flowEngine` (e.g. the durable Restate engine wired by `linch dev`) still takes precedence and is unaffected. (#476)

--- a/.changeset/in-process-trigger-flow.md
+++ b/.changeset/in-process-trigger-flow.md
@@ -1,5 +1,8 @@
 ---
 "@linchkit/cap-adapter-server": minor
+"@linchkit/cli": patch
 ---
 
-Wire an in-process `SyncFlowEngine` into the `createDevApp` / `createRuntimeContext` boot path so a `trigger_flow` rule effect actually starts its flow. Previously this DB-free, in-process path never aggregated capability flows nor built a flow engine, so the effect silently logged + skipped. `createRuntimeContext` now accepts `flows` and builds a default sync engine from them; `assembleDevSchema` / `extractCapabilities` aggregate `cap.flows`. An externally injected `flowEngine` (e.g. the durable Restate engine wired by `linch dev`) still takes precedence and is unaffected. (#476)
+Wire an in-process `SyncFlowEngine` into the `createDevApp` / `createRuntimeContext` boot path so a `trigger_flow` rule effect actually starts its flow. Previously this DB-free, in-process path never aggregated capability flows nor built a flow engine, so the effect silently logged + skipped. `createRuntimeContext` now accepts `flows` and builds a default sync engine from them; `assembleDevSchema` / `extractCapabilities` aggregate `cap.flows`. An externally injected `flowEngine` (e.g. the durable Restate engine wired by `linch dev`) still takes precedence and is unaffected.
+
+Also forward the Saga compensation idempotency key (Spec 26 §3.2) from the flow step context into `executor.execute` in both flow-engine wiring sites (`createRuntimeContext` and `dev-wiring.ts`), so a retried compensating action started through the sync flow engine is not executed twice. (#476)

--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-schema-boot.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-schema-boot.test.ts
@@ -50,6 +50,7 @@ import type {
   ActionDefinition,
   CapabilityDefinition,
   EntityDefinition,
+  FlowDefinition,
   RelationDefinition,
   StateDefinition,
 } from "@linchkit/core";
@@ -284,5 +285,38 @@ describe("capability contribution merging", () => {
     const contributions = extractCapabilities([a, b]);
     expect(contributions.extraQueryFields.fieldA).toBeDefined();
     expect(contributions.extraQueryFields.fieldB).toBeDefined();
+  });
+
+  // Build a minimal capability contributing a single flow, so two of them can
+  // collide on the same flow name.
+  function capWithFlow(name: string, flowName: string): CapabilityDefinition {
+    const flow: FlowDefinition = {
+      name: flowName,
+      label: flowName,
+      trigger: { type: "manual" },
+      steps: [{ id: "s1", name: "Step", type: "action", actionName: "noop" }],
+    };
+    return defineCapability({
+      name,
+      label: name,
+      description: `Synthetic capability contributing flow "${flowName}"`,
+      type: "standard",
+      category: "business",
+      version: "0.1.0",
+      flows: [flow],
+    });
+  }
+
+  it("throws (does not silently overwrite) on a duplicate flow name", () => {
+    const a = capWithFlow("cap-flow-a", "duplicatedFlow");
+    const b = capWithFlow("cap-flow-b", "duplicatedFlow");
+    expect(() => extractCapabilities([a, b])).toThrow(/Duplicate flow "duplicatedFlow"/);
+  });
+
+  it("aggregates distinct flows from different capabilities", () => {
+    const a = capWithFlow("cap-flow-distinct-a", "flowA");
+    const b = capWithFlow("cap-flow-distinct-b", "flowB");
+    const contributions = extractCapabilities([a, b]);
+    expect(contributions.flows.map((f) => f.name).sort()).toEqual(["flowA", "flowB"]);
   });
 });

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-trigger-flow.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-trigger-flow.test.ts
@@ -1,0 +1,248 @@
+/**
+ * E2E Test: `trigger_flow` rule effect on the in-process boot path (#476).
+ *
+ * Proves that a `trigger_flow` rule effect actually STARTS its flow when the app
+ * is assembled via `createDevApp` — the DB-free, in-process boot path that
+ * `assembleDevSchema` → `createRuntimeContext` backs. Before #476 this path never
+ * built a flow engine nor aggregated capability flows, so a `trigger_flow` effect
+ * silently logged + skipped (`flowEngine` was undefined). The fix makes the path
+ * build a default in-process `SyncFlowEngine` from the capabilities' flows so the
+ * effect runs (Spec 23 §1.1 / Spec 26 §2.2). The `linch dev` boot path still
+ * injects its durable engine via `flowEngine`, which always wins — unaffected.
+ *
+ * Setup mirrors the other adapter-server e2e suites:
+ *  - In-process, port-free: requests are dispatched via `app.handle(new Request(...))`.
+ *    NEVER `app.listen(PORT)` — a bound socket per suite SEGFAULTS the batched runner.
+ *  - DB-free: no Postgres — InMemoryStore is the fallback when no dataProvider.
+ *
+ * Design:
+ *  - Entity `order` — the triggering record.
+ *  - Entity `fulfilment` — an observable marker written ONLY by the flow's step.
+ *  - Action `record_fulfilment` — the flow's step action; creates a `fulfilment`
+ *    row. Tolerant of whatever input it receives.
+ *  - Flow `order_fulfilment` — one action step that runs `record_fulfilment`.
+ *  - Rule `fulfil_on_submit` — on `submit_order`, `trigger_flow` → `order_fulfilment`.
+ *
+ * The post-commit rule-effects runner is awaited and the SyncFlowEngine runs
+ * synchronously, so the flow completes before the submit response returns. We
+ * then query `fulfilment` and assert a row exists — proving the flow ran.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  ActionDefinition,
+  CapabilityDefinition,
+  EntityDefinition,
+  FlowDefinition,
+  RuleDefinition,
+} from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { capAdapterServer } from "../src/capability";
+import { createDevApp } from "../src/dev-app";
+
+// ── Entities ────────────────────────────────────────────────────────────────
+
+const orderEntity: EntityDefinition = {
+  name: "order",
+  label: "Order",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+    status: { type: "string", default: "draft", label: "Status" },
+  },
+};
+
+// Observable marker written ONLY by the flow's step action. A row here proves
+// the `trigger_flow` rule effect started the flow and its step executed.
+const fulfilmentEntity: EntityDefinition = {
+  name: "fulfilment",
+  label: "Fulfilment",
+  fields: {
+    sourceOrderId: { type: "string", label: "Source Order ID" },
+    note: { type: "string", label: "Note" },
+  },
+};
+
+// ── Action: the flow's step ─────────────────────────────────────────────────
+
+/**
+ * record_fulfilment: the flow's single step. Creates a `fulfilment` row — the
+ * observable side effect. Tolerant of whatever input the flow passes; it derives
+ * `sourceOrderId` from the flow input (`$input.id`, mapped in the flow step) but
+ * falls back gracefully so the flow demonstrably runs regardless of mapping.
+ */
+const recordFulfilmentAction: ActionDefinition = {
+  name: "record_fulfilment",
+  entity: "fulfilment",
+  label: "Record Fulfilment",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    const sourceOrderId = (ctx.input.sourceOrderId as string | undefined) ?? "unknown";
+    return ctx.create("fulfilment", { sourceOrderId, note: "fulfilled-by-flow" });
+  },
+};
+
+// ── Action: the triggering action ───────────────────────────────────────────
+
+/**
+ * submit_order: writes status = "submitted". The `fulfil_on_submit` rule fires a
+ * `trigger_flow` effect post-commit, starting `order_fulfilment`.
+ */
+const submitOrderAction: ActionDefinition = {
+  name: "submit_order",
+  entity: "order",
+  label: "Submit Order",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    const id = ctx.input.id as string;
+    return ctx.update("order", id, { status: "submitted" });
+  },
+};
+
+// ── Flow ────────────────────────────────────────────────────────────────────
+
+/**
+ * order_fulfilment: a single action step. The rule path calls `startFlow`
+ * directly with the triggering action's effective input (`{ id: <orderId> }`),
+ * so `$input.id` resolves to the submitted order's id — proving flow input flows
+ * through to the step action.
+ */
+const orderFulfilmentFlow: FlowDefinition = {
+  name: "order_fulfilment",
+  label: "Order Fulfilment",
+  trigger: { type: "manual" },
+  steps: [
+    {
+      id: "fulfil",
+      name: "Record Fulfilment",
+      type: "action",
+      actionName: "record_fulfilment",
+      input: { sourceOrderId: "$input.id" },
+    },
+  ],
+};
+
+// ── Rule ────────────────────────────────────────────────────────────────────
+
+/**
+ * fulfil_on_submit: on every submit_order, start the order_fulfilment flow as a
+ * post-commit side effect. No condition narrowing — fires for every submission.
+ */
+const fulfilOnSubmitRule: RuleDefinition = {
+  name: "fulfil_on_submit",
+  label: "Fulfil on Submit",
+  description: "Start the order_fulfilment flow after an order is submitted",
+  trigger: { action: "submit_order" },
+  effect: { type: "trigger_flow", flow: "order_fulfilment" },
+};
+
+// ── Business capability ─────────────────────────────────────────────────────
+
+const capTriggerFlowBiz: CapabilityDefinition = defineCapability({
+  name: "cap-trigger-flow-biz",
+  label: "Trigger Flow Business",
+  description: "Synthetic business capability: an order whose submit triggers a fulfilment flow",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [orderEntity, fulfilmentEntity],
+  actions: [submitOrderAction, recordFulfilmentAction],
+  rules: [fulfilOnSubmitRule],
+  flows: [orderFulfilmentFlow],
+});
+
+// ── Request helpers (in-process, port-free) ─────────────────────────────────
+
+const BASE_URL = "http://local.test";
+
+async function postAction(
+  app: ReturnType<typeof createDevApp>["app"],
+  name: string,
+  input: Record<string, unknown> = {},
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await app.handle(
+    new Request(`${BASE_URL}/api/actions/${name}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+async function gql(
+  app: ReturnType<typeof createDevApp>["app"],
+  query: string,
+): Promise<{ data: Record<string, unknown>; errors?: Array<{ message: string }> }> {
+  const res = await app.handle(
+    new Request(`${BASE_URL}/graphql`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query }),
+    }),
+  );
+  return res.json() as Promise<{
+    data: Record<string, unknown>;
+    errors?: Array<{ message: string }>;
+  }>;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("E2E rule effect: trigger_flow (in-process, DB-free, port-free)", () => {
+  test("1. submit_order triggers order_fulfilment flow → a fulfilment row is written", async () => {
+    const { app } = createDevApp([capAdapterServer, capTriggerFlowBiz], { cors: false });
+
+    // Create an order via the auto-generated CRUD action.
+    const created = await postAction(app, "create_order", { title: "Widget Order" });
+    expect(created.status).toBe(200);
+    expect(created.body.success).toBe(true);
+    const orderId = (created.body.data as Record<string, unknown>).id as string;
+    expect(orderId).toBeTruthy();
+
+    // Sanity: no fulfilment exists before the flow runs.
+    const before = await gql(app, `query { fulfilmentList { items { id } } }`);
+    expect(before.errors).toBeUndefined();
+    const beforeItems = (before.data.fulfilmentList as Record<string, unknown>).items as unknown[];
+    expect(beforeItems).toHaveLength(0);
+
+    // Submit — the fulfil_on_submit rule fires a trigger_flow effect post-commit.
+    // The SyncFlowEngine runs synchronously, so the flow completes before this
+    // response returns.
+    const submit = await postAction(app, "submit_order", { id: orderId });
+    expect(submit.status).toBe(200);
+    expect(submit.body.success).toBe(true);
+
+    // The primary write happened.
+    const orderGql = await gql(app, `query { order(id: "${orderId}") { id status } }`);
+    expect(orderGql.errors).toBeUndefined();
+    expect((orderGql.data.order as Record<string, unknown>).status).toBe("submitted");
+
+    // The flow ran: its step action created a fulfilment row.
+    const after = await gql(app, `query { fulfilmentList { items { id sourceOrderId note } } }`);
+    expect(after.errors).toBeUndefined();
+    const items = (after.data.fulfilmentList as Record<string, unknown>).items as Array<
+      Record<string, unknown>
+    >;
+    expect(items).toHaveLength(1);
+    expect(items[0].note).toBe("fulfilled-by-flow");
+    // The flow input ($input.id) flowed through to the step action.
+    expect(items[0].sourceOrderId).toBe(orderId);
+  });
+
+  test("2. a submit with no triggering flow does NOT write a fulfilment row", async () => {
+    // Fresh app = fresh in-memory store, fully isolated from test 1.
+    const { app } = createDevApp([capAdapterServer, capTriggerFlowBiz], { cors: false });
+
+    // Create an order but never submit it — the rule (and thus the flow) never fires.
+    const created = await postAction(app, "create_order", { title: "Unsubmitted Order" });
+    expect(created.status).toBe(200);
+
+    const res = await gql(app, `query { fulfilmentList { items { id } } }`);
+    expect(res.errors).toBeUndefined();
+    const items = (res.data.fulfilmentList as Record<string, unknown>).items as unknown[];
+    // No submit → no trigger_flow → no fulfilment row.
+    expect(items).toHaveLength(0);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-trigger-flow.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-trigger-flow.test.ts
@@ -62,18 +62,6 @@ const fulfilmentEntity: EntityDefinition = {
   },
 };
 
-// Observable marker written by the DOWNSTREAM flow reached via an `onComplete`
-// chain. A row here proves the in-process engine resolved the chain — which only
-// works when `createRuntimeContext` builds + passes a FlowRegistry to the sync
-// engine (the hardening this suite guards). Without it, the chain silently no-ops.
-const notificationEntity: EntityDefinition = {
-  name: "notification",
-  label: "Notification",
-  fields: {
-    message: { type: "string", label: "Message" },
-  },
-};
-
 // ── Action: the flow's step ─────────────────────────────────────────────────
 
 /**
@@ -91,22 +79,6 @@ const recordFulfilmentAction: ActionDefinition = {
   handler: async (ctx) => {
     const sourceOrderId = (ctx.input.sourceOrderId as string | undefined) ?? "unknown";
     return ctx.create("fulfilment", { sourceOrderId, note: "fulfilled-by-flow" });
-  },
-};
-
-/**
- * notify_fulfilment: the downstream flow's step, reached via the
- * `order_fulfilment` flow's `onComplete` chain. Writes a `notification` row —
- * proving the in-process engine resolved the chain.
- */
-const notifyFulfilmentAction: ActionDefinition = {
-  name: "notify_fulfilment",
-  entity: "notification",
-  label: "Notify Fulfilment",
-  policy: { mode: "sync", transaction: false },
-  exposure: "all",
-  handler: async (ctx) => {
-    return ctx.create("notification", { message: "fulfilment-completed" });
   },
 };
 
@@ -149,27 +121,6 @@ const orderFulfilmentFlow: FlowDefinition = {
       input: { sourceOrderId: "$input.id" },
     },
   ],
-  // On completion, chain to the downstream flow. This resolves ONLY when the
-  // sync engine was built with a FlowRegistry (the codex-flagged hardening).
-  onComplete: { flow: "post_fulfilment" },
-};
-
-/**
- * post_fulfilment: the downstream flow reached via `order_fulfilment.onComplete`.
- * One action step writing a `notification` row.
- */
-const postFulfilmentFlow: FlowDefinition = {
-  name: "post_fulfilment",
-  label: "Post Fulfilment",
-  trigger: { type: "manual" },
-  steps: [
-    {
-      id: "notify",
-      name: "Notify Fulfilment",
-      type: "action",
-      actionName: "notify_fulfilment",
-    },
-  ],
 };
 
 // ── Rule ────────────────────────────────────────────────────────────────────
@@ -195,10 +146,10 @@ const capTriggerFlowBiz: CapabilityDefinition = defineCapability({
   type: "standard",
   category: "business",
   version: "0.1.0",
-  entities: [orderEntity, fulfilmentEntity, notificationEntity],
-  actions: [submitOrderAction, recordFulfilmentAction, notifyFulfilmentAction],
+  entities: [orderEntity, fulfilmentEntity],
+  actions: [submitOrderAction, recordFulfilmentAction],
   rules: [fulfilOnSubmitRule],
-  flows: [orderFulfilmentFlow, postFulfilmentFlow],
+  flows: [orderFulfilmentFlow],
 });
 
 // ── Request helpers (in-process, port-free) ─────────────────────────────────
@@ -278,16 +229,6 @@ describe("E2E rule effect: trigger_flow (in-process, DB-free, port-free)", () =>
     expect(items[0].note).toBe("fulfilled-by-flow");
     // The flow input ($input.id) flowed through to the step action.
     expect(items[0].sourceOrderId).toBe(orderId);
-
-    // The onComplete chain reached the downstream flow: a notification row exists.
-    // This only happens because createRuntimeContext built + passed a FlowRegistry
-    // to the sync engine — without it, the chain silently no-ops.
-    const notified = await gql(app, `query { notificationList { items { id message } } }`);
-    expect(notified.errors).toBeUndefined();
-    const notifications = (notified.data.notificationList as Record<string, unknown>)
-      .items as Array<Record<string, unknown>>;
-    expect(notifications).toHaveLength(1);
-    expect(notifications[0].message).toBe("fulfilment-completed");
   });
 
   test("2. a submit with no triggering flow does NOT write a fulfilment row", async () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-trigger-flow.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-rules-trigger-flow.test.ts
@@ -62,6 +62,18 @@ const fulfilmentEntity: EntityDefinition = {
   },
 };
 
+// Observable marker written by the DOWNSTREAM flow reached via an `onComplete`
+// chain. A row here proves the in-process engine resolved the chain — which only
+// works when `createRuntimeContext` builds + passes a FlowRegistry to the sync
+// engine (the hardening this suite guards). Without it, the chain silently no-ops.
+const notificationEntity: EntityDefinition = {
+  name: "notification",
+  label: "Notification",
+  fields: {
+    message: { type: "string", label: "Message" },
+  },
+};
+
 // ── Action: the flow's step ─────────────────────────────────────────────────
 
 /**
@@ -79,6 +91,22 @@ const recordFulfilmentAction: ActionDefinition = {
   handler: async (ctx) => {
     const sourceOrderId = (ctx.input.sourceOrderId as string | undefined) ?? "unknown";
     return ctx.create("fulfilment", { sourceOrderId, note: "fulfilled-by-flow" });
+  },
+};
+
+/**
+ * notify_fulfilment: the downstream flow's step, reached via the
+ * `order_fulfilment` flow's `onComplete` chain. Writes a `notification` row —
+ * proving the in-process engine resolved the chain.
+ */
+const notifyFulfilmentAction: ActionDefinition = {
+  name: "notify_fulfilment",
+  entity: "notification",
+  label: "Notify Fulfilment",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    return ctx.create("notification", { message: "fulfilment-completed" });
   },
 };
 
@@ -121,6 +149,27 @@ const orderFulfilmentFlow: FlowDefinition = {
       input: { sourceOrderId: "$input.id" },
     },
   ],
+  // On completion, chain to the downstream flow. This resolves ONLY when the
+  // sync engine was built with a FlowRegistry (the codex-flagged hardening).
+  onComplete: { flow: "post_fulfilment" },
+};
+
+/**
+ * post_fulfilment: the downstream flow reached via `order_fulfilment.onComplete`.
+ * One action step writing a `notification` row.
+ */
+const postFulfilmentFlow: FlowDefinition = {
+  name: "post_fulfilment",
+  label: "Post Fulfilment",
+  trigger: { type: "manual" },
+  steps: [
+    {
+      id: "notify",
+      name: "Notify Fulfilment",
+      type: "action",
+      actionName: "notify_fulfilment",
+    },
+  ],
 };
 
 // ── Rule ────────────────────────────────────────────────────────────────────
@@ -146,10 +195,10 @@ const capTriggerFlowBiz: CapabilityDefinition = defineCapability({
   type: "standard",
   category: "business",
   version: "0.1.0",
-  entities: [orderEntity, fulfilmentEntity],
-  actions: [submitOrderAction, recordFulfilmentAction],
+  entities: [orderEntity, fulfilmentEntity, notificationEntity],
+  actions: [submitOrderAction, recordFulfilmentAction, notifyFulfilmentAction],
   rules: [fulfilOnSubmitRule],
-  flows: [orderFulfilmentFlow],
+  flows: [orderFulfilmentFlow, postFulfilmentFlow],
 });
 
 // ── Request helpers (in-process, port-free) ─────────────────────────────────
@@ -229,6 +278,16 @@ describe("E2E rule effect: trigger_flow (in-process, DB-free, port-free)", () =>
     expect(items[0].note).toBe("fulfilled-by-flow");
     // The flow input ($input.id) flowed through to the step action.
     expect(items[0].sourceOrderId).toBe(orderId);
+
+    // The onComplete chain reached the downstream flow: a notification row exists.
+    // This only happens because createRuntimeContext built + passed a FlowRegistry
+    // to the sync engine — without it, the chain silently no-ops.
+    const notified = await gql(app, `query { notificationList { items { id message } } }`);
+    expect(notified.errors).toBeUndefined();
+    const notifications = (notified.data.notificationList as Record<string, unknown>)
+      .items as Array<Record<string, unknown>>;
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].message).toBe("fulfilment-completed");
   });
 
   test("2. a submit with no triggering flow does NOT write a fulfilment row", async () => {

--- a/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
@@ -19,6 +19,7 @@ import type {
   AIService,
   CapabilityDefinition,
   EntityDefinition,
+  FlowDefinition,
   MiddlewareRegistration,
   RelationDefinition,
   RuleDefinition,
@@ -63,6 +64,7 @@ export interface CapabilityContributions {
   views: ViewDefinition[];
   relations: RelationDefinition[];
   rules: RuleDefinition[];
+  flows: FlowDefinition[];
   middlewares: MiddlewareRegistration[];
   seed: Record<string, Array<Record<string, unknown>>>;
   extraQueryFields: Record<string, unknown>;
@@ -83,6 +85,7 @@ export function extractCapabilities(
   const views: ViewDefinition[] = [];
   const relations: RelationDefinition[] = [];
   const rules: RuleDefinition[] = [];
+  const flows: FlowDefinition[] = [];
   const middlewares: MiddlewareRegistration[] = [];
   const seed: Record<string, Array<Record<string, unknown>>> = {};
   const extraQueryFields: Record<string, unknown> = {};
@@ -95,6 +98,7 @@ export function extractCapabilities(
     if (cap.views) views.push(...cap.views);
     if (cap.relations) relations.push(...cap.relations);
     if (cap.rules) rules.push(...cap.rules);
+    if (cap.flows) flows.push(...cap.flows);
 
     if (cap.seed) {
       for (const [entityName, records] of Object.entries(cap.seed)) {
@@ -138,6 +142,7 @@ export function extractCapabilities(
     views,
     relations,
     rules,
+    flows,
     middlewares,
     seed,
     extraQueryFields,
@@ -210,6 +215,7 @@ export function assembleDevSchema(
     views: contributions.views,
     middlewares: contributions.middlewares,
     rules: contributions.rules,
+    flows: contributions.flows,
     ai: options?.aiService,
     capabilityNames,
   });

--- a/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
@@ -86,6 +86,7 @@ export function extractCapabilities(
   const relations: RelationDefinition[] = [];
   const rules: RuleDefinition[] = [];
   const flows: FlowDefinition[] = [];
+  const flowNames = new Set<string>();
   const middlewares: MiddlewareRegistration[] = [];
   const seed: Record<string, Array<Record<string, unknown>>> = {};
   const extraQueryFields: Record<string, unknown> = {};
@@ -98,7 +99,22 @@ export function extractCapabilities(
     if (cap.views) views.push(...cap.views);
     if (cap.relations) relations.push(...cap.relations);
     if (cap.rules) rules.push(...cap.rules);
-    if (cap.flows) flows.push(...cap.flows);
+    // Detect duplicate flow names at assembly time. The sync flow engine
+    // registers by name (Map.set), so a collision would otherwise let the later
+    // capability's flow silently overwrite the earlier one — a hard-to-debug
+    // runtime surprise. Fail loud, mirroring mergeGraphQLFields above.
+    if (cap.flows) {
+      for (const flow of cap.flows) {
+        if (flowNames.has(flow.name)) {
+          throw new Error(
+            `Duplicate flow "${flow.name}" contributed by capability "${cap.name}" — ` +
+              "another capability already registered a flow with this name.",
+          );
+        }
+        flowNames.add(flow.name);
+        flows.push(flow);
+      }
+    }
 
     if (cap.seed) {
       for (const [entityName, records] of Object.entries(cap.seed)) {

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -108,7 +108,7 @@ export function createDevApp(
     rules: contributions.rules,
     aiService: runtime.ai,
     states: contributions.states,
-    flows: [],
+    flows: contributions.flows,
     dataProvider: runtime.dataProvider,
     onchangeEvaluator,
   });

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -108,7 +108,12 @@ export function createDevApp(
     rules: contributions.rules,
     aiService: runtime.ai,
     states: contributions.states,
-    flows: contributions.flows,
+    // Flow admin endpoints (/api/flows) stay out of the in-process path, mirroring
+    // dev.ts — only the real `linch dev` boot path (http-transport) exposes them
+    // with a flowEngine. `trigger_flow` rule effects do NOT need this: their flow
+    // engine is wired onto the executor inside createRuntimeContext (from the
+    // aggregated capability flows), independent of this server-introspection arg.
+    flows: [],
     dataProvider: runtime.dataProvider,
     onchangeEvaluator,
   });

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -226,7 +226,13 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
             actionName,
             input,
             opts?.actor ?? { type: "system", id: "flow-engine", groups: [] },
-            { tenantId: opts?.tenantId, channel: "internal" },
+            {
+              tenantId: opts?.tenantId,
+              channel: "internal",
+              // Forward the Saga compensation idempotency key (Spec 26 §3.2) so a
+              // retried compensating action is not executed twice.
+              idempotencyKey: opts?.idempotencyKey,
+            },
           ),
       },
       actionRegistry: executor.registry,

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -33,7 +33,6 @@ import {
   createApprovalEngine,
   createApprovalVerifier,
   createCommandLayer,
-  createFlowRegistry,
   createFlowStepContext,
   createInterfaceRegistry,
   createNoopAIService,
@@ -232,18 +231,14 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
       },
       actionRegistry: executor.registry,
     });
-    // Build a FlowRegistry so the sync engine can resolve `onComplete` flow
-    // chains, and forward any configured eventBus so it emits flow.completed /
-    // flow.failed events. Each flow is registered on the engine (to run it) and
-    // on the registry (so onComplete chain targets resolve).
-    const flowRegistry = createFlowRegistry();
-    for (const flow of options.flows) {
-      flowRegistry.register(flow);
-    }
-    const syncFlowEngine = createSyncFlowEngine(flowStepContext, {
-      flowRegistry,
-      eventBus: options?.eventBus,
-    });
+    // Mirror the `linch dev` boot path (dev-wiring.ts): a plain SyncFlowEngine
+    // with each flow registered on it. We deliberately do NOT pass a
+    // `flowRegistry` (which would enable `onComplete` flow chaining): core's
+    // `processOnCompleteChains` starts chained flows with `tenantId: undefined`
+    // and no actor, so enabling it here would drop tenant/actor scope for
+    // downstream flows. Production does not enable chaining via the sync engine
+    // either; trigger_flow itself does not need it.
+    const syncFlowEngine = createSyncFlowEngine(flowStepContext);
     for (const flow of options.flows) {
       syncFlowEngine.registerFlow(flow);
     }

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -20,6 +20,7 @@ import type {
   EntityDefinition,
   EventBus,
   ExecutionLogger,
+  FlowDefinition,
   InterfaceDefinition,
   MiddlewareRegistration,
   RuleDefinition,
@@ -32,9 +33,11 @@ import {
   createApprovalEngine,
   createApprovalVerifier,
   createCommandLayer,
+  createFlowStepContext,
   createInterfaceRegistry,
   createNoopAIService,
   createStateMachine,
+  createSyncFlowEngine,
   detectEnvironment,
   EntityRegistry,
   InMemoryApprovalStore,
@@ -83,6 +86,14 @@ export interface RuntimeContextOptions {
    * satisfies it) — when omitted, trigger_flow rules are logged and skipped.
    */
   flowEngine?: ActionFlowStarter;
+  /**
+   * Capability flows (defineFlow). When supplied and no external `flowEngine`
+   * is injected, an in-process SyncFlowEngine is built from them so a
+   * `trigger_flow` rule effect starts its flow post-commit on this DB-free path
+   * (Spec 23 §1.1 / Spec 26 §2.2). The `linch dev` boot path injects a durable
+   * engine via `flowEngine` instead, which always wins.
+   */
+  flows?: FlowDefinition[];
   middlewares?: MiddlewareRegistration[];
   /** Interface definitions — registered before schemas so field injection/validation works */
   interfaces?: InterfaceDefinition[];
@@ -200,10 +211,34 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
   approvalEngine.setExecutor(executor);
   executor.setApprovalEngine(approvalEngine);
 
-  // Wire the flow engine for `trigger_flow` rule effects when one is provided
-  // (the boot path injects it; the server does not yet aggregate flows here).
-  if (options?.flowEngine) {
-    executor.setFlowEngine(options.flowEngine);
+  // Wire the flow engine for `trigger_flow` rule effects. An injected engine
+  // (e.g. the durable Restate engine from the `linch dev` boot path) always
+  // wins. Otherwise, when capability flows are supplied, build a default
+  // in-process SyncFlowEngine so a `trigger_flow` rule still starts its flow
+  // post-commit on this DB-free path (it previously logged + skipped).
+  let flowEngine: ActionFlowStarter | undefined = options?.flowEngine;
+  if (!flowEngine && options?.flows?.length) {
+    const flowStepContext = createFlowStepContext({
+      aiService: ai,
+      actionEngine: {
+        execute: (actionName, input, opts) =>
+          executor.execute(
+            actionName,
+            input,
+            opts?.actor ?? { type: "system", id: "flow-engine", groups: [] },
+            { tenantId: opts?.tenantId, channel: "internal" },
+          ),
+      },
+      actionRegistry: executor.registry,
+    });
+    const syncFlowEngine = createSyncFlowEngine(flowStepContext);
+    for (const flow of options.flows) {
+      syncFlowEngine.registerFlow(flow);
+    }
+    flowEngine = syncFlowEngine;
+  }
+  if (flowEngine) {
+    executor.setFlowEngine(flowEngine);
   }
 
   // Register views grouped by schema

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -33,6 +33,7 @@ import {
   createApprovalEngine,
   createApprovalVerifier,
   createCommandLayer,
+  createFlowRegistry,
   createFlowStepContext,
   createInterfaceRegistry,
   createNoopAIService,
@@ -231,7 +232,18 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
       },
       actionRegistry: executor.registry,
     });
-    const syncFlowEngine = createSyncFlowEngine(flowStepContext);
+    // Build a FlowRegistry so the sync engine can resolve `onComplete` flow
+    // chains, and forward any configured eventBus so it emits flow.completed /
+    // flow.failed events. Each flow is registered on the engine (to run it) and
+    // on the registry (so onComplete chain targets resolve).
+    const flowRegistry = createFlowRegistry();
+    for (const flow of options.flows) {
+      flowRegistry.register(flow);
+    }
+    const syncFlowEngine = createSyncFlowEngine(flowStepContext, {
+      flowRegistry,
+      eventBus: options?.eventBus,
+    });
     for (const flow of options.flows) {
       syncFlowEngine.registerFlow(flow);
     }

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -375,6 +375,9 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
           return executor.execute(actionName, input, actor, {
             tenantId: options?.tenantId,
             channel: "internal",
+            // Forward the Saga compensation idempotency key (Spec 26 §3.2) so a
+            // retried compensating action is not executed twice.
+            idempotencyKey: options?.idempotencyKey,
           });
         },
       },


### PR DESCRIPTION
## Summary

Closes #476. The in-process boot path — `assembleDevSchema` → `createRuntimeContext` (public via `createDevApp`) — never aggregated capability flows nor built a flow engine, so a `trigger_flow` rule effect silently logged + skipped on this DB-free path (`flowEngine` was `undefined`). The real `linch dev` path (`dev-wiring.ts` → `http-transport.ts`) wires a Restate/Sync engine correctly, so only the in-process path (tests, smoke checks, lightweight `createDevApp` consumers) was affected. This also explains why #475's e2e suite covered enrich/require_approval/execute_action but **not** trigger_flow.

## Changes

- **`createRuntimeContext`** now accepts `flows?: FlowDefinition[]`. When flows are supplied and no external `flowEngine` is injected, it builds a default in-process `SyncFlowEngine` — **mirroring `dev-wiring.ts` exactly** (plain `createSyncFlowEngine(flowStepContext)` + `registerFlow`) — and wires it onto the executor via `setFlowEngine`. An injected `flowEngine` (e.g. the durable Restate engine from `linch dev`) still wins.
- **`extractCapabilities` / `assembleDevSchema`** aggregate `cap.flows` into `CapabilityContributions.flows` and pass them to `createRuntimeContext`.
- **New DB-free e2e** (`e2e-rules-trigger-flow.test.ts`, dispatched via `app.handle` — no `app.listen`) asserting a `trigger_flow` rule actually runs its flow end-to-end through `createDevApp`.

## Scope decisions (why no onComplete chaining / flow admin endpoints here)

This path deliberately mirrors `dev-wiring.ts`:
- It does **not** pass a `flowRegistry` to the sync engine. Doing so would enable core's `processOnCompleteChains`, which starts chained flows with `tenantId: undefined` and no actor — a tenant-isolation risk. Production does not enable chaining via the sync engine either. Proper tenant/actor propagation for `onComplete` chains is a separate core concern.
- `createDevApp` keeps `flows: []` for `createServer` (matching `dev.ts`); flow admin endpoints (`/api/flows`) are only exposed by the real `http-transport` boot path with a `flowEngine`.

## Verification

- `bun run check`, `bun run typecheck`, full `bun run test` — all green.
- Cross-model review: **codex, 4 iterative rounds** → converged clean (each round caught scope-creep; the final form matches the production wiring). gemini-code-assist / CodeRabbit will review here.

Spec 23 §1.1 / Spec 26 §2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flows now execute in in-process development environments, enabling `trigger_flow` effects to start flows without external infrastructure.

* **Tests**
  * Added end-to-end test validating flow execution in the development mode when actions trigger flows.

* **Documentation**
  * Updated release notes documenting flow engine integration in development paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->