### PR TITLE
fix(adapter-server): activate dormant server-engine wiring (SSE/approvals/cache)

### DIFF
--- a/.changeset/server-engine-wiring.md
+++ b/.changeset/server-engine-wiring.md
@@ -1,0 +1,12 @@
+---
+"@linchkit/cap-adapter-server": minor
+---
+
+Activate dormant server-engine wiring so SSE subscriptions, approvals, and cache stats work.
+
+The `createServer(...)` calls in both boot paths omitted engines that the rest of the stack expects:
+
+- `http-transport.ts` (the real `linch dev` path) never passed `eventBus`, `approvalEngine`, or `cacheManager` from the transport context, so `/api/subscribe` (SSE), `/api/approvals`, and `/internal/cache/stats` were silently disabled (`subscription-api` bailed on a missing bus, `approval-api` returned 501).
+- The in-process path (`assembleDevSchema` → `createRuntimeContext` → `createDevApp`) never built or wired an event bus at all, so domain events never reached SSE subscribers.
+
+`assembleDevSchema` now builds an in-memory event bus and threads it through `createRuntimeContext` (which forwards it to the action executor so actions emit domain events) and into `createServer`. A new DB-free SSE e2e (`app.handle`) guards the path. Also adds a duplicate-name guard to action registration in `createRuntimeContext`, mirroring the existing `build-registries` / `http-transport` guard.

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-sse-subscribe.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-sse-subscribe.test.ts
@@ -1,0 +1,152 @@
+/**
+ * SSE subscription e2e (in-process, DB-free, port-free).
+ *
+ * Regression guard for the dormant-eventBus wiring fix. The in-process boot
+ * path (`createDevApp` → `assembleDevSchema` → `createRuntimeContext`) never
+ * wired an event bus, so:
+ *   - `mountSubscriptionRoutes` early-returned (`subscription-api.ts`:
+ *     `if (!eventBus) return;`) → `GET /api/subscribe` was a dead route, and
+ *   - actions emitted domain events into a void (no bus → no subscribers).
+ *
+ * The fix assembles an in-memory bus in `assembleDevSchema`, threads it into
+ * `createActionExecutor` (via `createRuntimeContext`), and forwards it to
+ * `createServer` (via `createDevApp`). This test proves that wiring is LIVE:
+ *
+ *   1. `GET /api/subscribe` returns HTTP 200 with `content-type:
+ *      text/event-stream` and streams the initial `connected` SSE frame —
+ *      impossible when the route early-returns on a missing bus.
+ *   2. A domain event emitted on the wired bus (`assembled.runtime.eventBus`)
+ *      flows through the SubscriptionManager and arrives on the open SSE stream
+ *      as a `record.created` frame — proving the bus the server mounts and the
+ *      bus actions emit on are the same, end to end.
+ *
+ * Dispatch is in-process via `app.handle(new Request(...))` ONLY — never
+ * `app.listen(PORT)`. A bound socket passes in isolation but SEGFAULTS the
+ * batched runner; the streaming read uses a hard timeout so the test can never
+ * hang. Mirrors the bootstrap in `smoke-action-roundtrip.test.ts`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { CapabilityDefinition, EntityDefinition, EventRecord } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { capAdapterServer } from "../src/capability";
+import { createDevApp } from "../src/dev-app";
+
+// ── Synthetic business capability (inline) ───────────────────────────────────
+//
+// One entity with its auto-generated CRUD — enough to mount the entity into the
+// registry so the SSE permission checker recognizes it as a readable schema.
+
+const noteEntity: EntityDefinition = {
+  name: "sse_note",
+  label: "SSE Note",
+  description: "Synthetic entity for the SSE subscription e2e",
+  fields: {
+    title: { type: "string", required: true, label: "Title", ui: { importance: "primary" } },
+  },
+};
+
+const capSseBusiness: CapabilityDefinition = defineCapability({
+  name: "cap-sse-business",
+  label: "SSE Business",
+  description: "Synthetic business capability (inline) — one entity for SSE subscription tests",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [noteEntity],
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Read one SSE frame (text up to the `\n\n` terminator) from a stream reader,
+ * bounded by a hard timeout so the test can never hang. Resolves to the
+ * accumulated text on the first chunk (or whatever has arrived by the timeout).
+ */
+async function readChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  timeoutMs: number,
+): Promise<string> {
+  const timeout = new Promise<{ value: undefined; done: true }>((resolve) => {
+    setTimeout(() => resolve({ value: undefined, done: true }), timeoutMs);
+  });
+  const result = await Promise.race([reader.read(), timeout]);
+  return result.value ? decoder.decode(result.value) : "";
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("SSE /api/subscribe e2e (in-process, DB-free, port-free)", () => {
+  it("returns 200 + text/event-stream and streams the initial connected frame", async () => {
+    const { app } = createDevApp([capAdapterServer, capSseBusiness], { cors: false });
+
+    const res = await app.handle(
+      new Request("http://local.test/api/subscribe?entities=sse_note", { method: "GET" }),
+    );
+
+    // Core regression guard: before the fix, a missing eventBus made
+    // mountSubscriptionRoutes early-return → this route would 404 / not stream.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    // The stream must be readable and deliver the initial `connected` frame.
+    const body = res.body as ReadableStream<Uint8Array> | null;
+    expect(body).not.toBeNull();
+    const reader = (body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+
+    const firstFrame = await readChunkWithTimeout(reader, decoder, 2000);
+    expect(firstFrame).toContain("event: connected");
+    expect(firstFrame).toContain("connectionId");
+
+    await reader.cancel();
+  });
+
+  it("delivers a domain event emitted on the wired bus to an open subscription", async () => {
+    const { app, assembled } = createDevApp([capAdapterServer, capSseBusiness], { cors: false });
+
+    // The bus must now exist on the runtime (it was undefined before the fix).
+    const eventBus = assembled.runtime.eventBus;
+    expect(eventBus).toBeDefined();
+
+    const res = await app.handle(
+      new Request("http://local.test/api/subscribe?entities=sse_note", { method: "GET" }),
+    );
+    expect(res.status).toBe(200);
+
+    const reader = (res.body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+
+    // Drain the initial `connected` frame so the next read targets our event.
+    const connected = await readChunkWithTimeout(reader, decoder, 2000);
+    expect(connected).toContain("event: connected");
+
+    // Emit a properly-shaped domain event on the SAME bus the server mounts and
+    // actions emit on. If the bus were not forwarded to createServer, the
+    // SubscriptionManager would not be listening and this frame would never
+    // arrive (the read below would time out to "").
+    const domainEvent: EventRecord = {
+      id: crypto.randomUUID(),
+      type: "record.created",
+      category: "change",
+      timestamp: new Date(),
+      actor: { type: "system", id: "sse-test" },
+      entity: "sse_note",
+      recordId: "note-1",
+      executionId: "exec-sse-test",
+      payload: { id: "note-1", title: "hello" },
+    };
+    if (!eventBus) throw new Error("eventBus was not wired by the dev boot path");
+    await eventBus.emit(domainEvent);
+
+    // Bounded read — the event is delivered synchronously to in-memory
+    // subscribers, so a short timeout is a safety net, not the happy path.
+    const eventFrame = await readChunkWithTimeout(reader, decoder, 2000);
+    expect(eventFrame).toContain("event: record.created");
+    expect(eventFrame).toContain('"entity":"sse_note"');
+    expect(eventFrame).toContain('"recordId":"note-1"');
+
+    await reader.cancel();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-sse-subscribe.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-sse-subscribe.test.ts
@@ -68,11 +68,18 @@ async function readChunkWithTimeout(
   decoder: TextDecoder,
   timeoutMs: number,
 ): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<{ value: undefined; done: true }>((resolve) => {
-    setTimeout(() => resolve({ value: undefined, done: true }), timeoutMs);
+    timer = setTimeout(() => resolve({ value: undefined, done: true }), timeoutMs);
   });
-  const result = await Promise.race([reader.read(), timeout]);
-  return result.value ? decoder.decode(result.value) : "";
+  try {
+    const result = await Promise.race([reader.read(), timeout]);
+    return result.value ? decoder.decode(result.value) : "";
+  } finally {
+    // Clear the timer on the happy path so it does not linger as a background
+    // timer after the read resolves (avoids batched-runner timer accumulation).
+    if (timer) clearTimeout(timer);
+  }
 }
 
 // ── Suite ─────────────────────────────────────────────────────────────────────
@@ -100,6 +107,8 @@ describe("SSE /api/subscribe e2e (in-process, DB-free, port-free)", () => {
     expect(firstFrame).toContain("event: connected");
     expect(firstFrame).toContain("connectionId");
 
+    // Cancelling the reader closes the SSE stream, which removes the
+    // subscription and clears its per-connection heartbeat/idle timers.
     await reader.cancel();
   });
 

--- a/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
@@ -26,7 +26,7 @@ import type {
   StateDefinition,
   ViewDefinition,
 } from "@linchkit/core";
-import { createOnchangeEvaluator } from "@linchkit/core/server";
+import { createEventBus, createOnchangeEvaluator } from "@linchkit/core/server";
 import type { GraphQLFieldConfig, GraphQLSchema } from "graphql";
 import { buildGraphQLSchema, generateCrudActions } from "./graphql/build-schema";
 import { createRuntimeContext, type RuntimeContext } from "./runtime-context";
@@ -224,6 +224,12 @@ export function assembleDevSchema(
 
   const capabilityNames = new Set(capabilities.map((c) => c.name));
 
+  // In-process event bus for the DB-free dev/boot path. The durable `linch dev`
+  // boot path (dev-wiring.ts) builds a PersistentEventBus instead; here a plain
+  // in-memory bus is enough to flush domain events to SSE subscribers and event
+  // handlers. Mirrors dev-wiring.ts's `const { bus } = createEventBus()`.
+  const { bus: eventBus } = createEventBus();
+
   const runtime = createRuntimeContext({
     entities: allEntities,
     actions: allActions,
@@ -234,6 +240,7 @@ export function assembleDevSchema(
     flows: contributions.flows,
     ai: options?.aiService,
     capabilityNames,
+    eventBus,
   });
 
   const onchangeEvaluator = createOnchangeEvaluator({

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -114,6 +114,11 @@ export function createDevApp(
     // engine is wired onto the executor inside createRuntimeContext (from the
     // aggregated capability flows), independent of this server-introspection arg.
     flows: [],
+    // Event bus assembled in createRuntimeContext — forwarded so the SSE
+    // subscription route (`/api/subscribe`) mounts and domain events reach
+    // subscribers. Without it, `mountSubscriptionRoutes` early-returns and the
+    // route is dead.
+    eventBus: runtime.eventBus,
     dataProvider: runtime.dataProvider,
     onchangeEvaluator,
   });

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -43,6 +43,7 @@ export interface CreateDevAppOptions
         ServerOptions,
         | "executor"
         | "commandLayer"
+        | "approvalEngine"
         | "executionLogger"
         | "entityRegistry"
         | "views"
@@ -51,6 +52,7 @@ export interface CreateDevAppOptions
         | "aiService"
         | "states"
         | "flows"
+        | "eventBus"
         | "dataProvider"
         | "onchangeEvaluator"
       >

--- a/addons/adapter-server/cap-adapter-server/src/http-transport.ts
+++ b/addons/adapter-server/cap-adapter-server/src/http-transport.ts
@@ -139,6 +139,12 @@ export async function createHttpTransport(ctx: TransportContext): Promise<Transp
     views: viewsMap,
     capabilities: ctx.capabilities,
     dataProvider: ctx.dataProvider,
+    // Wire the event bus so SSE /api/subscribe is live (subscription-api bails when absent).
+    eventBus: ctx.eventBus,
+    // Wire the approval engine so /api/approvals works (returns 501 when absent).
+    approvalEngine: ctx.approvalEngine,
+    // Wire the cache manager so /internal/cache/stats reports real stats (errors when absent).
+    cacheManager: ctx.cacheManager,
     healthCheckRegistry: ctx.healthCheckRegistry,
     permissionGroups: permGroups,
     entityMap,

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -163,6 +163,10 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     capabilityNames: options?.capabilityNames,
     entityRegistry,
     transactionManager: options?.transactionManager,
+    // Event bus — domain events (record.created/updated/deleted, action.succeeded)
+    // are emitted here so SSE subscribers and event handlers receive them. Without
+    // it, ctx.emit() events are collected but never flushed to any subscriber.
+    eventBus: options?.eventBus,
     // Strict type/constraint input validation in production + staging; dev/test
     // stay lenient (toy inputs). Sourced from the canonical environment policy.
     strictValidation: detectEnvironment().features.strictValidation,
@@ -170,10 +174,14 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     rules: options?.rules,
   });
 
-  // Register actions
+  // Register actions, skipping duplicate names. Mirrors the dedup guard at
+  // build-registries.ts and http-transport.ts (ActionRegistry.has → skip) so a
+  // capability that re-declares a CRUD action name does not throw on re-register.
   if (options?.actions) {
     for (const action of options.actions) {
-      executor.registry.register(action);
+      if (!executor.registry.has(action.name)) {
+        executor.registry.register(action);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #476/#477. The scout that found the dormant `trigger_flow` wiring surfaced a sibling cluster: **`createServer(...)` in both server boot paths omitted engines the rest of the stack expects**, so several endpoints were silently dead.

## Verified gap

- **`http-transport.ts`** (the real `linch dev` path) never passed `eventBus`, `approvalEngine`, or `cacheManager` from `transportCtx` — even though all three exist there (dev-wiring.ts) and are `ServerOptions` optionals. Read sites bail when absent: SSE `/api/subscribe` (`subscription-api.ts:24` `if (!eventBus) return;`), `/api/approvals` (501), `/internal/cache/stats` ("not configured").
- **In-process path** (`assembleDevSchema` → `createRuntimeContext` → `createDevApp`) never built an event bus at all, so domain events never reached SSE subscribers.

## Changes

- `http-transport.ts`: forward `eventBus`/`approvalEngine`/`cacheManager` from `ctx` into `createServer`.
- `assemble-schema.ts`: build an in-memory `createEventBus()` and thread it through `createRuntimeContext`.
- `runtime-context.ts`: forward `eventBus` into `createActionExecutor` (actions now emit domain events); add a duplicate-name guard to action registration, mirroring `build-registries`/`http-transport`.
- `dev-app.ts`: pass `eventBus` into `createServer`.
- New DB-free SSE e2e (`e2e-sse-subscribe.test.ts`, `app.handle` — no `app.listen`) asserting `/api/subscribe` returns 200 `text/event-stream` and streams a domain event off the wired bus.

## Notes

- Known follow-up (out of scope): CRUD handlers emit `record.created` with a `schema` field but the event flush/SubscriptionManager keys on `entity`, so action-driven SSE delivery is a separate pre-existing mismatch. The e2e emits a correctly-shaped event directly on the bus to exercise the bus→SSE path deterministically.

## Verification

`bun run check`, `bun run typecheck`, full `bun run test` all green (SSE e2e uses `app.handle`, confirmed not to segfault the batched runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSE subscriptions now fully functional with proper event bus wiring in development environment.

* **Bug Fixes**
  * Fixed missing engine initialization for approvals endpoint and cache stats functionality.
  * Added protection against duplicate action name registration errors.

* **Tests**
  * Added end-to-end test suite for SSE subscription behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->