### PR TITLE
feat(adapter-ui): add natural-language rule drafting surface ("说→有")

### DIFF
--- a/.changeset/nl-rule-drafting-surface.md
+++ b/.changeset/nl-rule-drafting-surface.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cap-adapter-ui": minor
+---
+
+Add a natural-language rule-drafting surface ("说→有"). A new `resolveSchemaIntent` API client and `NlRuleDrafter` component (mounted on the Evolution page) let users describe a rule in natural language; the server mints a governed draft Proposal that flows into the existing human-gated review pipeline. The surface renders every outcome state (draft / clarification / no_match / unavailable / error) and never submits, approves, or applies.

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/resolve-schema-intent.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/resolve-schema-intent.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the `resolveSchemaIntent` client (Spec 52 — "说→有").
+ *
+ * The client maps the server's discriminated `ResolveSchemaIntentResponse`
+ * (proposal_draft / clarification / no_match, plus 503 / 4xx-5xx / transport
+ * error) onto a discriminated `ResolveSchemaIntentResult` the UI renders.
+ *
+ * We inject a stub `fetch` via the `fetchImpl` option so the assertions never
+ * rely on a GLOBAL fetch mock — a global stub would leak across the batched
+ * suite and clobber other tests' network calls. Each case builds its own
+ * `Response` and asserts the mapping.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+// Minimal localStorage shim — the client calls getAuthHeaders() which reads
+// localStorage. The bun test runner has no DOM; mirror tenant.test.ts.
+const store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+      key: (index: number) => [...store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import { resolveSchemaIntent } from "../src/lib/api";
+
+/** Build a JSON Response with a given status + body. */
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** A `fetch` stub that always returns the given response and records the call. */
+function stubFetch(response: Response | (() => Response | Promise<Response>)): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; init?: RequestInit }>;
+} {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return typeof response === "function" ? await response() : response;
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("resolveSchemaIntent client", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("posts the prompt to the resolve-schema-intent endpoint", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonResponse(200, { outcome: "no_match", reason: "n/a" }),
+    );
+    await resolveSchemaIntent("hello world", { fetchImpl });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("/api/ai/resolve-schema-intent");
+    expect(calls[0]?.init?.method).toBe("POST");
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ prompt: "hello world" });
+  });
+
+  test("maps proposal_draft to a draft result with id/status/confidence", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, {
+        outcome: "proposal_draft",
+        proposalId: "prop_123",
+        proposalStatus: "draft",
+        ruleName: "require_approver_high_value",
+        targetEntity: "purchase_order",
+        confidence: 0.82,
+        explanation: "Require an approver when total > 10000",
+      }),
+    );
+    const result = await resolveSchemaIntent("require approver for big orders", { fetchImpl });
+    expect(result.kind).toBe("proposal_draft");
+    if (result.kind !== "proposal_draft") return;
+    expect(result.draft).toEqual({
+      proposalId: "prop_123",
+      proposalStatus: "draft",
+      ruleName: "require_approver_high_value",
+      targetEntity: "purchase_order",
+      confidence: 0.82,
+      explanation: "Require an approver when total > 10000",
+    });
+  });
+
+  test("maps clarification to a clarification result with the question", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, {
+        outcome: "clarification",
+        question: "Which entity should this rule apply to?",
+        bestConfidence: 0.4,
+      }),
+    );
+    const result = await resolveSchemaIntent("require approval", { fetchImpl });
+    expect(result.kind).toBe("clarification");
+    if (result.kind !== "clarification") return;
+    expect(result.question).toBe("Which entity should this rule apply to?");
+    expect(result.bestConfidence).toBe(0.4);
+  });
+
+  test("maps no_match to a no_match result with the reason", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, {
+        outcome: "no_match",
+        reason: "No entity matched the description.",
+        message: "try again",
+      }),
+    );
+    const result = await resolveSchemaIntent("xyzzy", { fetchImpl });
+    expect(result.kind).toBe("no_match");
+    if (result.kind !== "no_match") return;
+    expect(result.reason).toBe("No entity matched the description.");
+    expect(result.message).toBe("try again");
+  });
+
+  test("maps 503 to an unavailable result with the structured message", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(503, {
+        success: false,
+        error: {
+          code: "SERVICE.UNAVAILABLE",
+          message: "AI service is not configured.",
+        },
+      }),
+    );
+    const result = await resolveSchemaIntent("draft a rule", { fetchImpl });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.message).toBe("AI service is not configured.");
+  });
+
+  test("maps a 400 validation error to an error result", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(400, {
+        success: false,
+        error: { code: "VALIDATION.FAILED", message: "prompt must be a non-empty string" },
+      }),
+    );
+    const result = await resolveSchemaIntent("", { fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("prompt must be a non-empty string");
+  });
+
+  test("maps a 500 to an error result", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(500, {
+        success: false,
+        error: { code: "AI.RESOLVE_SCHEMA_INTENT.FAILED", message: "boom" },
+      }),
+    );
+    const result = await resolveSchemaIntent("draft a rule", { fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("boom");
+  });
+
+  test("maps a transport-level throw to an error result", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+    const result = await resolveSchemaIntent("draft a rule", { fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("network down");
+  });
+
+  test("maps an unknown outcome to an error result", async () => {
+    const { fetchImpl } = stubFetch(jsonResponse(200, { outcome: "something_new" }));
+    const result = await resolveSchemaIntent("draft a rule", { fetchImpl });
+    expect(result.kind).toBe("error");
+  });
+
+  test("falls back to a generic 503 message when the body is non-JSON", async () => {
+    const { fetchImpl } = stubFetch(new Response("not json", { status: 503 }));
+    const result = await resolveSchemaIntent("draft a rule", { fetchImpl });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    // No structured message — `message` is undefined; the UI shows its own
+    // localized "not configured" fallback.
+    expect(result.message).toBeUndefined();
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/nl-rule-drafter.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/nl-rule-drafter.tsx
@@ -70,6 +70,14 @@ export function NlRuleDrafter() {
       if (outcome.kind === "proposal_draft") {
         setPrompt("");
       }
+    } catch (err) {
+      // resolveSchemaIntent maps transport errors internally, but a defensive
+      // catch keeps an unexpected throw (e.g. handleUnauthorized, or storage
+      // access denied) from becoming an unhandled rejection with no UI feedback.
+      setResult({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Schema intent resolution failed",
+      });
     } finally {
       setSubmitting(false);
     }
@@ -101,6 +109,7 @@ export function NlRuleDrafter() {
             onChange={(e) => setPrompt(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t("nlRule.placeholder")}
+            aria-label={t("nlRule.title")}
             rows={2}
             className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             disabled={submitting}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/nl-rule-drafter.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/nl-rule-drafter.tsx
@@ -1,0 +1,237 @@
+/**
+ * NlRuleDrafter — "say it → it exists" (说→有) rule drafting affordance.
+ *
+ * A focused, self-contained surface for turning a natural-language utterance
+ * into a GOVERNED rule draft via `POST /api/ai/resolve-schema-intent`. Placed on
+ * the Evolution page (the proposal / evolution management surface) so the draft
+ * it produces sits next to the review pipeline it feeds.
+ *
+ * Hard rule ("AI Never Modifies Production Directly"): the endpoint persists a
+ * `draft`-status Proposal only — this component NEVER submits, approves, or
+ * applies anything. On a `proposal_draft` outcome it surfaces the draft and
+ * links the user into the existing Proposal review surface.
+ *
+ * Outcome handling mirrors `ai-assistant.tsx`'s `resolveIntent` UX:
+ *  - proposal_draft → draft card (id / status / confidence) + "review" link.
+ *  - clarification  → show the question; the input stays so the user can refine.
+ *  - no_match       → show the reason.
+ *  - unavailable    → graceful "AI not configured" message (503).
+ *  - error          → user-friendly error state.
+ */
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@linchkit/ui-kit/components";
+import { Link } from "@tanstack/react-router";
+import {
+  AlertTriangleIcon,
+  ExternalLinkIcon,
+  HelpCircleIcon,
+  Loader2Icon,
+  SearchXIcon,
+  SparklesIcon,
+  WandSparklesIcon,
+} from "lucide-react";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { type ResolveSchemaIntentResult, resolveSchemaIntent } from "../lib/api";
+
+/**
+ * Format a confidence score (0-1) as a percentage. Defensive against
+ * NaN/Infinity/undefined leaking from a malformed AI response.
+ */
+function formatConfidencePct(confidence: number | undefined): string {
+  if (confidence == null || !Number.isFinite(confidence)) return "—";
+  return `${Math.round(confidence * 100)}%`;
+}
+
+export function NlRuleDrafter() {
+  const { t } = useTranslation();
+  const [prompt, setPrompt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ResolveSchemaIntentResult | null>(null);
+
+  const handleSubmit = useCallback(async () => {
+    const trimmed = prompt.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      const outcome = await resolveSchemaIntent(trimmed);
+      setResult(outcome);
+      // On a successful draft, clear the input so a stale prompt does not look
+      // like it is still pending. For clarification we KEEP the prompt so the
+      // user can refine and resubmit without retyping.
+      if (outcome.kind === "proposal_draft") {
+        setPrompt("");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [prompt, submitting]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        void handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <SparklesIcon className="size-4 text-primary" />
+          {t("nlRule.title")}
+        </CardTitle>
+        <CardDescription>{t("nlRule.subtitle")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-end gap-2">
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={t("nlRule.placeholder")}
+            rows={2}
+            className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            disabled={submitting}
+          />
+          <Button
+            size="sm"
+            onClick={() => void handleSubmit()}
+            disabled={submitting || prompt.trim().length === 0}
+          >
+            {submitting ? (
+              <Loader2Icon className="mr-1 size-3.5 animate-spin" />
+            ) : (
+              <WandSparklesIcon className="mr-1 size-3.5" />
+            )}
+            {t("nlRule.draft")}
+          </Button>
+        </div>
+
+        {result && <SchemaIntentOutcome result={result} t={t} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Outcome renderer ─────────────────────────────────────
+
+function SchemaIntentOutcome({
+  result,
+  t,
+}: {
+  result: ResolveSchemaIntentResult;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  switch (result.kind) {
+    case "proposal_draft": {
+      const { draft } = result;
+      return (
+        <div className="rounded-md border bg-muted/40 p-3 space-y-2" data-testid="draft-outcome">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-sm font-medium">
+              <SparklesIcon className="size-3.5 text-primary" />
+              {draft.ruleName ?? t("nlRule.draftCreated")}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Badge variant="secondary" className="text-[10px] uppercase">
+                {draft.proposalStatus ?? "draft"}
+              </Badge>
+              <Badge variant="outline" className="text-[10px]">
+                {formatConfidencePct(draft.confidence)}
+              </Badge>
+            </div>
+          </div>
+          {draft.explanation && (
+            <p className="text-xs text-muted-foreground">{draft.explanation}</p>
+          )}
+          <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+            {draft.targetEntity && (
+              <span>
+                {t("nlRule.targetEntity")}:{" "}
+                <span className="font-medium">{draft.targetEntity}</span>
+              </span>
+            )}
+            {draft.proposalId && (
+              <span>
+                {t("nlRule.proposalId")}: <span className="font-mono">{draft.proposalId}</span>
+              </span>
+            )}
+          </div>
+          {/* Route the user to the existing review surface — this component never
+              approves or applies; review/approval stays human-gated there. */}
+          <Link to={"/entities/proposal" as "/"}>
+            <Button variant="outline" size="sm" className="h-7 gap-1 text-xs">
+              <ExternalLinkIcon className="size-3" />
+              {t("nlRule.reviewDraft")}
+            </Button>
+          </Link>
+        </div>
+      );
+    }
+
+    case "clarification":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950/30"
+          data-testid="clarification-outcome"
+        >
+          <HelpCircleIcon className="mt-0.5 size-4 shrink-0 text-amber-500" />
+          <div className="space-y-1">
+            {result.question && (
+              <p className="text-sm text-amber-700 dark:text-amber-300">{result.question}</p>
+            )}
+            <p className="text-[11px] text-muted-foreground">{t("nlRule.refineHint")}</p>
+          </div>
+        </div>
+      );
+
+    case "no_match":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border bg-muted/40 p-3"
+          data-testid="no-match-outcome"
+        >
+          <SearchXIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            {result.reason ?? result.message ?? t("nlRule.noMatch")}
+          </p>
+        </div>
+      );
+
+    case "unavailable":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-3"
+          data-testid="unavailable-outcome"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            {result.message ?? t("nlRule.notConfigured")}
+          </p>
+        </div>
+      );
+
+    case "error":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="error-outcome"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">{result.message || t("nlRule.error")}</p>
+        </div>
+      );
+  }
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -852,6 +852,20 @@
     "revert": "Revert",
     "showChanges": "Show {{count}} change(s)"
   },
+  "nlRule": {
+    "title": "Draft a rule from natural language",
+    "subtitle": "Describe a business rule in plain language. AI drafts it as a proposal for your review — nothing is applied automatically.",
+    "placeholder": "e.g. Require an approver when a purchase order total exceeds 10000",
+    "draft": "Draft rule",
+    "draftCreated": "Rule draft created",
+    "targetEntity": "Target entity",
+    "proposalId": "Proposal",
+    "reviewDraft": "Review draft",
+    "refineHint": "Refine your description and submit again.",
+    "noMatch": "Couldn't draft a rule from that description. Try rephrasing.",
+    "notConfigured": "AI is not configured. Configure an AI provider to enable rule drafting.",
+    "error": "Something went wrong. Please try again."
+  },
   "insights": {
     "title": "AI Insights",
     "subtitle": "AI-detected patterns and suggestions",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -852,6 +852,20 @@
     "revert": "回滚",
     "showChanges": "查看 {{count}} 项变更"
   },
+  "nlRule": {
+    "title": "用自然语言起草规则",
+    "subtitle": "用日常语言描述一条业务规则，AI 会将其起草为提案供你审阅 —— 不会自动应用任何变更。",
+    "placeholder": "例如：当采购订单总额超过 10000 时需要审批人",
+    "draft": "起草规则",
+    "draftCreated": "规则草稿已创建",
+    "targetEntity": "目标实体",
+    "proposalId": "提案",
+    "reviewDraft": "审阅草稿",
+    "refineHint": "请完善你的描述后重新提交。",
+    "noMatch": "无法根据该描述起草规则，请尝试换一种说法。",
+    "notConfigured": "AI 尚未配置。请配置 AI 提供商以启用规则起草。",
+    "error": "出现错误，请重试。"
+  },
   "insights": {
     "title": "AI 洞察",
     "subtitle": "AI 检测到的模式和建议",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -843,7 +843,7 @@ interface SchemaIntentWireResponse {
  */
 export async function resolveSchemaIntent(
   text: string,
-  opts: { fetchImpl?: typeof fetch } = {},
+  opts: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
 ): Promise<ResolveSchemaIntentResult> {
   const doFetch = opts.fetchImpl ?? fetch;
   let res: Response;
@@ -852,6 +852,7 @@ export async function resolveSchemaIntent(
       method: "POST",
       headers: { "Content-Type": "application/json", ...getAuthHeaders() },
       body: JSON.stringify({ prompt: text }),
+      signal: opts.signal,
     });
   } catch (err) {
     // Transport-level error (network down, etc.).

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -757,6 +757,171 @@ export async function resolveIntent(
   return { kind: "proposal", proposal };
 }
 
+// ── Schema-intent resolution ("说→有" — Spec 52) ──────────
+
+/**
+ * A natural-language rule draft that was minted as a GOVERNED, `draft`-status
+ * Proposal in the shared review engine. Mirrors the `proposal_draft` arm of the
+ * server's `ResolveSchemaIntentResponse` — the fields the UI needs to surface
+ * the draft and route the user to the existing review flow.
+ *
+ * Defined locally (the UI NEVER imports from `@linchkit/core` / server packages
+ * per the module-boundary rule); kept in sync with the route's wire response in
+ * `ai-resolve-schema-intent.ts`.
+ */
+export interface SchemaIntentDraft {
+  /**
+   * The governed Proposal id (persisted into `/api/proposals`). Use it to link
+   * the user into the existing review surface. Always references a `draft`-status
+   * Proposal — the endpoint never submits, approves, or applies it.
+   */
+  proposalId?: string;
+  /** Lifecycle status at persist time — always `"draft"`. */
+  proposalStatus?: string;
+  /** The generated rule's name. */
+  ruleName?: string;
+  /** The entity the rule attaches to. */
+  targetEntity?: string;
+  /** Resolver confidence (0-1). */
+  confidence?: number;
+  /** Human-readable explanation of the proposed rule. */
+  explanation?: string;
+}
+
+/**
+ * Discriminated result of `resolveSchemaIntent`.
+ *
+ * Mirrors `resolveIntent`'s discriminated shape so callers can render each
+ * outcome distinctly:
+ *
+ *  - `{ kind: "proposal_draft" }` — the server minted a `draft` governed
+ *    Proposal; surface it and link into the review flow. NEVER auto-approve.
+ *  - `{ kind: "clarification" }` — the resolver needs more info; show the
+ *    `question` and let the user refine + resubmit.
+ *  - `{ kind: "no_match" }` — no rule could be drafted; show the `reason`.
+ *  - `{ kind: "unavailable" }` — the server returned 503 (AI / ontology not
+ *    configured); surface a graceful "AI not configured" state.
+ *  - `{ kind: "error" }` — a 400 / 500 / transport error; show a user-friendly
+ *    error message.
+ */
+export type ResolveSchemaIntentResult =
+  | { kind: "proposal_draft"; draft: SchemaIntentDraft }
+  | { kind: "clarification"; question: string; bestConfidence?: number }
+  | { kind: "no_match"; reason?: string; message?: string }
+  | { kind: "unavailable"; message?: string }
+  | { kind: "error"; message: string };
+
+/** Shape of the JSON the server returns. Local mirror of the wire contract. */
+interface SchemaIntentWireResponse {
+  outcome?: "proposal_draft" | "clarification" | "no_match";
+  proposalId?: string;
+  proposalStatus?: string;
+  ruleName?: string;
+  targetEntity?: string;
+  confidence?: number;
+  explanation?: string;
+  question?: string;
+  bestConfidence?: number;
+  reason?: string;
+  message?: string;
+  error?: { code?: string; message?: string };
+}
+
+/**
+ * Resolve a natural-language utterance into a GOVERNED rule draft.
+ *
+ * Wire contract (Spec 52 — POST /api/ai/resolve-schema-intent):
+ *   request:  { prompt }
+ *   response: discriminated by `outcome`
+ *             (proposal_draft / clarification / no_match), or a 503 envelope.
+ *
+ * Returns a discriminated `ResolveSchemaIntentResult` so the caller can render
+ * each outcome. This NEVER submits / approves / applies anything — the server
+ * persists a `draft`-status Proposal and the UI only routes the user to review
+ * it. The optional `fetchImpl` parameter lets tests inject a stub `fetch`
+ * without leaking a global mock across the batched suite.
+ */
+export async function resolveSchemaIntent(
+  text: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<ResolveSchemaIntentResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch("/api/ai/resolve-schema-intent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+      body: JSON.stringify({ prompt: text }),
+    });
+  } catch (err) {
+    // Transport-level error (network down, etc.).
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : "Schema intent resolution failed",
+    };
+  }
+
+  handleUnauthorized(res);
+
+  // 503 — AI service / ontology not configured (graceful degradation).
+  if (res.status === 503) {
+    let message: string | undefined;
+    try {
+      const json = (await res.json()) as SchemaIntentWireResponse;
+      message = json.error?.message ?? json.message;
+    } catch {
+      // Body may be empty/non-JSON — fall back to the generic message below.
+    }
+    return { kind: "unavailable", message };
+  }
+
+  // 400 / 500 / other non-2xx — surface a user-friendly error.
+  if (!res.ok) {
+    let message = "Schema intent resolution failed";
+    try {
+      const json = (await res.json()) as SchemaIntentWireResponse;
+      message = json.error?.message ?? json.message ?? message;
+    } catch {
+      // Non-JSON error body — keep the generic message.
+    }
+    return { kind: "error", message };
+  }
+
+  let json: SchemaIntentWireResponse;
+  try {
+    json = (await res.json()) as SchemaIntentWireResponse;
+  } catch {
+    return { kind: "error", message: "Schema intent resolution returned an invalid response" };
+  }
+
+  switch (json.outcome) {
+    case "proposal_draft":
+      return {
+        kind: "proposal_draft",
+        draft: {
+          proposalId: json.proposalId,
+          proposalStatus: json.proposalStatus,
+          ruleName: json.ruleName,
+          targetEntity: json.targetEntity,
+          confidence: json.confidence,
+          explanation: json.explanation,
+        },
+      };
+    case "clarification":
+      return {
+        kind: "clarification",
+        question: json.question ?? "",
+        bestConfidence: json.bestConfidence,
+      };
+    case "no_match":
+      return { kind: "no_match", reason: json.reason, message: json.message };
+    default:
+      // Unknown / missing outcome — treat as an error rather than silently
+      // dropping it, so the UI surfaces something actionable.
+      return { kind: "error", message: "Schema intent resolution returned an unknown outcome" };
+  }
+}
+
 // ── Chatter ──────────────────────────────────────────────
 
 export interface ChatterMessageAuthor {

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/evolution.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/evolution.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { NlRuleDrafter } from "@/components/nl-rule-drafter";
 import { type EvolutionEntry, fetchEvolutionHistory } from "@/lib/proposal-api";
 
 // ── Change type badge ────────────────────────────────────
@@ -200,6 +201,10 @@ export function EvolutionPage() {
 
   return (
     <div className="p-4 space-y-4">
+      {/* "说→有" — draft a governed rule from natural language. The draft enters
+          the human-gated review pipeline; this surface never approves/applies. */}
+      <NlRuleDrafter />
+
       <div className="flex justify-end">
         <Button variant="outline" size="icon-sm" onClick={loadHistory}>
           <RefreshCwIcon className="h-4 w-4" />


### PR DESCRIPTION
## What & why

The server's `POST /api/ai/resolve-schema-intent` endpoint (Spec 52) turns a natural-language utterance into a **governed, draft-status Proposal** and is fully hardened (permission-scoped catalog, prompt-injection defense, operator/field allowlists). But it had **zero UI entry point** — the "说→有" pipeline was reachable only via an API client (G2).

## Change

Give it a real product surface:

- **`resolveSchemaIntent(text, opts)` client** in `lib/api.ts`, mirroring `resolveIntent`: hand-rolled fetch, a discriminated result covering `proposal_draft` / `clarification` / `no_match` / `unavailable` (503) / `error`. Types are declared **locally** (ui never imports from server). An optional `fetchImpl` allows test injection (no global fetch-mock leak).
- **`NlRuleDrafter` component** (textarea + submit) mounted on the **Evolution page**, next to the proposal review pipeline it feeds. It renders every outcome state and, on a draft, links the user into the existing proposal review surface.
- `nlRule` **i18n** namespace (en + zh-CN).

## Human-gated by design

The endpoint only persists a **draft**; this surface **never submits, approves, or applies** — review/approval stays in the existing pipeline.

## Tests

`__tests__/resolve-schema-intent.test.ts` — 10 unit tests injecting a stub `fetch`, asserting correct mapping for `proposal_draft` / `clarification` / `no_match` / 503 / 400 / 500 / transport-throw / unknown-outcome. (No component-render infra exists in this package; the renderer is JSX-only and the testable logic lives in the client.)

## Review

Cross-model reviewed (codex + gemini). codex: clean. gemini: LGTM with minor notes — **applied**: `no_match` now falls back to `message`, and an empty `clarification` question no longer renders an empty line. Rejected: the `<Link ... as "/">` cast (pervasive existing pattern across the UI; route-typing change is out of scope).

## Gates

`bun run check`, `bun run typecheck`, full `bun run test` (batched runner) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)