### PR TITLE
feat(core): model state-machine dependency edges in the ontology impact graph

### DIFF
--- a/.changeset/ontology-state-dependency-edges.md
+++ b/.changeset/ontology-state-dependency-edges.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/core": patch
+---
+
+Model state-machine dependency edges in the ontology impact graph. `extractDependencyEdges` now emits a `state_transition` edge (state → action) for each `StateDefinition.transitions[].action` and a `state_machine` edge (entity → state) for each entity field of `type: "state"` whose `machine` names a registered state machine. As a result `impactAnalysis` / `dependencyGraph` — and therefore proposal-validation Phase 3 — now detect that deleting an action used as a state transition, or a state machine attached to an entity, is a breaking change. Closes the documented Phase 3 under-reporting limitation.

--- a/packages/core/src/__tests__/engine/validation-phase3.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase3.test.ts
@@ -250,15 +250,18 @@ describe("validatePhase3 — action/state deletion", () => {
     expect(result.warnings.map((w) => w.code)).toContain("BREAKING_ELEMENT_DELETE");
   });
 
-  test("deleting a state machine that nothing depends on produces no findings", () => {
+  test("deleting a state machine attached to an entity flags the owning entity", () => {
     const ontology = buildOntology();
     const result = validatePhase3({
       changes: [{ target: "state", operation: "delete", name: "order_state" }],
       ontology,
     });
-    // Nothing in the DAG points TO state:order_state, so no breakage.
-    expect(result.status).toBe("passed");
-    expect(result.warnings).toHaveLength(0);
+    // order.status is a `type: "state"` field whose `machine` is "order_state",
+    // so entity:order depends on state:order_state (state_machine DAG edge).
+    expect(result.status).toBe("passed"); // warn-only
+    const elementWarnings = result.warnings.filter((w) => w.code === "BREAKING_ELEMENT_DELETE");
+    expect(elementWarnings.length).toBeGreaterThanOrEqual(1);
+    expect(elementWarnings.some((w) => w.message.includes('entity "order"'))).toBe(true);
   });
 
   test("deleting a whole entity flags entity-level dependents (not just fields)", () => {

--- a/packages/core/src/__tests__/ontology/state-dependency-edges.test.ts
+++ b/packages/core/src/__tests__/ontology/state-dependency-edges.test.ts
@@ -1,0 +1,249 @@
+/**
+ * State dependency DAG edges — Spec 67 §4.1
+ *
+ * Verifies the two state-related dependency edges that close the documented
+ * impactAnalysis gap:
+ *  1. State.transitions[].action → `state_transition` edge (State depends on Action).
+ *  2. Entity `type: "state"` field's `machine` → `state_machine` edge (Entity
+ *     depends on State).
+ *
+ * These edges let `impactAnalysis` (and therefore validation Phase 3) flag the
+ * deletion of an action used only as a state transition, or of a state machine
+ * attached to an entity, as breaking.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createOntologyRegistry,
+  extractDependencyEdges,
+  type OntologyRegistryDeps,
+} from "../../ontology";
+import type { ActionDefinition } from "../../types/action";
+import type { EntityDefinition } from "../../types/entity";
+import type { MetaModelRef } from "../../types/meta-semantics";
+import type { StateDefinition } from "../../types/state";
+
+// ── Fixtures ─────────────────────────────────────────────
+
+const orderEntity: EntityDefinition = {
+  name: "order",
+  label: "Order",
+  fields: {
+    title: { type: "string", label: "Title", required: true },
+    // `type: "state"` field whose `machine` references the order_state machine.
+    status: { type: "state", label: "Status", machine: "order_state" },
+  },
+};
+
+const approveAction: ActionDefinition = {
+  name: "approve_order",
+  entity: "order",
+  label: "Approve Order",
+  policy: { mode: "sync", transaction: true },
+} as unknown as ActionDefinition;
+
+// Action used ONLY as a state transition (no rule/flow/handler references it).
+const submitAction: ActionDefinition = {
+  name: "submit_order",
+  entity: "order",
+  label: "Submit Order",
+  policy: { mode: "sync", transaction: true },
+} as unknown as ActionDefinition;
+
+// Action referenced by nothing at all — regression control.
+const archiveAction: ActionDefinition = {
+  name: "archive_order",
+  entity: "order",
+  label: "Archive Order",
+  policy: { mode: "sync", transaction: true },
+} as unknown as ActionDefinition;
+
+const orderState: StateDefinition = {
+  name: "order_state",
+  entity: "order",
+  field: "status",
+  initial: "draft",
+  states: ["draft", "submitted", "approved"],
+  transitions: [
+    { from: "draft", to: "submitted", action: "submit_order" },
+    { from: "submitted", to: "approved", action: "approve_order" },
+    // Duplicate action across a second transition — must NOT produce a duplicate edge.
+    { from: "draft", to: "approved", action: "approve_order" },
+  ],
+};
+
+function buildOntology(overrides?: Partial<OntologyRegistryDeps>) {
+  const deps: OntologyRegistryDeps = {
+    schemas: {
+      getAll: () => [orderEntity],
+      get: (name: string) => (name === orderEntity.name ? orderEntity : undefined),
+      has: (name: string) => name === orderEntity.name,
+    },
+    actions: { getAll: () => [approveAction, submitAction, archiveAction] },
+    rules: [],
+    states: [orderState],
+    views: [],
+    ...overrides,
+  };
+  return createOntologyRegistry(deps);
+}
+
+function hasRef(refs: MetaModelRef[], type: MetaModelRef["type"], name: string): boolean {
+  return refs.some((r) => r.type === type && r.name === name);
+}
+
+// ── extractDependencyEdges: edge production ──────────────
+
+describe("extractDependencyEdges — state edges", () => {
+  const edges = extractDependencyEdges({
+    entities: [orderEntity],
+    actions: [approveAction, submitAction, archiveAction],
+    rules: [],
+    states: [orderState],
+    events: [],
+    handlers: [],
+    flows: [],
+    views: [],
+    relations: [],
+  });
+
+  test("adds a state_transition edge from State to each transition Action", () => {
+    const transitionEdges = edges.filter((e) => e.type === "state_transition");
+    // Two distinct transition actions (approve_order, submit_order); the
+    // duplicate approve_order transition must be deduped.
+    expect(transitionEdges).toHaveLength(2);
+    for (const e of transitionEdges) {
+      expect(e.from).toEqual({ type: "state", name: "order_state" });
+      expect(e.to.type).toBe("action");
+    }
+    const toNames = transitionEdges.map((e) => e.to.name).sort();
+    expect(toNames).toEqual(["approve_order", "submit_order"]);
+  });
+
+  test("adds a state_machine edge from Entity to the referenced State", () => {
+    const machineEdges = edges.filter((e) => e.type === "state_machine");
+    expect(machineEdges).toHaveLength(1);
+    expect(machineEdges[0]).toEqual({
+      from: { type: "entity", name: "order" },
+      to: { type: "state", name: "order_state" },
+      type: "state_machine",
+    });
+  });
+
+  test("adds a state_machine edge from StateDefinition.entity even when the entity has no state field", () => {
+    // The entity has no `type: "state"` field referencing the machine (so the
+    // field-scan fallback finds nothing), but the registered StateDefinition
+    // authoritatively declares entity:"task" — the edge must still be produced.
+    const taskEntity: EntityDefinition = {
+      name: "task",
+      fields: { title: { type: "string" } },
+    };
+    const taskState: StateDefinition = {
+      name: "task_state",
+      entity: "task",
+      field: "status",
+      initial: "open",
+      states: ["open", "done"],
+      transitions: [],
+    };
+    const out = extractDependencyEdges({
+      entities: [taskEntity],
+      actions: [],
+      rules: [],
+      states: [taskState],
+      events: [],
+      handlers: [],
+      flows: [],
+      views: [],
+      relations: [],
+    });
+    expect(out.filter((e) => e.type === "state_machine")).toEqual([
+      {
+        from: { type: "entity", name: "task" },
+        to: { type: "state", name: "task_state" },
+        type: "state_machine",
+      },
+    ]);
+  });
+
+  test("does not add a state_transition edge for an unknown action", () => {
+    const danglingState: StateDefinition = {
+      name: "dangling_state",
+      entity: "order",
+      field: "status",
+      initial: "a",
+      states: ["a", "b"],
+      transitions: [{ from: "a", to: "b", action: "no_such_action" }],
+    };
+    const out = extractDependencyEdges({
+      entities: [],
+      actions: [approveAction],
+      rules: [],
+      states: [danglingState],
+      events: [],
+      handlers: [],
+      flows: [],
+      views: [],
+      relations: [],
+    });
+    expect(out.filter((e) => e.type === "state_transition")).toHaveLength(0);
+  });
+
+  test("does not add a state_machine edge for an unknown machine name", () => {
+    const entityWithDanglingMachine: EntityDefinition = {
+      name: "thing",
+      fields: { status: { type: "state", machine: "no_such_machine" } },
+    };
+    const out = extractDependencyEdges({
+      entities: [entityWithDanglingMachine],
+      actions: [],
+      rules: [],
+      states: [orderState],
+      events: [],
+      handlers: [],
+      flows: [],
+      views: [],
+      relations: [],
+    });
+    expect(out.filter((e) => e.type === "state_machine")).toHaveLength(0);
+  });
+});
+
+// ── impactAnalysis: dependents surfaced ──────────────────
+
+describe("impactAnalysis — state edges", () => {
+  test("an action used ONLY as a state transition returns the owning state", () => {
+    const ontology = buildOntology();
+    // submit_order is referenced only by order_state's transition.
+    const layers = ontology.impactAnalysis({ type: "action", name: "submit_order" });
+    const dependents = layers.slice(1).flat();
+    expect(hasRef(dependents, "state", "order_state")).toBe(true);
+  });
+
+  test("a state machine attached to an entity returns that entity", () => {
+    const ontology = buildOntology();
+    const layers = ontology.impactAnalysis({ type: "state", name: "order_state" });
+    const dependents = layers.slice(1).flat();
+    expect(hasRef(dependents, "entity", "order")).toBe(true);
+  });
+
+  test("an action not referenced anywhere still returns no dependents (regression)", () => {
+    const ontology = buildOntology();
+    const layers = ontology.impactAnalysis({ type: "action", name: "archive_order" });
+    const dependents = layers.slice(1).flat();
+    expect(dependents).toHaveLength(0);
+  });
+});
+
+// ── dependencyGraph: forward reachability ────────────────
+
+describe("dependencyGraph — state edges", () => {
+  test("entity → state → transition actions are reachable forward", () => {
+    const ontology = buildOntology();
+    const graph = ontology.dependencyGraph({ type: "entity", name: "order" });
+    // entity:order --state_machine--> state:order_state --state_transition--> actions
+    expect(hasRef(graph.nodes, "state", "order_state")).toBe(true);
+    expect(hasRef(graph.nodes, "action", "approve_order")).toBe(true);
+    expect(hasRef(graph.nodes, "action", "submit_order")).toBe(true);
+  });
+});

--- a/packages/core/src/ontology/meta-semantics-inference.ts
+++ b/packages/core/src/ontology/meta-semantics-inference.ts
@@ -160,7 +160,12 @@ export function extractDependencyEdges(input: DagExtractionInput): DependencyEdg
   }
 
   // State.transitions → guards → Rule
+  // State.transitions → state_transition → Action (State depends on the action it
+  // uses as a transition; deleting the action breaks the state machine).
+  const stateNames = new Set(input.states.map((s) => s.name));
   for (const state of input.states) {
+    // Dedupe per state: a state may reuse the same action across transitions.
+    const seenTransitionActions = new Set<string>();
     for (const transition of state.transitions) {
       if (transition.guard) {
         edges.push({
@@ -168,6 +173,55 @@ export function extractDependencyEdges(input: DagExtractionInput): DependencyEdg
           to: { type: "rule", name: transition.guard },
           type: "guards",
         });
+      }
+      if (
+        transition.action &&
+        actionToEntity.has(transition.action) &&
+        !seenTransitionActions.has(transition.action)
+      ) {
+        seenTransitionActions.add(transition.action);
+        edges.push({
+          from: { type: "state", name: state.name },
+          to: { type: "action", name: transition.action },
+          type: "state_transition",
+        });
+      }
+    }
+  }
+
+  // Entity → state_machine → State (Entity depends on its StateDefinition;
+  // deleting the state machine breaks the entity). Derive from BOTH the
+  // authoritative `StateDefinition.entity` attachment AND a `type: "state"`
+  // field's `machine` reference, deduped — a state machine may be attached via
+  // either, and the registered field's `machine` can be absent or differ from
+  // the state name while the StateDefinition still declares its entity.
+  const entityNames = new Set(input.entities.map((e) => e.name));
+  const seenStateMachineEdges = new Set<string>();
+  const pushStateMachineEdge = (entityName: string, stateName: string): void => {
+    const key = `${entityName} ${stateName}`;
+    if (seenStateMachineEdges.has(key)) return;
+    seenStateMachineEdges.add(key);
+    edges.push({
+      from: { type: "entity", name: entityName },
+      to: { type: "state", name: stateName },
+      type: "state_machine",
+    });
+  };
+  // Authoritative: each registered StateDefinition declares the entity it is on.
+  for (const state of input.states) {
+    if (state.entity && entityNames.has(state.entity)) {
+      pushStateMachineEdge(state.entity, state.name);
+    }
+  }
+  // Fallback: an entity field of `type: "state"` naming a registered machine.
+  for (const entity of input.entities) {
+    for (const field of Object.values(entity.fields)) {
+      if (
+        field.type === "state" &&
+        typeof field.machine === "string" &&
+        stateNames.has(field.machine)
+      ) {
+        pushStateMachineEdge(entity.name, field.machine);
       }
     }
   }

--- a/packages/core/src/ontology/meta-semantics-inference.ts
+++ b/packages/core/src/ontology/meta-semantics-inference.ts
@@ -215,7 +215,7 @@ export function extractDependencyEdges(input: DagExtractionInput): DependencyEdg
   }
   // Fallback: an entity field of `type: "state"` naming a registered machine.
   for (const entity of input.entities) {
-    for (const field of Object.values(entity.fields)) {
+    for (const field of Object.values(entity.fields ?? {})) {
       if (
         field.type === "state" &&
         typeof field.machine === "string" &&

--- a/packages/core/src/types/meta-semantics.ts
+++ b/packages/core/src/types/meta-semantics.ts
@@ -129,7 +129,9 @@ export type DependencyEdgeType =
   | "guards" // State.transition guarded by Rule
   | "handles" // EventHandler handles Event
   | "contains" // Flow contains Action step
-  | "references"; // Action/Relation/View references Entity
+  | "references" // Action/Relation/View references Entity
+  | "state_transition" // State.transition[].action references Action (State → Action)
+  | "state_machine"; // Entity state field references its StateDefinition (Entity → State)
 
 export interface DependencyEdge {
   from: MetaModelRef;


### PR DESCRIPTION
## What & why

Follow-up to #487 (proposal-validation Phase 3). The ontology dependency DAG modeled `State→guards→Rule` but **never** `State→Action` (transition actions) or `Entity→State` (an entity's state machine). So `impactAnalysis` / `dependencyGraph` — and therefore validation Phase 3 — could **not** detect that deleting an action used as a state transition, or a state machine attached to an entity, is a breaking change. That was the documented Phase 3 under-reporting limitation.

## Change

`extractDependencyEdges` now emits two new edge kinds:
- **`state_transition`** (`state → action`): one per distinct `StateDefinition.transitions[].action`, deduped per state, only for registered actions. → `impactAnalysis(action)` now returns states that use it as a transition.
- **`state_machine`** (`entity → state`): derived from BOTH the authoritative `StateDefinition.entity` attachment **and** an entity `type: "state"` field's `machine` reference, deduped. → `impactAnalysis(state)` now returns the owning entity.

Two new `DependencyEdgeType` values.

## Review

Cross-model reviewed (codex). codex P2 — **addressed**: the first cut derived the `state_machine` edge only from `field.machine`, which misses states attached via `StateDefinition.entity` when the entity has no matching state field. Now derived primarily from the authoritative `StateDefinition.entity` (with the `field.machine` path kept as a deduped fallback). Regression test added for the entity-with-no-state-field case.

## Backward compatible

Edges only **add** dependents. One existing Phase 3 test that asserted a "state machine with no dependents" is retitled — `entity:order` now legitimately depends on `order_state`, so deleting that machine correctly flags the entity.

## Tests

`state-dependency-edges.test.ts` — edge-production (count/dedup/unknown-action/unknown-machine/authoritative-entity-attachment) + `impactAnalysis` (action-as-transition → state; machine → entity; regression: unreferenced action → none) + `dependencyGraph` forward reachability.

## Gates

`bun run check`, `bun run typecheck`, full `bun run test` (batched) all green. Pure analysis enhancement — no approval/commit/deploy/graduation/write path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)