### PR TITLE
feat(adapter-ui): surface proposal validation findings in the review UI

### DIFF
--- a/.changeset/proposal-validation-findings-ui.md
+++ b/.changeset/proposal-validation-findings-ui.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cap-adapter-ui": minor
+---
+
+Surface proposal validation findings in the proposal review UI. A new read-only `ProposalValidationFindings` component renders each non-skipped validation phase's errors (blocking, destructive styling) and warnings (advisory, amber styling) with their code + message, emphasizing Phase 3 (compatibility / breaking-reference checks) — sorted first with a distinct icon — so a reviewer can see when a proposal would break existing references. The inline `validationResult` shape on `Proposal` is extracted into reusable exported types. Defensive against missing/partial validation data; purely presentational (never approves/applies). Pre-analysis (dedup/impact) is not yet plumbed to the client and is out of scope.

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-validation-findings.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-validation-findings.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for ProposalValidationFindings helpers (Spec 09 §4.5 — compatibility).
+ *
+ * The component itself is JSX-only — we test the pure data-shaping helpers
+ * since the package's test setup is logic-only (no happy-dom / jsdom). The
+ * helpers cover every branch the component renders:
+ *   - selecting non-skipped phases that carry findings
+ *   - sorting the compatibility phase (Phase 3) first
+ *   - counting errors / warnings defensively across phases
+ *   - tolerating null / undefined / partial / malformed results without crashing
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  COMPATIBILITY_PHASE,
+  countFindings,
+  hasAnyFindings,
+  selectPhasesWithFindings,
+} from "../src/components/proposal-validation-findings-helpers";
+import type { ProposalValidationResult } from "../src/lib/proposal-api";
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const compatWarnings: ProposalValidationResult = {
+  passed: true,
+  impactSummary: "",
+  phases: [
+    { phase: 1, status: "passed", errors: [], warnings: [], duration: 1 },
+    {
+      phase: 3,
+      status: "passed",
+      errors: [],
+      warnings: [
+        { code: "BREAKING_FIELD_DELETE", message: "field still referenced", field: "task.x" },
+      ],
+      duration: 5,
+    },
+  ],
+};
+
+const mixedPhases: ProposalValidationResult = {
+  passed: false,
+  impactSummary: "",
+  phases: [
+    {
+      phase: 1,
+      status: "failed",
+      errors: [{ code: "SCHEMA_INVALID", message: "bad schema" }],
+      warnings: [],
+      duration: 2,
+    },
+    { phase: 2, status: "skipped", errors: [], warnings: [], duration: 0 },
+    {
+      phase: 3,
+      status: "failed",
+      errors: [{ code: "BREAKING_ELEMENT_DELETE", message: "action deleted" }],
+      warnings: [{ code: "BREAKING_ENUM_VALUE_REMOVED", message: "enum removed" }],
+      duration: 9,
+    },
+    { phase: 4, status: "passed", errors: [], warnings: [], duration: 1 },
+  ],
+};
+
+// ── COMPATIBILITY_PHASE constant ────────────────────────────
+
+describe("COMPATIBILITY_PHASE", () => {
+  test("is phase 3 (Spec 09 §4.5)", () => {
+    expect(COMPATIBILITY_PHASE).toBe(3);
+  });
+});
+
+// ── selectPhasesWithFindings ────────────────────────────────
+
+describe("selectPhasesWithFindings", () => {
+  test("null result → empty (defensive)", () => {
+    expect(selectPhasesWithFindings(null)).toEqual([]);
+  });
+
+  test("undefined result → empty (defensive)", () => {
+    expect(selectPhasesWithFindings(undefined)).toEqual([]);
+  });
+
+  test("result with no phases array → empty (defensive)", () => {
+    expect(
+      selectPhasesWithFindings({ passed: true, impactSummary: "", phases: undefined as never }),
+    ).toEqual([]);
+  });
+
+  test("excludes skipped phases", () => {
+    const result: ProposalValidationResult = {
+      passed: true,
+      impactSummary: "",
+      phases: [
+        {
+          phase: 3,
+          status: "skipped",
+          errors: [{ code: "X", message: "y" }],
+          warnings: [],
+          duration: 0,
+        },
+      ],
+    };
+    expect(selectPhasesWithFindings(result)).toEqual([]);
+  });
+
+  test("excludes non-skipped phases with zero findings (clean pass)", () => {
+    const result: ProposalValidationResult = {
+      passed: true,
+      impactSummary: "",
+      phases: [{ phase: 1, status: "passed", errors: [], warnings: [], duration: 1 }],
+    };
+    expect(selectPhasesWithFindings(result)).toEqual([]);
+  });
+
+  test("includes a phase that has warnings only", () => {
+    const selected = selectPhasesWithFindings(compatWarnings);
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.phase).toBe(3);
+    expect(selected[0]?.isCompatibility).toBe(true);
+    expect(selected[0]?.warnings).toHaveLength(1);
+    expect(selected[0]?.errors).toHaveLength(0);
+  });
+
+  test("sorts the compatibility phase (3) first, then ascending", () => {
+    const selected = selectPhasesWithFindings(mixedPhases);
+    // phase 2 skipped → excluded; phase 4 clean → excluded.
+    expect(selected.map((p) => p.phase)).toEqual([3, 1]);
+    expect(selected[0]?.isCompatibility).toBe(true);
+    expect(selected[1]?.isCompatibility).toBe(false);
+  });
+
+  test("tolerates a phase missing its errors/warnings arrays", () => {
+    const result: ProposalValidationResult = {
+      passed: true,
+      impactSummary: "",
+      // Malformed: errors/warnings omitted by an older producer.
+      phases: [{ phase: 3, status: "passed", duration: 1 } as never],
+    };
+    // No findings → excluded, but does not throw.
+    expect(selectPhasesWithFindings(result)).toEqual([]);
+  });
+
+  test("non-3 phase with findings is still included and not flagged compatibility", () => {
+    const result: ProposalValidationResult = {
+      passed: false,
+      impactSummary: "",
+      phases: [
+        {
+          phase: 1,
+          status: "failed",
+          errors: [{ code: "E", message: "m" }],
+          warnings: [],
+          duration: 1,
+        },
+      ],
+    };
+    const selected = selectPhasesWithFindings(result);
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.phase).toBe(1);
+    expect(selected[0]?.isCompatibility).toBe(false);
+  });
+});
+
+// ── countFindings ───────────────────────────────────────────
+
+describe("countFindings", () => {
+  test("null result → zeros (defensive)", () => {
+    expect(countFindings(null)).toEqual({ errors: 0, warnings: 0 });
+  });
+
+  test("undefined result → zeros (defensive)", () => {
+    expect(countFindings(undefined)).toEqual({ errors: 0, warnings: 0 });
+  });
+
+  test("counts errors and warnings across non-skipped phases", () => {
+    expect(countFindings(mixedPhases)).toEqual({ errors: 2, warnings: 1 });
+  });
+
+  test("skipped phase findings are not counted", () => {
+    const result: ProposalValidationResult = {
+      passed: true,
+      impactSummary: "",
+      phases: [
+        {
+          phase: 3,
+          status: "skipped",
+          errors: [{ code: "X", message: "y" }],
+          warnings: [{ code: "W", message: "z" }],
+          duration: 0,
+        },
+      ],
+    };
+    expect(countFindings(result)).toEqual({ errors: 0, warnings: 0 });
+  });
+
+  test("tolerates missing errors/warnings arrays", () => {
+    const result: ProposalValidationResult = {
+      passed: true,
+      impactSummary: "",
+      phases: [{ phase: 3, status: "passed", duration: 1 } as never],
+    };
+    expect(countFindings(result)).toEqual({ errors: 0, warnings: 0 });
+  });
+});
+
+// ── hasAnyFindings ──────────────────────────────────────────
+
+describe("hasAnyFindings", () => {
+  test("false for null / undefined", () => {
+    expect(hasAnyFindings(null)).toBe(false);
+    expect(hasAnyFindings(undefined)).toBe(false);
+  });
+
+  test("false for a clean pass", () => {
+    const result: ProposalValidationResult = {
+      passed: true,
+      impactSummary: "",
+      phases: [{ phase: 1, status: "passed", errors: [], warnings: [], duration: 1 }],
+    };
+    expect(hasAnyFindings(result)).toBe(false);
+  });
+
+  test("true when warnings exist", () => {
+    expect(hasAnyFindings(compatWarnings)).toBe(true);
+  });
+
+  test("true when errors exist", () => {
+    expect(hasAnyFindings(mixedPhases)).toBe(true);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-validation-findings-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-validation-findings-helpers.ts
@@ -1,0 +1,119 @@
+/**
+ * Helpers for ProposalValidationFindings (Spec 09 §4.5 — compatibility checks).
+ *
+ * Kept separate from the JSX component so the data-shaping logic can be
+ * unit-tested without a DOM (the package has no jsdom/happy-dom; tests are
+ * logic-only). The component file imports from here.
+ *
+ * Validation produces, per phase, `errors` (blocking) and `warnings`
+ * (advisory). Phase 3 is the compatibility / breaking-reference phase: its
+ * findings (codes like BREAKING_FIELD_DELETE) tell a reviewer the proposal
+ * would break existing references. This module selects the phases worth showing
+ * and counts findings — purely defensive against missing / partial data.
+ */
+
+import type {
+  ProposalValidationFinding,
+  ProposalValidationPhase,
+  ProposalValidationResult,
+} from "../lib/proposal-api";
+
+// ── Constants ───────────────────────────────────────────────
+
+/** The compatibility / breaking-reference phase (Spec 09 §4.5). */
+export const COMPATIBILITY_PHASE = 3;
+
+/** Visual tone for a finding group. */
+export type FindingTone = "error" | "warning";
+
+// ── Phase selection ─────────────────────────────────────────
+
+/**
+ * A phase that actually carries findings worth rendering. Skipped phases and
+ * clean (zero-finding) phases are excluded so the panel only shows signal.
+ */
+export interface PhaseWithFindings {
+  phase: number;
+  status: string;
+  errors: ProposalValidationFinding[];
+  warnings: ProposalValidationFinding[];
+  /** True when this is the compatibility phase (Phase 3) — emphasised in UI. */
+  isCompatibility: boolean;
+}
+
+/** True when a phase has at least one error or warning to show. */
+function phaseHasFindings(phase: ProposalValidationPhase): boolean {
+  const errorCount = phase.errors?.length ?? 0;
+  const warningCount = phase.warnings?.length ?? 0;
+  return errorCount > 0 || warningCount > 0;
+}
+
+/**
+ * Select the phases that should be rendered: non-skipped phases that carry at
+ * least one finding. Defensive against a null/undefined result, a missing
+ * `phases` array, and phases missing their `errors` / `warnings` arrays.
+ *
+ * Phase 3 (compatibility) is sorted FIRST so the most safety-relevant findings
+ * lead; remaining phases keep their natural numeric order.
+ */
+export function selectPhasesWithFindings(
+  result: ProposalValidationResult | null | undefined,
+): PhaseWithFindings[] {
+  const phases = result?.phases;
+  if (!Array.isArray(phases)) return [];
+
+  const selected: PhaseWithFindings[] = [];
+  for (const phase of phases) {
+    if (!phase) continue;
+    if (phase.status === "skipped") continue;
+    if (!phaseHasFindings(phase)) continue;
+    selected.push({
+      phase: phase.phase,
+      status: phase.status,
+      errors: phase.errors ?? [],
+      warnings: phase.warnings ?? [],
+      isCompatibility: phase.phase === COMPATIBILITY_PHASE,
+    });
+  }
+
+  // Compatibility phase first, then ascending phase number.
+  return selected.sort((a, b) => {
+    if (a.isCompatibility !== b.isCompatibility) return a.isCompatibility ? -1 : 1;
+    return a.phase - b.phase;
+  });
+}
+
+// ── Counting ────────────────────────────────────────────────
+
+/** Aggregate finding counts across every non-skipped phase. */
+export interface FindingCounts {
+  errors: number;
+  warnings: number;
+}
+
+/**
+ * Count total errors and warnings across all phases of a result. Defensive
+ * against null/partial data — returns zeros rather than throwing.
+ */
+export function countFindings(result: ProposalValidationResult | null | undefined): FindingCounts {
+  const phases = result?.phases;
+  if (!Array.isArray(phases)) return { errors: 0, warnings: 0 };
+
+  let errors = 0;
+  let warnings = 0;
+  for (const phase of phases) {
+    if (!phase || phase.status === "skipped") continue;
+    errors += phase.errors?.length ?? 0;
+    warnings += phase.warnings?.length ?? 0;
+  }
+  return { errors, warnings };
+}
+
+/**
+ * True when there is at least one finding worth surfacing. Used by the
+ * component to decide whether to render anything at all.
+ */
+export function hasAnyFindings(result: ProposalValidationResult | null | undefined): boolean {
+  const { errors, warnings } = countFindings(result);
+  return errors > 0 || warnings > 0;
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-validation-findings.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-validation-findings.tsx
@@ -1,0 +1,168 @@
+/**
+ * ProposalValidationFindings — Spec 09 §4.5 review surface.
+ *
+ * Renders a proposal's validation findings — especially Phase 3 (compatibility
+ * / breaking-reference) errors and warnings — so a reviewer can see that a
+ * proposal would break existing references before approving it.
+ *
+ * Layout: one bordered section per non-skipped phase that carries findings.
+ * Errors use destructive styling; warnings use amber/advisory styling. Each
+ * finding shows its `code` (mono) + `message`, plus optional `target` / `field`
+ * context. The compatibility phase (Phase 3) is emphasised and sorted first.
+ *
+ * Purely presentational and READ-ONLY: it never validates, approves, applies,
+ * or mutates anything. If `validationResult` is absent, all phases are
+ * skipped/clean, or data is partial, it renders a subtle "no issues" line (or
+ * nothing when `hideWhenEmpty`) and never crashes.
+ */
+
+import { Badge, Card, CardContent, CardHeader, CardTitle } from "@linchkit/ui-kit/components";
+import { AlertTriangleIcon, CheckCircle2Icon, ShieldAlertIcon, XCircleIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ProposalValidationFinding, ProposalValidationResult } from "../lib/proposal-api";
+import {
+  type FindingTone,
+  hasAnyFindings,
+  type PhaseWithFindings,
+  selectPhasesWithFindings,
+} from "./proposal-validation-findings-helpers";
+
+// ── Component props ────────────────────────────────────────
+
+export interface ProposalValidationFindingsProps {
+  /** The proposal's validation result. Null/undefined → renders nothing/empty. */
+  result: ProposalValidationResult | null | undefined;
+  /** When true, render nothing at all if there are no findings. */
+  hideWhenEmpty?: boolean;
+  /** Optional className for the outer wrapper. */
+  className?: string;
+}
+
+// ── Tone styling (mirrors proposal-impact-preview tones) ───
+
+const FINDING_BLOCK_CLASS: Record<FindingTone, string> = {
+  error: "rounded-md border border-destructive/30 bg-destructive/5 p-2.5",
+  warning: "rounded-md border border-amber-500/30 bg-amber-500/5 p-2.5",
+};
+
+const FINDING_CODE_CLASS: Record<FindingTone, string> = {
+  error: "font-mono text-[11px] text-destructive",
+  warning: "font-mono text-[11px] text-amber-700 dark:text-amber-400",
+};
+
+// ── Single finding row ─────────────────────────────────────
+
+function FindingRow({ finding, tone }: { finding: ProposalValidationFinding; tone: FindingTone }) {
+  const Icon = tone === "error" ? XCircleIcon : AlertTriangleIcon;
+  const iconClass = tone === "error" ? "text-destructive" : "text-amber-500";
+
+  // Compose optional target/field context defensively.
+  const context = [finding.target, finding.field].filter(Boolean).join(" · ");
+
+  return (
+    <div className={FINDING_BLOCK_CLASS[tone]}>
+      <div className="flex items-start gap-2">
+        <Icon className={`h-3.5 w-3.5 shrink-0 mt-0.5 ${iconClass}`} />
+        <div className="min-w-0 text-xs">
+          <div className={FINDING_CODE_CLASS[tone]}>{finding.code}</div>
+          <div className="mt-0.5 text-foreground">{finding.message}</div>
+          {context && <div className="mt-0.5 text-[11px] text-muted-foreground">{context}</div>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── One phase section ──────────────────────────────────────
+
+function PhaseSection({ phase }: { phase: PhaseWithFindings }) {
+  const { t } = useTranslation();
+  const titleKey = phase.isCompatibility
+    ? "proposals.findings.compatibilityTitle"
+    : "proposals.findings.phaseTitle";
+
+  return (
+    <Card
+      className={`border-l-4 ${phase.errors.length > 0 ? "border-l-destructive" : "border-l-amber-500"}`}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          {phase.isCompatibility ? (
+            <ShieldAlertIcon className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <AlertTriangleIcon className="h-4 w-4 text-muted-foreground" />
+          )}
+          {t(titleKey, { phase: phase.phase })}
+          {phase.errors.length > 0 && (
+            <Badge
+              variant="outline"
+              className="text-[10px] bg-destructive/10 text-destructive border-destructive/30"
+            >
+              {t("proposals.findings.errorCount", { count: phase.errors.length })}
+            </Badge>
+          )}
+          {phase.warnings.length > 0 && (
+            <Badge
+              variant="outline"
+              className="text-[10px] bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/30"
+            >
+              {t("proposals.findings.warningCount", { count: phase.warnings.length })}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1.5 pt-0">
+        {phase.errors.map((finding) => (
+          <FindingRow
+            key={`err-${finding.code}-${finding.message}`}
+            finding={finding}
+            tone="error"
+          />
+        ))}
+        {phase.warnings.map((finding) => (
+          <FindingRow
+            key={`warn-${finding.code}-${finding.message}`}
+            finding={finding}
+            tone="warning"
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────
+
+export function ProposalValidationFindings({
+  result,
+  hideWhenEmpty = false,
+  className,
+}: ProposalValidationFindingsProps) {
+  const { t } = useTranslation();
+  const phases = selectPhasesWithFindings(result);
+
+  if (phases.length === 0) {
+    if (hideWhenEmpty) return null;
+    // Distinguish "validated, all clean" from "no validation result at all".
+    const messageKey = hasAnyFindings(result)
+      ? "proposals.findings.empty"
+      : result
+        ? "proposals.findings.clean"
+        : "proposals.findings.empty";
+    return (
+      <div className={`flex items-center gap-2 text-xs text-muted-foreground ${className ?? ""}`}>
+        <CheckCircle2Icon className="h-3.5 w-3.5 text-emerald-500" />
+        <span>{t(messageKey)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-3 ${className ?? ""}`}>
+      <h3 className="text-sm font-semibold">{t("proposals.findings.heading")}</h3>
+      {phases.map((phase) => (
+        <PhaseSection key={phase.phase} phase={phase} />
+      ))}
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-validation-findings.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-validation-findings.tsx
@@ -22,7 +22,6 @@ import { useTranslation } from "react-i18next";
 import type { ProposalValidationFinding, ProposalValidationResult } from "../lib/proposal-api";
 import {
   type FindingTone,
-  hasAnyFindings,
   type PhaseWithFindings,
   selectPhasesWithFindings,
 } from "./proposal-validation-findings-helpers";
@@ -114,14 +113,14 @@ function PhaseSection({ phase }: { phase: PhaseWithFindings }) {
       <CardContent className="space-y-1.5 pt-0">
         {phase.errors.map((finding) => (
           <FindingRow
-            key={`err-${finding.code}-${finding.message}`}
+            key={`err-${finding.code}-${finding.target ?? ""}-${finding.field ?? ""}-${finding.message}`}
             finding={finding}
             tone="error"
           />
         ))}
         {phase.warnings.map((finding) => (
           <FindingRow
-            key={`warn-${finding.code}-${finding.message}`}
+            key={`warn-${finding.code}-${finding.target ?? ""}-${finding.field ?? ""}-${finding.message}`}
             finding={finding}
             tone="warning"
           />
@@ -143,12 +142,9 @@ export function ProposalValidationFindings({
 
   if (phases.length === 0) {
     if (hideWhenEmpty) return null;
-    // Distinguish "validated, all clean" from "no validation result at all".
-    const messageKey = hasAnyFindings(result)
-      ? "proposals.findings.empty"
-      : result
-        ? "proposals.findings.clean"
-        : "proposals.findings.empty";
+    // No non-skipped phase carries findings here, so distinguish only
+    // "validated, all clean" (a result is present) from "no validation result".
+    const messageKey = result ? "proposals.findings.clean" : "proposals.findings.empty";
     return (
       <div className={`flex items-center gap-2 text-xs text-muted-foreground ${className ?? ""}`}>
         <CheckCircle2Icon className="h-3.5 w-3.5 text-emerald-500" />

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -776,6 +776,17 @@
     "phaseErrors": "{{count}} error",
     "phaseErrors_other": "{{count}} errors",
     "defaultRejectReason": "Rejected by user",
+    "findings": {
+      "heading": "Validation Findings",
+      "phaseTitle": "Phase {{phase}}",
+      "compatibilityTitle": "Phase {{phase}}: Compatibility",
+      "errorCount": "{{count}} error",
+      "errorCount_other": "{{count}} errors",
+      "warningCount": "{{count}} warning",
+      "warningCount_other": "{{count}} warnings",
+      "clean": "Validation passed with no findings.",
+      "empty": "No validation findings to display."
+    },
     "preanalysis": {
       "heading": "Pre-Analysis",
       "empty": "No pre-analysis result available for this proposal.",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -776,6 +776,17 @@
     "phaseErrors": "{{count}} 个错误",
     "phaseErrors_other": "{{count}} 个错误",
     "defaultRejectReason": "用户拒绝",
+    "findings": {
+      "heading": "校验发现",
+      "phaseTitle": "阶段 {{phase}}",
+      "compatibilityTitle": "阶段 {{phase}}：兼容性",
+      "errorCount": "{{count}} 个错误",
+      "errorCount_other": "{{count}} 个错误",
+      "warningCount": "{{count}} 个警告",
+      "warningCount_other": "{{count}} 个警告",
+      "clean": "校验通过，未发现问题。",
+      "empty": "没有可显示的校验发现。"
+    },
     "preanalysis": {
       "heading": "预分析结果",
       "empty": "该提案暂无预分析结果。",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -30,6 +30,37 @@ export interface ProposalImpact {
   migrationRequired: boolean;
 }
 
+/**
+ * A single validation finding (error or warning) surfaced by a validation
+ * phase. Mirrors the core `ValidationError` / `ValidationWarning` shape — kept
+ * local so the UI never imports the server/core runtime. `target` / `field` are
+ * optional context the producer may attach (e.g. the entity/field a breaking
+ * reference points at). Guarded as optional because older payloads omit them.
+ */
+export interface ProposalValidationFinding {
+  code: string;
+  message: string;
+  target?: string;
+  field?: string;
+}
+
+/** One validation phase's outcome (mirrors core `PhaseResult`). */
+export interface ProposalValidationPhase {
+  phase: number;
+  /** "passed" | "failed" | "skipped" — kept as a string for forward-compat. */
+  status: string;
+  errors: ProposalValidationFinding[];
+  warnings: ProposalValidationFinding[];
+  duration: number;
+}
+
+/** Aggregate validation result attached to a proposal (mirrors core). */
+export interface ProposalValidationResult {
+  passed: boolean;
+  phases: ProposalValidationPhase[];
+  impactSummary: string;
+}
+
 export interface Proposal {
   id: string;
   title: string;
@@ -40,17 +71,7 @@ export interface Proposal {
   changes: ProposalChange[];
   impact: ProposalImpact;
   status: string;
-  validationResult?: {
-    passed: boolean;
-    phases: Array<{
-      phase: number;
-      status: string;
-      errors: Array<{ code: string; message: string }>;
-      warnings: Array<{ code: string; message: string }>;
-      duration: number;
-    }>;
-    impactSummary: string;
-  };
+  validationResult?: ProposalValidationResult;
   createdAt: string;
   updatedAt: string;
   validatedAt?: string;

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-demo.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-demo.tsx
@@ -21,6 +21,8 @@ import {
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ProposalImpactPreview } from "@/components/proposal-impact-preview";
+import { ProposalValidationFindings } from "@/components/proposal-validation-findings";
+import type { ProposalValidationResult } from "@/lib/proposal-api";
 
 // ── Mock fixtures ──────────────────────────────────────────
 
@@ -181,6 +183,92 @@ const partialFixture: ProposalPreAnalysisResult = {
   },
 };
 
+// ── Validation-findings fixtures (Spec 09 §4.5) ────────────
+//
+// Mirrors the four pre-analysis branches but for the validation result: a
+// proposal that surfaces Phase 3 (compatibility / breaking-reference) warnings
+// in default mode, the same findings as blocking errors under strict mode, a
+// clean pass, and an absent result. Demonstrates every render branch of
+// ProposalValidationFindings against realistic breaking-reference codes.
+
+const findingsWarnFixture: ProposalValidationResult = {
+  passed: true,
+  impactSummary: "1 breaking reference (warning, non-blocking).",
+  phases: [
+    { phase: 1, status: "passed", errors: [], warnings: [], duration: 4 },
+    { phase: 2, status: "passed", errors: [], warnings: [], duration: 6 },
+    {
+      phase: 3,
+      status: "passed",
+      errors: [],
+      warnings: [
+        {
+          code: "BREAKING_FIELD_DELETE",
+          message: "Field 'task.priority' is still referenced by view 'task_board'.",
+          target: "view:task_board",
+          field: "task.priority",
+        },
+        {
+          code: "BREAKING_ENUM_VALUE_REMOVED",
+          message: "Enum value 'urgent' is removed but used by rule 'escalate_urgent'.",
+          target: "rule:escalate_urgent",
+          field: "task.priority",
+        },
+      ],
+      duration: 12,
+    },
+    { phase: 4, status: "skipped", errors: [], warnings: [], duration: 0 },
+  ],
+};
+
+const findingsErrorFixture: ProposalValidationResult = {
+  passed: false,
+  impactSummary: "2 breaking references (strict mode → blocking).",
+  phases: [
+    { phase: 1, status: "passed", errors: [], warnings: [], duration: 3 },
+    {
+      phase: 3,
+      status: "failed",
+      errors: [
+        {
+          code: "BREAKING_ELEMENT_DELETE",
+          message: "Action 'archive_task' is deleted but referenced by flow 'cleanup_flow'.",
+          target: "flow:cleanup_flow",
+        },
+        {
+          code: "BREAKING_FIELD_TYPE_CHANGE",
+          message: "Field 'task.due_at' type changes from date to string (narrowing).",
+          field: "task.due_at",
+        },
+        {
+          code: "BREAKING_REQUIRED_DEFAULT_DROP",
+          message: "Required field 'task.owner' loses its default; existing rows would fail.",
+          field: "task.owner",
+        },
+      ],
+      warnings: [],
+      duration: 15,
+    },
+  ],
+};
+
+const findingsCleanFixture: ProposalValidationResult = {
+  passed: true,
+  impactSummary: "No breaking references.",
+  phases: [
+    { phase: 1, status: "passed", errors: [], warnings: [], duration: 2 },
+    { phase: 2, status: "passed", errors: [], warnings: [], duration: 3 },
+    { phase: 3, status: "passed", errors: [], warnings: [], duration: 5 },
+  ],
+};
+
+const findingsFixtures: Record<string, ProposalValidationResult | null> = {
+  full: findingsWarnFixture,
+  error: findingsErrorFixture,
+  partial: findingsCleanFixture,
+  empty: null,
+};
+
 const fixtures: Fixture[] = [
   {
     id: "full",
@@ -233,6 +321,11 @@ export function ProposalReviewDemoPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Validation findings — Spec 09 §4.5 compatibility checks. READ-ONLY:
+          surfaces breaking-reference errors/warnings for a reviewer; never
+          approves or applies anything. */}
+      <ProposalValidationFindings result={findingsFixtures[activeId] ?? null} />
 
       <ProposalImpactPreview result={active?.result} />
     </div>


### PR DESCRIPTION
## What & why

Proposal-validation **Phase 3 (compatibility / breaking-reference checks)** (#487) produces warnings/errors on a proposal's `validationResult`, but the review UI never displayed them — a reviewer could not see that a proposal would **break existing references**. This surfaces them.

## Change

New **read-only** `ProposalValidationFindings` component + pure, tested helpers:
- Renders each non-skipped validation phase's **errors** (blocking — destructive styling) and **warnings** (advisory — amber styling) with `code` + `message` + optional `target`/`field`.
- **Emphasizes Phase 3 (compatibility)**: distinct icon, dedicated title, sorted first.
- Defensive against missing/partial `validationResult` (returns `[]`/zeros, never throws); renders nothing when clean.
- Mounted on the proposal review surface (`proposal-review-demo`) beside the existing impact preview, driven by the same fixture switcher.

Extracts the inline `validationResult` shape on `Proposal` into reusable exported types (`ProposalValidationFinding` / `Phase` / `Result`).

## Boundary

Purely presentational — **never submits/approves/applies/commits**. `ui` imports no server/core runtime (the validation-result type is mirrored locally in the client lib). Pre-analysis (dedup/impact) is **not yet plumbed to the client** — verified, left out of scope (no server plumbing added).

## Review

Cross-model reviewed (codex): clean, no actionable findings.

## Tests

`proposal-validation-findings.test.ts` — 19 `bun:test` assertions over the helpers (`selectPhasesWithFindings` null/partial defensiveness, skipped/clean exclusion, Phase-3-first sort; `countFindings` cross-phase totals + defensive zeros; `hasAnyFindings`). Helpers are logic-only (the package has no jsdom/happy-dom render infra — consistent with sibling tests).

## Gates

`bun run check`, `bun run typecheck`, full `bun run test` (batched) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)