### PR TITLE
feat(cli): wire dormant evolution-loop proposal generation into dev boot path

### DIFF
--- a/.changeset/wire-evolution-loop-proposals.md
+++ b/.changeset/wire-evolution-loop-proposals.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cli": minor
+---
+
+Wire the Spec-55 evolution loop's dormant proposal generation into the live `linch dev` boot path. The dev runtime now passes `ontology`, `translatorRegistry`, `proposalCapability`, and a dedup+impact pre-analysis pipeline to `createEvolutionRuntime()`, so surfaced insights are translated into analyzed proposals instead of dead-ending at the Insight stage. Proposals appear strictly as data on the cycle result — no graduation (file write / git commit) is wired.

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -31,9 +31,16 @@ import type {
 } from "@linchkit/core";
 import {
   type ConfigRegistry,
+  createDedupAnalyzer,
+  createDefaultInsightTranslatorRegistry,
   createDerivedPropertyEngine,
   createDispatchQuery,
   createEvolutionRuntime,
+  createImpactAnalyzer,
+  createPreAnalysisPipeline,
+  type ImpactDataProvider,
+  type PendingProposalStore,
+  type ProposalDefinition,
 } from "@linchkit/core";
 import {
   type ActionRegistry,
@@ -539,12 +546,77 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
   // Dispatch query routes `execution_log` → ExecutionLogger and other schemas
   // → DataProvider. Without this split, sensors reading execution_log would
   // silently see zero rows in both PostgreSQL and in-memory dev modes.
+  //
+  // The runtime must ALSO receive `ontology` + `translatorRegistry` for the
+  // cycle to translate surfaced insights into proposals (Spec 55 §7). Without
+  // BOTH, structural checks have no input and `result.proposals` stays `[]` —
+  // the live loop dead-ends at Insight. We supply the same ontologyRegistry the
+  // transport uses, the default structural translator registry, and a
+  // pre-analysis pipeline so every proposal arrives with a reviewer envelope
+  // (dedup + impact) attached on `result.proposalAnalyses`.
+  //
+  // SAFETY: this produces proposals as DATA only. No graduation is wired —
+  // nothing here writes files, commits, or opens PRs (Spec 55 §7.6/§7.7 are
+  // intentionally NOT instantiated in the dev boot path).
+
+  // Real impact provider: the impact analyzer's narrow ImpactDataProvider
+  // contract (countRecords / sampleRecordIds) maps directly onto the overlay-
+  // aware DataProvider already in scope, so dev proposals get true first-order
+  // record counts instead of stubbed zeros.
+  const impactDataProvider: ImpactDataProvider = {
+    async countRecords(entity, filter) {
+      return overlayAwareDataProvider.count(entity, filter);
+    },
+    async sampleRecordIds(entity, limit, filter) {
+      const safeLimit = Math.max(0, limit);
+      if (safeLimit === 0) return [];
+      // Push the limit into the query so the provider fetches only the sample
+      // rows. Both DrizzleDataProvider and InMemoryStore honor the `limit` filter
+      // key, so this avoids scanning + materializing a whole table just to return
+      // a handful of ids. The post-fetch slice stays as a defensive cap in case a
+      // provider ignores the hint.
+      const rows = await overlayAwareDataProvider.query(entity, {
+        ...(filter ?? {}),
+        limit: safeLimit,
+      });
+      return rows
+        .slice(0, safeLimit)
+        .map((row) => String((row as { id?: unknown }).id ?? ""))
+        .filter((id) => id.length > 0);
+    },
+  };
+
+  // Empty pending-proposal store: dev-wiring instantiates no ProposalEngine /
+  // proposal repository, so there is no live pending set to dedup against. The
+  // dedup stage still runs (proving the pipeline executes) and reports an empty
+  // similar list. Wiring a real store would require standing up proposal
+  // persistence, which is out of scope for G1.
+  // TODO(G1 follow-up): back with the real PendingProposalStore once a proposal
+  // repository (e.g. ProposalEngine's pending view) is available in dev-wiring.
+  const pendingProposalStore: PendingProposalStore = {
+    async listPending(): Promise<ProposalDefinition[]> {
+      return [];
+    },
+  };
+
+  const proposalPreAnalysisPipeline = createPreAnalysisPipeline({
+    analyzers: [
+      createDedupAnalyzer({ store: pendingProposalStore }),
+      createImpactAnalyzer({ dataProvider: impactDataProvider }),
+    ],
+  });
+
   const evolutionRuntime = createEvolutionRuntime({
     sensors,
     query: createDispatchQuery({ dataProvider: overlayAwareDataProvider, executionLogger }),
+    ontology: ontologyRegistry,
+    translatorRegistry: createDefaultInsightTranslatorRegistry(),
+    proposalCapability: "linch-dev",
+    proposalPreAnalysisPipeline,
   });
   consoleLogger.info(
-    `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered`,
+    `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered ` +
+      "(insight→proposal translator + pre-analysis pipeline wired)",
   );
 
   const transportCtx: TransportContext = {

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -568,7 +568,9 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
       return overlayAwareDataProvider.count(entity, filter);
     },
     async sampleRecordIds(entity, limit, filter) {
-      const safeLimit = Math.max(0, limit);
+      // Guard against NaN/Infinity/fractional limits: Math.max(0, NaN) is NaN,
+      // which would slip past a `=== 0` check and reach the query/slice.
+      const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 0;
       if (safeLimit === 0) return [];
       // Push the limit into the query so the provider fetches only the sample
       // rows. Both DrizzleDataProvider and InMemoryStore honor the `limit` filter
@@ -581,7 +583,11 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
       });
       return rows
         .slice(0, safeLimit)
-        .map((row) => String((row as { id?: unknown }).id ?? ""))
+        .map((row) =>
+          row && typeof row === "object" && "id" in row
+            ? String((row as { id?: unknown }).id ?? "")
+            : "",
+        )
         .filter((id) => id.length > 0);
     },
   };

--- a/packages/core/src/__tests__/life-system/runtime-live-proposals.test.ts
+++ b/packages/core/src/__tests__/life-system/runtime-live-proposals.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Live evolution-cycle proposal wiring (Spec 55 §7) — G1 regression guard.
+ *
+ * The `linch dev` boot path constructs the evolution runtime via
+ * `createEvolutionRuntime({...})`. Before G1 it passed only `sensors` + `query`,
+ * so `ontology` fell back to an empty stub and `translatorRegistry` was omitted —
+ * meaning the structural check had no input AND no translator, so the cycle
+ * dead-ended at Insight and `result.proposals` was always `[]`.
+ *
+ * This test reconstructs the runtime EXACTLY as dev-wiring now wires it (the
+ * same four options: an ontology carrying a view-less entity, the default
+ * translator registry, the `proposalCapability` label, and the dedup+impact
+ * pre-analysis pipeline) and asserts the loop now emits an analyzed proposal.
+ *
+ * dev-wiring itself builds a full server context (too heavy to invoke here), so
+ * this focuses on the runtime composition contract that wiring depends on.
+ *
+ * SAFETY: this asserts proposals appear as DATA on the cycle result only. The
+ * runtime exposes no committer/file-writer surface, so no graduation can occur
+ * by construction — see the explicit assertion at the end.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createDedupAnalyzer,
+  createDefaultInsightTranslatorRegistry,
+  createImpactAnalyzer,
+  createPreAnalysisPipeline,
+} from "../../life-system";
+import { defineSensor } from "../../life-system/define-sensor";
+import type {
+  ImpactDataProvider,
+  PendingProposalStore,
+} from "../../life-system/proposal-preanalysis/types";
+import { createEvolutionRuntime } from "../../life-system/runtime";
+import type { EntityDescriptor, OntologyRegistry } from "../../ontology/ontology-registry";
+import type { SensorContext, SensorSignal } from "../../types/life-system";
+import type { ProposalDefinition } from "../../types/proposal";
+
+const FROZEN_NOW = new Date("2026-06-06T00:00:00.000Z");
+
+/**
+ * Tiny in-process ontology carrying one entity (`metric_sample`) that has NO
+ * view — the trigger for the `schema_no_view` structural issue → insight →
+ * `add_view` proposal pipeline. No-op stubs satisfy the rest of the contract.
+ */
+function createViewlessOntology(): OntologyRegistry {
+  const schemas: Record<string, Partial<EntityDescriptor>> = {
+    metric_sample: {
+      views: [],
+      actions: [],
+      fields: {
+        id: { type: "string" },
+        value: { type: "number" },
+      } as EntityDescriptor["fields"],
+    },
+  };
+
+  return {
+    describe: (name) => schemas[name] as EntityDescriptor | undefined,
+    listEntities: () => Object.keys(schemas),
+    searchEntities: () => [],
+    actionsFor: () => [],
+    rulesFor: () => [],
+    stateFor: () => undefined,
+    viewsFor: () => [],
+    flowsFor: () => [],
+    handlersFor: () => [],
+    relatedEntities: () => [],
+    entitiesImplementing: () => [],
+    toJSON: () => ({}) as ReturnType<OntologyRegistry["toJSON"]>,
+    toMarkdown: () => "",
+    searchByIntent: () => [],
+    searchByDomain: () => [],
+    getSemanticsFor: () => undefined,
+    dependencyGraph: (ref) => ({ root: ref, nodes: [ref], edges: [] }),
+    impactAnalysis: (ref) => [[ref]],
+  };
+}
+
+/** Single-emit sensor so one `runCycle()` has exactly one signal to ingest. */
+function createOneShotSensor() {
+  let emitted = false;
+  return defineSensor({
+    name: "metric_sample_tick",
+    source: "server",
+    entity: "metric_sample",
+    async detect(ctx: SensorContext): Promise<SensorSignal | null> {
+      if (emitted) return null;
+      emitted = true;
+      return {
+        sensor: "metric_sample_tick",
+        source: "server",
+        timestamp: ctx.timestamp,
+        value: 42,
+        baseline: 40,
+        deviation: 0.05,
+        confidence: 0.95,
+        context: { entity: "metric_sample", metric: "value", tenantId: "dev" },
+      };
+    },
+  });
+}
+
+/** Empty stores mirroring dev-wiring's stubs — the pipeline still runs. */
+function createEmptyPendingProposalStore(): PendingProposalStore {
+  return {
+    async listPending(): Promise<ProposalDefinition[]> {
+      return [];
+    },
+  };
+}
+
+function createEmptyImpactDataProvider(): ImpactDataProvider {
+  return {
+    async countRecords(): Promise<number> {
+      return 0;
+    },
+    async sampleRecordIds(): Promise<string[]> {
+      return [];
+    },
+  };
+}
+
+describe("createEvolutionRuntime — live proposal wiring (G1)", () => {
+  it("emits an analyzed add_view proposal for a view-less entity (matches dev-wiring options)", async () => {
+    // Construct the runtime with the SAME option shape dev-wiring now uses:
+    // ontology + translatorRegistry + proposalCapability + preanalysis pipeline.
+    const runtime = createEvolutionRuntime({
+      sensors: [createOneShotSensor()],
+      ontology: createViewlessOntology(),
+      translatorRegistry: createDefaultInsightTranslatorRegistry(),
+      proposalCapability: "linch-dev",
+      proposalPreAnalysisPipeline: createPreAnalysisPipeline({
+        analyzers: [
+          createDedupAnalyzer({ store: createEmptyPendingProposalStore() }),
+          createImpactAnalyzer({ dataProvider: createEmptyImpactDataProvider() }),
+        ],
+      }),
+    });
+
+    const result = await runtime.evolutionCycle.runCycle({ timestamp: FROZEN_NOW });
+
+    // Insight: the view-less entity surfaced a structural insight.
+    const structural = result.newInsights.filter((i) => i.type === "structural");
+    expect(structural).toHaveLength(1);
+    expect(structural[0]?.entity).toBe("metric_sample");
+
+    // Proposal: the default translator produced at least one add_view proposal.
+    expect(result.proposals.length).toBeGreaterThan(0);
+    const addView = result.proposals.find((p) =>
+      p.changes.some((c) => c.target === "view" && c.operation === "create"),
+    );
+    expect(addView).toBeDefined();
+    if (!addView) throw new Error("expected an add_view proposal");
+    expect(addView.capability).toBe("linch-dev");
+    // The cycle timestamp propagates to the proposal stamp.
+    expect(addView.createdAt.getTime()).toBe(FROZEN_NOW.getTime());
+
+    // Pre-analysis: the pipeline ran — proposalAnalyses is populated 1:1.
+    expect(result.proposalAnalyses).toHaveLength(result.proposals.length);
+    expect(result.proposalAnalyses.length).toBeGreaterThan(0);
+    const analysis = result.proposalAnalyses[0];
+    if (!analysis) throw new Error("expected a pre-analysis envelope");
+    expect(analysis.stages.dedup?.status).toBe("ok");
+    expect(analysis.stages.impact?.status).toBe("ok");
+    expect(analysis.allStagesSucceeded).toBe(true);
+
+    // SAFETY (by construction): the runtime surface carries NO graduation hook —
+    // no committer, file-writer, or git path. Proposals are pure cycle DATA.
+    const runtimeKeys = Object.keys(runtime);
+    expect(runtimeKeys).toEqual([
+      "signalBus",
+      "evolutionCycle",
+      "insightEngine",
+      "awarenessEngine",
+    ]);
+    expect(runtimeKeys).not.toContain("committer");
+    expect(runtimeKeys).not.toContain("fileWriter");
+    expect((runtime as unknown as { gitCommitter?: unknown }).gitCommitter).toBeUndefined();
+  });
+
+  it("emits NO proposals when ontology + translator are omitted (pre-G1 dead-end regression guard)", async () => {
+    // The exact pre-G1 dev-wiring call shape: only sensors + (here) no query.
+    // Without ontology the structural check has no input; without a translator
+    // registry nothing translates — so the cycle dead-ends at Insight.
+    const runtime = createEvolutionRuntime({
+      sensors: [createOneShotSensor()],
+    });
+
+    const result = await runtime.evolutionCycle.runCycle({ timestamp: FROZEN_NOW });
+
+    expect(result.proposals).toEqual([]);
+    expect(result.proposalAnalyses).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

The Spec-55 evolution loop (Sense→Memory→Awareness→Insight→Proposal) is fully built and unit-tested, but the **live `linch dev` boot path** called `createEvolutionRuntime()` with only `sensors` + `query` — omitting `ontology` and `translatorRegistry`. Without an ontology the structural check has no input, and without a translator nothing translates, so the cycle **silently dead-ended at Insight** and `result.proposals` was always empty. This was a "demo works e2e but the live path is dormant" gap (G1).

## Change

Wire the four missing options at the dev-wiring call site (`packages/cli/src/commands/dev-wiring.ts`):

- `ontology: ontologyRegistry` — the same registry the transport uses, so structural checks (`schema_no_view`, `action_never_called`) actually produce insights.
- `translatorRegistry: createDefaultInsightTranslatorRegistry()` — so insights become proposals.
- `proposalCapability: "linch-dev"`.
- `proposalPreAnalysisPipeline` (dedup + impact). **Impact uses a real provider** backed by the overlay-aware DataProvider (true first-order record counts); dedup uses an empty stub (no proposal repository in dev yet) with a `TODO`.

## Safety boundary (important)

Proposals appear **strictly as data** on the cycle result. **No graduation is wired** — no `ProposalEngine` onApproved hook, `ProposalFileWriter`, or `ProposalGitCommitter` is instantiated in the dev boot path. Nothing writes files, commits, or opens PRs. A test asserts the runtime surface carries **no committer** (graduation impossible by construction).

## Tests

`packages/core/src/__tests__/life-system/runtime-live-proposals.test.ts`:
- Reconstructs the runtime with the exact options dev-wiring now uses → asserts a `structural` insight surfaces, an `add_view` proposal is produced (stamped `linch-dev`), and `proposalAnalyses` is populated 1:1; plus a safety assertion that the runtime exposes no committer.
- A pre-G1 dead-end regression guard: sensors-only runtime → `proposals` and `proposalAnalyses` are both `[]`.

## Review

Cross-model reviewed (codex + gemini). codex flagged a P2: the impact sampler loaded a full table before slicing — **fixed** to push `limit` into the query (both Drizzle and InMemory honor the `limit` filter key).

## Gates

`bun run check`, `bun run typecheck`, full `bun run test` (batched runner) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The dev runtime now automatically generates, translates, and analyzes proposals during the evolution loop.
  * Analyzed proposals are returned as data without file writing or git commits.

* **Tests**
  * Added regression tests to validate live proposal wiring, translation, and analysis stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->