### PR TITLE
fix(adapter-server): deliver action-driven SSE events for CRUD writes (#482)

### DIFF
--- a/.changeset/sse-action-delivery.md
+++ b/.changeset/sse-action-delivery.md
@@ -1,0 +1,13 @@
+---
+"@linchkit/core": patch
+"@linchkit/cap-adapter-server": patch
+---
+
+fix: deliver action-driven SSE events for CRUD writes
+
+CRUD actions emitted `record.created`/`updated`/`deleted` with a `schema` payload
+field but no `entity`, so the action-engine event flush set the bus `EventRecord`'s
+`entity` to `undefined` and `SubscriptionManager.dispatchEvent` dropped the event —
+action-driven create/update/delete never reached SSE subscribers. CRUD actions now
+emit the canonical `entity` field (keeping `schema` as a legacy alias), and the
+event flush falls back to `payload.schema` when `entity` is absent (#482).

--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-action-sse-delivery.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-action-sse-delivery.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Action-driven SSE delivery e2e (in-process, DB-free, port-free).
+ *
+ * Regression guard for issue #482: action-driven SSE delivery was broken for
+ * CRUD writes. The chain that failed:
+ *   1. `build-crud-actions.ts` emitted `record.created` with a `schema` field
+ *      but NO `entity` field.
+ *   2. `action-engine.ts` flushed pending events to the bus reading
+ *      `pe.payload.entity` — which was `undefined` for CRUD emits.
+ *   3. `subscription-manager.ts` `dispatchEvent` early-returns when
+ *      `event.entity` is missing → SSE subscribers NEVER received
+ *      action-driven create/update/delete events.
+ *
+ * Unlike `e2e-sse-subscribe.test.ts` (which works around the bug by emitting a
+ * hand-shaped `EventRecord` with `entity` already set directly on the bus), this
+ * test drives the REAL path: it opens an SSE subscription and then creates a
+ * record THROUGH A CRUD ACTION (GraphQL `create_<entity>` mutation). That
+ * exercises build-crud-actions → action-engine event flush → SubscriptionManager,
+ * proving the whole chain delivers the event to the open SSE stream.
+ *
+ * Dispatch is in-process via `app.handle(new Request(...))` ONLY — never
+ * `app.listen(PORT)` (a bound socket passes in isolation but SEGFAULTS the
+ * batched runner). The streaming read uses a hard timeout so the test can never
+ * hang, and cleanup cancels the reader (never `app.stop()`).
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { CapabilityDefinition, EntityDefinition } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { capAdapterServer } from "../src/capability";
+import { createDevApp } from "../src/dev-app";
+
+// ── Synthetic business capability (inline) ───────────────────────────────────
+//
+// One entity with its auto-generated CRUD — enough to mount the entity into the
+// registry so the SSE permission checker recognizes it as a readable schema and
+// so `create_sse_task` exists as a GraphQL mutation.
+
+const taskEntity: EntityDefinition = {
+  name: "sse_task",
+  label: "SSE Task",
+  description: "Synthetic entity for the action-driven SSE delivery e2e",
+  fields: {
+    title: { type: "string", required: true, label: "Title", ui: { importance: "primary" } },
+  },
+};
+
+const capSseBusiness: CapabilityDefinition = defineCapability({
+  name: "cap-sse-action-business",
+  label: "SSE Action Business",
+  description:
+    "Synthetic business capability (inline) — one entity for action-driven SSE delivery tests",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [taskEntity],
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Read one SSE frame (text up to the `\n\n` terminator) from a stream reader,
+ * bounded by a hard timeout so the test can never hang. Resolves to the
+ * accumulated text on the first chunk (or "" if the timeout fires first).
+ *
+ * Mirrors the helper in `e2e-sse-subscribe.test.ts`, including clearing the
+ * timer in `finally` so it does not linger as a background timer.
+ */
+async function readChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  decoder: TextDecoder,
+  timeoutMs: number,
+): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{ value: undefined; done: true }>((resolve) => {
+    timer = setTimeout(() => resolve({ value: undefined, done: true }), timeoutMs);
+  });
+  try {
+    const result = await Promise.race([reader.read(), timeout]);
+    return result.value ? decoder.decode(result.value) : "";
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** POST a GraphQL operation through `app.handle` (no port, no network). */
+async function postGraphQL(
+  app: ReturnType<typeof createDevApp>["app"],
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<Response> {
+  return app.handle(
+    new Request("http://local.test/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query, variables }),
+    }),
+  );
+}
+
+// ── Type helpers (no `any`) ──────────────────────────────────────────────────
+
+interface CreatedTask {
+  id: string;
+  title: string;
+}
+
+interface CreateTaskResponse {
+  data: { createSseTask: CreatedTask } | null;
+  errors?: Array<{ message: string }>;
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("action-driven SSE delivery e2e (in-process, DB-free, port-free)", () => {
+  it("delivers record.created over SSE when a record is created THROUGH a CRUD action", async () => {
+    const { app } = createDevApp([capAdapterServer, capSseBusiness], { cors: false });
+
+    // Open the SSE subscription FIRST so the connection is registered before the
+    // action fires. In-memory delivery is synchronous, so once the create action
+    // resolves the event has already been pushed into this stream's buffer.
+    const subRes = await app.handle(
+      new Request("http://local.test/api/subscribe?entities=sse_task", { method: "GET" }),
+    );
+    expect(subRes.status).toBe(200);
+    expect(subRes.headers.get("content-type")).toContain("text/event-stream");
+
+    const reader = (subRes.body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+
+    // Drain the initial `connected` frame so the next read targets our event.
+    const connected = await readChunkWithTimeout(reader, decoder, 2000);
+    expect(connected).toContain("event: connected");
+
+    // Create a record THROUGH THE CRUD ACTION (GraphQL create mutation). This is
+    // the REAL path under test: build-crud-actions emits `record.created`, the
+    // action engine flushes it to the bus, and the SubscriptionManager dispatches
+    // it to this open subscription. Before the #482 fix the CRUD emit carried
+    // only `schema` (no `entity`), so the bus EventRecord had `entity:
+    // undefined` and `dispatchEvent` early-returned — the read below would then
+    // time out to "".
+    const createRes = await postGraphQL(
+      app,
+      `mutation CreateTask($input: SseTaskInput!) {
+        createSseTask(input: $input) {
+          id
+          title
+        }
+      }`,
+      { input: { title: "ship it" } },
+    );
+    expect(createRes.status).toBe(200);
+
+    const createBody = (await createRes.json()) as CreateTaskResponse;
+    expect(createBody.errors).toBeUndefined();
+    const created = createBody.data?.createSseTask;
+    expect(created).toBeDefined();
+    expect(typeof created?.id).toBe("string");
+    expect(created?.id).toBeTruthy();
+    expect(created?.title).toBe("ship it");
+
+    const createdId = created?.id as string;
+
+    // The action-driven event must arrive on the open SSE stream as a
+    // `record.created` frame carrying the canonical `entity` name and the right
+    // recordId. A bounded read keeps the test from hanging if the chain is broken.
+    const eventFrame = await readChunkWithTimeout(reader, decoder, 2000);
+    expect(eventFrame).toContain("event: record.created");
+    expect(eventFrame).toContain('"entity":"sse_task"');
+    expect(eventFrame).toContain(`"recordId":"${createdId}"`);
+
+    // Cancelling the reader closes the SSE stream, removing the subscription and
+    // clearing its per-connection heartbeat/idle timers. Never call app.stop().
+    await reader.cancel();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-crud-actions.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-crud-actions.ts
@@ -136,12 +136,15 @@ export function generateCrudActions(
       }
       const result = await ctx.create(name, inputWithDefaults);
       ctx.emit("record.created", {
+        // Spread record data FIRST so the routing metadata below always wins,
+        // even if a record field happens to be named `entity`/`schema`/`recordId`
+        // (the action engine prefers `payload.entity` for SSE routing).
+        ...result,
         entity: name,
         // Legacy alias — kept alongside the canonical `entity` for consumers
         // that still read `payload.schema` (e.g. cap-search fallback chain).
         schema: name,
         recordId: result.id as string,
-        ...result,
       });
       // Cascade recalculate parent aggregate fields if this child schema affects any
       if (derivedEngine?.hasCascadeTargets(name)) {

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-crud-actions.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-crud-actions.ts
@@ -136,6 +136,9 @@ export function generateCrudActions(
       }
       const result = await ctx.create(name, inputWithDefaults);
       ctx.emit("record.created", {
+        entity: name,
+        // Legacy alias — kept alongside the canonical `entity` for consumers
+        // that still read `payload.schema` (e.g. cap-search fallback chain).
         schema: name,
         recordId: result.id as string,
         ...result,
@@ -215,6 +218,9 @@ export function generateCrudActions(
         (k) => before[k] !== (result as Record<string, unknown>)[k],
       );
       ctx.emit("record.updated", {
+        entity: name,
+        // Legacy alias — kept alongside the canonical `entity` for consumers
+        // that still read `payload.schema` (e.g. cap-search fallback chain).
         schema: name,
         recordId: id,
         _old: before,
@@ -262,6 +268,9 @@ export function generateCrudActions(
       }
       await ctx.delete(name, id);
       ctx.emit("record.deleted", {
+        entity: name,
+        // Legacy alias — kept alongside the canonical `entity` for consumers
+        // that still read `payload.schema` (e.g. cap-search fallback chain).
         schema: name,
         recordId: id,
         id,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1670,14 +1670,17 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                 actor: { type: actor.type, id: actor.id },
                 // Legacy emitters (e.g. CRUD actions) populate `schema` rather
                 // than `entity`; fall back so the bus EventRecord always carries
-                // the entity name for SSE routing.
+                // the entity name for SSE routing. `payload` is typed non-null,
+                // but this flush is wrapped in a silent catch — optional chaining
+                // keeps a malformed (untyped) emit from dropping the whole batch.
                 entity:
-                  typeof pe.payload.entity === "string"
+                  typeof pe.payload?.entity === "string"
                     ? pe.payload.entity
-                    : typeof pe.payload.schema === "string"
+                    : typeof pe.payload?.schema === "string"
                       ? pe.payload.schema
                       : undefined,
-                recordId: typeof pe.payload.recordId === "string" ? pe.payload.recordId : undefined,
+                recordId:
+                  typeof pe.payload?.recordId === "string" ? pe.payload.recordId : undefined,
                 tenantId: pe.tenantId,
                 executionId: pe.sourceExecutionId ?? executionId,
                 payload: pe.payload,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1668,7 +1668,15 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                 category: pe.type.startsWith("record.") ? "change" : "custom",
                 timestamp: new Date(),
                 actor: { type: actor.type, id: actor.id },
-                entity: typeof pe.payload.entity === "string" ? pe.payload.entity : undefined,
+                // Legacy emitters (e.g. CRUD actions) populate `schema` rather
+                // than `entity`; fall back so the bus EventRecord always carries
+                // the entity name for SSE routing.
+                entity:
+                  typeof pe.payload.entity === "string"
+                    ? pe.payload.entity
+                    : typeof pe.payload.schema === "string"
+                      ? pe.payload.schema
+                      : undefined,
                 recordId: typeof pe.payload.recordId === "string" ? pe.payload.recordId : undefined,
                 tenantId: pe.tenantId,
                 executionId: pe.sourceExecutionId ?? executionId,


### PR DESCRIPTION
## Problem (#482)

Action-driven SSE delivery was broken for CRUD writes. The chain:

1. `build-crud-actions.ts` emitted `record.created`/`updated`/`deleted` with a `schema` payload field but **no `entity`**.
2. `action-engine.ts` flushed pending events to the EventBus reading `pe.payload.entity` — `undefined` for CRUD emits.
3. `subscription-manager.ts` `dispatchEvent` early-returns when `event.entity` is missing → SSE subscribers **never received** action-driven create/update/delete.

The `#478` SSE e2e only worked around this by emitting a hand-shaped `EventRecord` (with `entity` set) directly on the bus.

## Fix

- **CRUD producer** (`build-crud-actions.ts`): emit the canonical `entity` field on all three emits, keeping `schema` as a legacy alias (one live consumer — `cap-search`'s `event.entity → payload.entity → payload.schema` fallback chain — so removing it was avoided).
- **Core flush** (`action-engine.ts`): fall back to `payload.schema` when `payload.entity` is absent, so any other legacy `schema`-only emitter still routes.
- **Regression test** (`e2e-action-sse-delivery.test.ts`, new): drives the **real** path — opens an SSE subscription, creates a record **through a CRUD action** (GraphQL `createSseTask`), and asserts the stream delivers `record.created` with the right `entity` + `recordId`. In-process via `app.handle` (no socket), bounded reads, `reader.cancel()` cleanup, DB-free.

## Codex review addressed

Codex flagged (P2) that `record.created` spread `...result` **after** the routing keys, so a created record with a field literally named `entity`/`schema`/`recordId` would overwrite the routing metadata (and, now that the engine prefers `payload.entity`, misroute the event). Fixed by spreading record data first so routing keys always win. (`update`/`delete` nest record data under `_new`/no spread — already safe.)

## Validation

- `bun run typecheck`, `bun run check`: clean.
- `bun run test` (batched runner): all batches PASS (addons 2265 pass / 0 fail clean exit; new e2e: 1 pass / 12 expect).

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-sent events (SSE) delivery for CRUD operations so write events are reliably dispatched to subscribers by including the canonical entity metadata (while preserving legacy schema alias).

* **Tests**
  * Added an end-to-end test that validates SSE delivery for CRUD write operations and asserts emitted event type, entity name, and record ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->