### PR TITLE
fix(core): propagate tenant + actor through onComplete flow chains

### DIFF
--- a/.changeset/oncomplete-tenant-actor.md
+++ b/.changeset/oncomplete-tenant-actor.md
@@ -1,0 +1,7 @@
+---
+"@linchkit/core": patch
+---
+
+Propagate tenant and actor through `onComplete` flow chains (tenant-isolation fix).
+
+`processOnCompleteChains` started each downstream chained flow with `{ tenantId: undefined }` and no actor (the "inherit from context if available" comment was never implemented), so an `onComplete`-chained flow ran with no tenant scope and the default system actor — able to read/write records outside the originating tenant. `FlowInstance` now persists the run's `tenantId` and `actor` (both optional, backward-compatible), and `processOnCompleteChains` forwards them to the chained `startFlow`, mirroring the post-commit rule-effect path. No function signature change.

--- a/packages/core/__tests__/flow-chaining.test.ts
+++ b/packages/core/__tests__/flow-chaining.test.ts
@@ -6,14 +6,16 @@ import {
   FLOW_COMPLETED_EVENT,
   FLOW_FAILED_EVENT,
   getFlowDependencies,
+  processOnCompleteChains,
   resolveInputMapping,
   validateFlowChains,
 } from "../src/flow/flow-chaining";
 import { createFlowRegistry } from "../src/flow/flow-registry";
 import { createSyncFlowEngine } from "../src/flow/sync-engine";
-import type { FlowStepContext } from "../src/flow/types";
+import type { FlowEngine, FlowStepContext } from "../src/flow/types";
+import type { Actor } from "../src/types/action";
 import type { EventRecord } from "../src/types/event";
-import type { FlowDefinition } from "../src/types/flow";
+import type { FlowDefinition, FlowInstance } from "../src/types/flow";
 
 // ── Mock step context ───────────────────────────────────
 
@@ -470,6 +472,184 @@ describe("Flow Chaining", () => {
       expect(instance.status).toBe("failed");
       // flow-b should NOT have been triggered (onStatus defaults to "completed")
       expect(executedActions).not.toContain("do.b");
+    });
+  });
+
+  // ── Tenant-isolation: onComplete chains must inherit tenant + actor ──
+  //
+  // Security regression coverage. Before the fix, `processOnCompleteChains`
+  // started the downstream flow with `{ tenantId: undefined }` and dropped the
+  // actor entirely, so a chained flow ran with no tenant scope and the
+  // default/system actor — able to touch records OUTSIDE the originating
+  // tenant. The downstream flow MUST inherit the parent's tenantId + actor.
+  describe("onComplete chain tenant + actor inheritance", () => {
+    /**
+     * A fake FlowEngine whose only job is to record the options each chained
+     * `startFlow` call receives, so we can assert what context is forwarded.
+     */
+    function createRecordingEngine(): {
+      engine: FlowEngine;
+      calls: Array<{
+        flowName: string;
+        input: Record<string, unknown>;
+        options?: { instanceId?: string; tenantId?: string; actor?: Actor };
+      }>;
+    } {
+      const calls: Array<{
+        flowName: string;
+        input: Record<string, unknown>;
+        options?: { instanceId?: string; tenantId?: string; actor?: Actor };
+      }> = [];
+
+      const engine: FlowEngine = {
+        registerFlow() {},
+        async startFlow(flowName, input, options) {
+          calls.push({ flowName, input, options });
+          // Return a minimal completed instance — the chain does not read it.
+          return {
+            id: "downstream-inst",
+            flowName,
+            status: "completed",
+            currentStepId: "",
+            context: {},
+            startedAt: new Date(),
+          } satisfies FlowInstance;
+        },
+        async getFlowStatus() {
+          return null;
+        },
+        async sendSignal() {},
+        async cancelFlow() {},
+      };
+
+      return { engine, calls };
+    }
+
+    const parentActor: Actor = { type: "human", id: "user-77", groups: ["buyers"] };
+
+    /** Parent flow instance carrying a real tenant scope + actor. */
+    function makeParentInstance(): FlowInstance {
+      return {
+        id: "parent-inst",
+        flowName: "flow-a",
+        status: "completed",
+        currentStepId: "step1",
+        context: { __steps: { step1: { output: { orderId: "ord-1" } } } },
+        startedAt: new Date(),
+        completedAt: new Date(),
+        tenantId: "tenant-42",
+        actor: parentActor,
+      };
+    }
+
+    it("forwards the parent's tenantId to the downstream chained flow", async () => {
+      const registry = createFlowRegistry();
+      registry.register(flowA);
+      registry.register(flowB);
+
+      const { engine, calls } = createRecordingEngine();
+      await processOnCompleteChains(makeParentInstance(), registry, engine);
+
+      expect(calls.length).toBe(1);
+      expect(calls[0]?.flowName).toBe("flow-b");
+      // Fail-first guard: old behavior passed `tenantId: undefined`; this
+      // assertion fails unless the parent's tenant is threaded through.
+      expect(calls[0]?.options?.tenantId).toBe("tenant-42");
+      expect(calls[0]?.options?.tenantId).not.toBeUndefined();
+    });
+
+    it("forwards the parent's actor (not the default system actor)", async () => {
+      const registry = createFlowRegistry();
+      registry.register(flowA);
+      registry.register(flowB);
+
+      const { engine, calls } = createRecordingEngine();
+      await processOnCompleteChains(makeParentInstance(), registry, engine);
+
+      expect(calls.length).toBe(1);
+      // Fail-first guard: old behavior dropped the actor entirely (undefined),
+      // which downstream resolves to the default/system actor.
+      expect(calls[0]?.options?.actor).toEqual(parentActor);
+      expect(calls[0]?.options?.actor?.type).not.toBe("system");
+      expect(calls[0]?.options?.actor?.id).toBe("user-77");
+    });
+
+    it("forwards tenant + actor to EVERY downstream flow in a multi-chain", async () => {
+      const multiChainA: FlowDefinition = {
+        name: "flow-a",
+        trigger: { type: "manual" },
+        steps: [{ id: "s1", name: "Step", type: "action", actionName: "do.a" }],
+        onComplete: [{ flow: "flow-b" }, { flow: "flow-c" }],
+      };
+
+      const registry = createFlowRegistry();
+      registry.register(multiChainA);
+      registry.register(flowB);
+      registry.register(flowC);
+
+      const { engine, calls } = createRecordingEngine();
+      await processOnCompleteChains(makeParentInstance(), registry, engine);
+
+      expect(calls.length).toBe(2);
+      for (const call of calls) {
+        expect(call.options?.tenantId).toBe("tenant-42");
+        expect(call.options?.actor).toEqual(parentActor);
+      }
+    });
+
+    it("end-to-end: SyncFlowEngine threads parent tenant + actor into the chained flow", async () => {
+      // Exercise the whole path with the real SyncFlowEngine: the parent
+      // instance must persist tenantId/actor (sync-engine) AND the chain must
+      // read + forward them (flow-chaining). Each downstream action runs with
+      // the per-run step context as its `this`, so we capture `this.tenantId`
+      // / `this.actor` to prove the scope crossed the chain boundary.
+      const captured: Record<string, { tenantId?: string; actor?: Actor }> = {};
+
+      const ctx: FlowStepContext = {
+        flowContext: {},
+        // Non-arrow method so `this` is the per-run context the engine injects.
+        async executeAction(this: FlowStepContext, actionName, input) {
+          captured[actionName] = { tenantId: this.tenantId, actor: this.actor };
+          return { ok: true, actionName, input };
+        },
+        async callAI() {
+          return { response: "", tokensUsed: 0 };
+        },
+        evaluateCondition() {
+          return false;
+        },
+      };
+
+      const registry = createFlowRegistry();
+      registry.register(flowA);
+      registry.register(flowB);
+
+      const engine = createSyncFlowEngine(ctx, { flowRegistry: registry });
+      engine.registerFlow(flowA);
+      engine.registerFlow(flowB);
+
+      const parentActor2: Actor = { type: "ai", id: "agent-9", groups: [] };
+      const parent = await engine.startFlow(
+        "flow-a",
+        { userId: "u-1" },
+        { tenantId: "tenant-99", actor: parentActor2 },
+      );
+
+      // Parent instance persisted its tenant + actor (prerequisite for chaining).
+      expect(parent.tenantId).toBe("tenant-99");
+      expect(parent.actor).toEqual(parentActor2);
+
+      // Parent action (do.a) ran with the parent's scope.
+      expect(captured["do.a"]?.tenantId).toBe("tenant-99");
+      expect(captured["do.a"]?.actor).toEqual(parentActor2);
+
+      // Downstream chained action (do.b) INHERITED the parent's scope, instead
+      // of running with undefined tenant + default/system actor (the old bug).
+      expect(captured["do.b"]).toBeDefined();
+      expect(captured["do.b"]?.tenantId).toBe("tenant-99");
+      expect(captured["do.b"]?.tenantId).not.toBeUndefined();
+      expect(captured["do.b"]?.actor).toEqual(parentActor2);
+      expect(captured["do.b"]?.actor?.type).not.toBe("system");
     });
   });
 });

--- a/packages/core/src/flow/flow-chaining.ts
+++ b/packages/core/src/flow/flow-chaining.ts
@@ -333,8 +333,10 @@ export async function processOnCompleteChains(
     // runs within the originating tenant boundary instead of with no tenant
     // scope and the default/system actor (tenant-isolation correctness).
     await flowEngine.startFlow(chain.flow, input, {
-      tenantId: instance.tenantId,
-      actor: instance.actor,
+      // Only include when the parent actually had them, so an absent tenant/actor
+      // does not override ambient context the engine may apply (tenant isolation).
+      ...(instance.tenantId !== undefined ? { tenantId: instance.tenantId } : {}),
+      ...(instance.actor !== undefined ? { actor: instance.actor } : {}),
     });
   }
 }

--- a/packages/core/src/flow/flow-chaining.ts
+++ b/packages/core/src/flow/flow-chaining.ts
@@ -329,8 +329,12 @@ export async function processOnCompleteChains(
       ? resolveInputMapping(chain.inputMapping, payload)
       : { _upstream: payload };
 
+    // Inherit the parent flow's tenant scope and actor so the downstream flow
+    // runs within the originating tenant boundary instead of with no tenant
+    // scope and the default/system actor (tenant-isolation correctness).
     await flowEngine.startFlow(chain.flow, input, {
-      tenantId: undefined, // Inherit from context if available
+      tenantId: instance.tenantId,
+      actor: instance.actor,
     });
   }
 }

--- a/packages/core/src/flow/sync-engine.ts
+++ b/packages/core/src/flow/sync-engine.ts
@@ -477,7 +477,8 @@ export function createSyncFlowEngine(
       __flow: { instanceId },
     };
 
-    // Create instance
+    // Create instance. Persist tenant/actor so `onComplete`-chained downstream
+    // flows inherit the originating tenant scope and actor (tenant-isolation).
     const instance: FlowInstance = {
       id: instanceId,
       flowName: definition.name,
@@ -485,6 +486,8 @@ export function createSyncFlowEngine(
       currentStepId: definition.steps[0]?.id ?? "",
       context: flowContext,
       startedAt: new Date(),
+      tenantId: runOptions?.tenantId,
+      actor: runOptions?.actor,
     };
     instances.set(instanceId, instance);
 

--- a/packages/core/src/flow/sync-engine.ts
+++ b/packages/core/src/flow/sync-engine.ts
@@ -495,8 +495,10 @@ export function createSyncFlowEngine(
     // multiple flows run concurrently (each gets its own tenant/actor/flowContext).
     const runCtx: FlowStepContext = {
       ...stepContext,
-      tenantId: runOptions?.tenantId,
-      actor: runOptions?.actor,
+      // Only override when explicitly provided so an absent tenant/actor does
+      // NOT wipe any ambient context already on stepContext (tenant isolation).
+      ...(runOptions?.tenantId !== undefined ? { tenantId: runOptions.tenantId } : {}),
+      ...(runOptions?.actor !== undefined ? { actor: runOptions.actor } : {}),
       flowContext,
     };
 

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -6,6 +6,7 @@
  * human approval gates, and AI completion steps.
  */
 
+import type { Actor } from "./action";
 import type { FlowSemantics } from "./meta-semantics";
 
 // ── Flow triggers ──────────────────────────────────────
@@ -239,4 +240,16 @@ export interface FlowInstance {
   error?: { stepId: string; message: string };
   /** Log of compensation actions executed during Saga rollback */
   compensationLog?: CompensationLogEntry[];
+  /**
+   * Tenant scope this instance runs under (if multi-tenant). Persisted so that
+   * `onComplete`-chained downstream flows inherit the originating tenant rather
+   * than running with no tenant scope. Optional for back-compat.
+   */
+  tenantId?: string;
+  /**
+   * Actor who triggered this instance. Persisted so that `onComplete`-chained
+   * downstream flows inherit the originating actor rather than falling back to
+   * the default/system actor. Optional for back-compat.
+   */
+  actor?: Actor;
 }


### PR DESCRIPTION
## Summary

Follow-up to #477 (closes a tenant-isolation gap deferred there). `onComplete` flow chains dropped tenant + actor scope.

## Verified gap

`processOnCompleteChains` started each downstream chained flow with `{ tenantId: undefined }` and no actor (the "inherit from context if available" comment was never implemented). So an `onComplete`-chained flow ran with **no tenant scope and the default system actor** — able to read/write records outside the originating tenant. The reference pattern (`action-rule-effects.ts`) forwards both.

## Changes

- `FlowInstance` now persists the run's `tenantId` + `actor` (both optional → backward-compatible).
- `processOnCompleteChains` forwards `instance.tenantId` + `instance.actor` to the chained `startFlow`. No function signature change.
- `flow-chaining.test.ts`: 4 tests proving the downstream flow inherits the parent's tenant + actor (fail-first verified against the old `undefined` behavior); existing chain tests stay green.

## Verification

`bun run check`, `bun run typecheck`, full `bun run test` all green. Reviewed by codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
