### PR TITLE
feat(core): bridge evolution cycle into governance review as drafts (on-demand)

### DIFF
--- a/.changeset/evolution-cycle-to-review-drafts.md
+++ b/.changeset/evolution-cycle-to-review-drafts.md
@@ -1,0 +1,8 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+---
+
+Bridge the Spec-55 evolution cycle into the governance review pipeline (on-demand). The evolution `runCycle()` was never invoked at runtime and its proposals were transient — they never reached human review. New `persistCycleProposalsAsDrafts` helper (`@linchkit/core`) maps each cycle `ProposalDefinition` to a governance `draft` via `ProposalEngine.createProposal`, deduped against the already-pending set (capability + change names) so re-running a cycle is idempotent. New `POST /api/evolution/run-cycle` endpoint (`@linchkit/cap-adapter-server`) runs one cycle on demand through CommandLayer (permission slot never skipped; 501 when the evolution runtime is absent, 503 when the command layer is absent) and persists the results as drafts, returning `{ created, deduped, total, createdIds }`.
+
+Strictly drafts-only: nothing is submitted, validated, approved, committed, deployed, or graduated, and there is no scheduler — invocation cadence and graduation (to files/PR) remain deferred. Pre-analysis envelopes are not attached (no slot on the proposal shape; out of scope).

--- a/addons/adapter-server/cap-adapter-server/src/http-transport.ts
+++ b/addons/adapter-server/cap-adapter-server/src/http-transport.ts
@@ -165,6 +165,9 @@ export async function createHttpTransport(ctx: TransportContext): Promise<Transp
     onchangeEvaluator,
     overlayRegistry: ctx.overlayRegistry,
     resolveRequestTenantId,
+    // Spec 55 §7 — enable `POST /api/evolution/run-cycle` so an operator can run
+    // one on-demand evolution cycle and land its proposals as governance drafts.
+    evolutionRuntime: ctx.evolutionRuntime,
   });
 
   return {

--- a/addons/adapter-server/cap-adapter-server/src/routes/evolution-cycle-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/evolution-cycle-api.ts
@@ -76,8 +76,11 @@ export function mountEvolutionCycleRoutes(app: Elysia, options: ServerOptions): 
   const evolutionRuntime: EvolutionRuntime | undefined = options.evolutionRuntime;
 
   app.post("/api/evolution/run-cycle", async ({ set, request }) => {
-    if (!evolutionRuntime) {
-      // 501 — feature not wired in this deployment. (No cycle to run.)
+    if (!evolutionRuntime?.evolutionCycle) {
+      // 501 — feature not wired in this deployment. Also covers a partially
+      // constructed runtime (present, but its `evolutionCycle` is missing, e.g.
+      // a mock or incomplete config): there is no cycle to run either way, so we
+      // degrade gracefully here instead of throwing a 500 deeper in the handler.
       return serviceUnavailable(
         set,
         "Evolution runtime is not configured — on-demand cycle execution is unavailable.",

--- a/addons/adapter-server/cap-adapter-server/src/routes/evolution-cycle-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/evolution-cycle-api.ts
@@ -1,0 +1,169 @@
+/**
+ * Evolution cycle trigger REST endpoint (Spec 55 §7).
+ *
+ * POST /api/evolution/run-cycle
+ *
+ * Runs ONE on-demand evolution cycle (`evolutionRuntime.evolutionCycle.runCycle`)
+ * and persists each proposal it produces as a governance `draft` in the shared
+ * {@link getSharedProposalEngine} engine — so cycle output enters the existing
+ * human review pipeline (`GET /api/proposals`) instead of evaporating as
+ * transient cycle data.
+ *
+ * Hard safety boundary (repo principle "AI Never Modifies Production Directly"):
+ *  - Proposals are persisted ONLY as `draft`. This route NEVER submits,
+ *    validates, approves, commits, deploys, or graduates anything. The
+ *    human review → approval pipeline stays untouched.
+ *  - The route is ON-DEMAND only. There is NO scheduler / cron / timer that
+ *    auto-runs the cycle — cadence is a deferred product decision.
+ *  - No file-write / git / PR path is wired here.
+ *
+ * Pipeline: like the onchange endpoint (Spec 64), the request first passes
+ * through CommandLayer with `skipActionSlots = true` so auth / permission /
+ * tenant slots still run (the permission slot is NEVER skipped) while the
+ * action-specific slots are bypassed. The synthetic command name
+ * `"evolution.run_cycle"` exists only for metrics/tracing labels; the
+ * authoritative permission target is carried in `meta.evolution`.
+ */
+
+import { type EvolutionRuntime, persistCycleProposalsAsDrafts } from "@linchkit/core/server";
+import type { Elysia } from "elysia";
+import { getSharedProposalEngine } from "../proposal-api";
+import type { ServerOptions } from "../server";
+import { resolveActor, resolveStatusCode, serverError, serviceUnavailable } from "./shared";
+
+/**
+ * Canonical authorization-denied envelope — every 401/403 path returns the
+ * SAME payload so the response text cannot be used as a side channel.
+ */
+const AUTHZ_DENIED_BODY = {
+  success: false as const,
+  error: {
+    code: "AUTHZ_DENIED",
+    message: "Access denied",
+  },
+} as const;
+
+/** Synthetic command name for the run-cycle dispatch (metrics/tracing only). */
+export const RUN_CYCLE_COMMAND_NAME = "evolution.run_cycle";
+
+/** Wire-format response for a successful run-cycle invocation. */
+export interface RunCycleResponse {
+  success: true;
+  data: {
+    /** Number of cycle proposals newly persisted as `draft`. */
+    created: number;
+    /** Number of cycle proposals skipped as duplicates of an already-pending draft. */
+    deduped: number;
+    /** Total cycle proposals considered (`created + deduped`). */
+    total: number;
+    /** Engine ids of the drafts created this run (all `draft` status). */
+    createdIds: string[];
+  };
+}
+
+/**
+ * Mount `POST /api/evolution/run-cycle` onto the given Elysia app.
+ *
+ * Behavior summary:
+ *   501 — evolution runtime not configured (graceful degradation).
+ *   503 — command layer not configured (cannot run the permission slot).
+ *   401/403 — caller failed the CommandLayer permission slot (canonical envelope).
+ *   500 — unexpected throw while running the cycle / persisting drafts.
+ *   200 — cycle ran; returns `{ created, deduped, total, createdIds }`.
+ */
+export function mountEvolutionCycleRoutes(app: Elysia, options: ServerOptions): void {
+  const { commandLayer } = options;
+  const evolutionRuntime: EvolutionRuntime | undefined = options.evolutionRuntime;
+
+  app.post("/api/evolution/run-cycle", async ({ set, request }) => {
+    if (!evolutionRuntime) {
+      // 501 — feature not wired in this deployment. (No cycle to run.)
+      return serviceUnavailable(
+        set,
+        "Evolution runtime is not configured — on-demand cycle execution is unavailable.",
+        501,
+      );
+    }
+    if (!commandLayer) {
+      // The permission slot lives in CommandLayer; without it we cannot
+      // authorize a mutation, so fail closed rather than skipping the slot.
+      return serviceUnavailable(
+        set,
+        "Command layer is not configured — cannot authorize the evolution cycle trigger.",
+      );
+    }
+
+    // ── Permission slot (CommandLayer, skipActionSlots) ────────────────
+    // Run auth / permission / tenant BEFORE touching the evolution runtime so
+    // an unauthorized caller learns nothing beyond "access denied".
+    const actor = await resolveActor(request, options.resolveRequestActor);
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+    const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
+
+    const commandResult = await commandLayer.execute({
+      command: RUN_CYCLE_COMMAND_NAME,
+      input: {},
+      actor,
+      channel: "http",
+      headers,
+      traceId: incomingTraceId,
+      meta: {
+        // Permission middleware gates on this target rather than an action named
+        // "run_cycle". Mirrors the onchange route's `meta.onchange` convention.
+        evolution: { operation: "run_cycle" },
+      },
+      skipActionSlots: true,
+    });
+
+    if (!commandResult.success) {
+      const status = resolveStatusCode(commandResult);
+      set.status = status;
+      if (status === 401 || status === 403) {
+        return AUTHZ_DENIED_BODY;
+      }
+      const errData = commandResult.data as Record<string, unknown> | undefined;
+      const middlewareMessage = (errData?.error as string) ?? "Evolution cycle trigger blocked";
+      const middlewareCode = (errData?.code as string) ?? "EVOLUTION.RUN_CYCLE.BLOCKED";
+      return { success: false, error: { code: middlewareCode, message: middlewareMessage } };
+    }
+
+    // ── Run the cycle + persist drafts ─────────────────────────────────
+    // Propagate the tenant the CommandLayer tenant slot resolved so tenant-aware
+    // sensors scope their observations to the authorized tenant (passing only a
+    // timestamp would make them read global/default data, defeating that slot).
+    // `query` is intentionally omitted — the runtime injects its configured
+    // default query for any context that omits one.
+    try {
+      // The skipActionSlots dispatch returns the tenant the tenant slot resolved
+      // on `data.tenantId` (CommandLayer's synthetic non-action result).
+      const resolvedTenantId = (commandResult.data as { tenantId?: string } | undefined)?.tenantId;
+      const result = await evolutionRuntime.evolutionCycle.runCycle({
+        timestamp: new Date(),
+        tenantId: resolvedTenantId,
+      });
+      // Persist each cycle proposal as a `draft` in the shared governance
+      // engine, deduped against the already-pending set. NEVER submitted /
+      // approved here — the helper only calls createProposal (draft status).
+      const summary = persistCycleProposalsAsDrafts({
+        proposals: result.proposals,
+        engine: getSharedProposalEngine(),
+      });
+      const response: RunCycleResponse = {
+        success: true,
+        data: {
+          created: summary.created,
+          deduped: summary.deduped,
+          total: summary.total,
+          createdIds: summary.createdIds,
+        },
+      };
+      return response;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Evolution cycle execution failed";
+      return serverError(set, message);
+    }
+  });
+}

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -63,6 +63,7 @@ import { mountConfigRoutes } from "./routes/config-api";
 import { mountConfigStoreRoutes } from "./routes/config-store-api";
 import { mountDeployRoutes } from "./routes/deploy-api";
 import { mountEntityRoutes } from "./routes/entity-api";
+import { mountEvolutionCycleRoutes } from "./routes/evolution-cycle-api";
 import { mountHealthRoutes } from "./routes/health";
 import { mountImportRoutes } from "./routes/import-api";
 import { mountOnchangeRoutes } from "./routes/onchange-api";
@@ -216,6 +217,13 @@ export interface ServerOptions {
    * events and trigger the configured deployment callback.
    */
   deployWebhookHandler?: DeployWebhookHandler;
+  /**
+   * Evolution runtime (Spec 55) — when provided, enables
+   * `POST /api/evolution/run-cycle` to run one on-demand evolution cycle and
+   * persist its proposals as governance `draft`s. No-op (501) when absent.
+   * Running the cycle is strictly on-demand: there is NO scheduler.
+   */
+  evolutionRuntime?: import("@linchkit/core/server").EvolutionRuntime;
 }
 
 // Re-export parseAcceptLanguage for external consumers
@@ -450,6 +458,11 @@ export function createServer(
     ontology: opts.ontologyRegistry,
     strictCompatibility: environment.features.strictCompatibility,
   });
+
+  // ── Evolution cycle trigger (Spec 55 §7) ─────────────────────
+  // On-demand: runs one cycle and lands its proposals as governance drafts.
+  // No-op (501) when no evolution runtime is wired. There is NO scheduler.
+  mountEvolutionCycleRoutes(app, opts);
 
   // ── SSE Subscription endpoint (/api/subscribe) ────────────────
   mountSubscriptionRoutes(app, opts);

--- a/docs/specs/55_evolution_system.md
+++ b/docs/specs/55_evolution_system.md
@@ -428,6 +428,8 @@ Proposal: {
 }
 ```
 
+> **运行时落地（已实现，on-demand）**：演化回路的 `runCycle()` 通过按需端点 `POST /api/evolution/run-cycle` 触发（权限槽经 CommandLayer，不跳过）；产出的 Proposal 经 `persistCycleProposalsAsDrafts` 持久化为治理引擎中的 `draft`，进入既有人审管线（`GET /api/proposals`），并按 capability + change 名去重避免重复。**仅产 `draft`**——不 submit/approve/落地。自动调度（cadence）与"毕业到代码/PR"（§7.6/§7.7）仍是独立、受控的后续步骤。
+
 ### 7.2 Skill 复用
 
 进化系统在归因和生成 Proposal 时，不只看内部数据——通过复用现有的 Skill/Tool 生态来获取外部上下文：

--- a/packages/core/__tests__/barrel-public-surface.test.ts
+++ b/packages/core/__tests__/barrel-public-surface.test.ts
@@ -368,6 +368,7 @@ const EXPECTED_SERVER_EXPORTS = [
   "noopTracer",
   "overlayStatusEnum",
   "overrideTargetTypeEnum",
+  "persistCycleProposalsAsDrafts",
   "redactContent",
   "redactPromptMessages",
   "registerDoctorCheck",

--- a/packages/core/src/__tests__/engine/evolution-cycle-drafts.test.ts
+++ b/packages/core/src/__tests__/engine/evolution-cycle-drafts.test.ts
@@ -1,0 +1,223 @@
+/**
+ * persistCycleProposalsAsDrafts — evolution-cycle → governance-draft bridge tests.
+ *
+ * Asserts the SAFE-side contract (Spec 55 §7):
+ *   (a) every cycle proposal becomes a `draft` in the shared ProposalEngine;
+ *   (b) re-running the same cycle does NOT create duplicate drafts;
+ *   (c) nothing is submitted / approved — status stays `draft`;
+ *   (d) the returned summary `{ created, deduped, total }` is accurate;
+ *   (e) within-batch duplicates are collapsed;
+ *   (f) structurally-distinct proposals on the same capability are NOT deduped.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { persistCycleProposalsAsDrafts } from "../../engine/evolution-cycle-drafts";
+import { createProposalEngine } from "../../engine/proposal-engine";
+import type { ProposalDefinition } from "../../types/proposal";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+/**
+ * Build a cycle-style ProposalDefinition (as `EvolutionCycleResult.proposals`
+ * carries them). The id/status here are deliberately "live"-looking to prove
+ * the helper never copies them — it always mints a fresh `draft`.
+ */
+function cycleProposal(overrides?: Partial<ProposalDefinition>): ProposalDefinition {
+  const now = new Date();
+  return {
+    id: "cycle-source-id-should-be-ignored",
+    title: "Add default for order.currency",
+    description: "Detected USD in 95% of records",
+    author: { type: "ai", id: "insight-translator", name: "Insight Translator" },
+    capability: "order",
+    changeType: "minor",
+    changes: [
+      { target: "rule", operation: "create", name: "order_currency_default", diff: "set USD" },
+    ],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: ["order_currency_default"],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    // Source status is irrelevant — helper must never copy it.
+    status: "validated",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("persistCycleProposalsAsDrafts", () => {
+  test("(a) each cycle proposal becomes a draft in the engine", () => {
+    const engine = createProposalEngine();
+    const proposals = [
+      cycleProposal(),
+      cycleProposal({
+        title: "Add validation for invoice.total",
+        capability: "invoice",
+        changes: [
+          { target: "rule", operation: "create", name: "invoice_total_positive", diff: ">0" },
+        ],
+      }),
+    ];
+
+    const result = persistCycleProposalsAsDrafts({ proposals, engine });
+
+    expect(result.created).toBe(2);
+    expect(result.deduped).toBe(0);
+    expect(result.total).toBe(2);
+    expect(result.createdIds).toHaveLength(2);
+
+    const stored = engine.listProposals({});
+    expect(stored).toHaveLength(2);
+    // Every persisted proposal is a draft.
+    for (const p of stored) {
+      expect(p.status).toBe("draft");
+    }
+    // Engine assigned fresh ids — the source id is never reused.
+    for (const id of result.createdIds) {
+      expect(id).not.toBe("cycle-source-id-should-be-ignored");
+    }
+  });
+
+  test("(b) re-running the same cycle does not create duplicates", () => {
+    const engine = createProposalEngine();
+    const proposals = [cycleProposal()];
+
+    const first = persistCycleProposalsAsDrafts({ proposals, engine });
+    expect(first.created).toBe(1);
+    expect(first.deduped).toBe(0);
+
+    // Re-run with structurally-identical proposals.
+    const second = persistCycleProposalsAsDrafts({ proposals: [cycleProposal()], engine });
+    expect(second.created).toBe(0);
+    expect(second.deduped).toBe(1);
+    expect(second.total).toBe(1);
+
+    // Engine still holds exactly one draft.
+    expect(engine.listProposals({})).toHaveLength(1);
+    expect(engine.listProposals({ status: "draft" })).toHaveLength(1);
+  });
+
+  test("(c) nothing is submitted or approved — status stays draft", () => {
+    const engine = createProposalEngine();
+    persistCycleProposalsAsDrafts({ proposals: [cycleProposal()], engine });
+
+    // No validated / approved / committed / deployed proposals exist.
+    expect(engine.listProposals({ status: "validated" })).toHaveLength(0);
+    expect(engine.listProposals({ status: "approved" })).toHaveLength(0);
+    expect(engine.listProposals({ status: "committed" })).toHaveLength(0);
+    expect(engine.listProposals({ status: "deployed" })).toHaveLength(0);
+    // Every stored proposal is draft.
+    expect(engine.listProposals({ status: "draft" })).toHaveLength(1);
+  });
+
+  test("(d) empty cycle produces a zero summary and persists nothing", () => {
+    const engine = createProposalEngine();
+    const result = persistCycleProposalsAsDrafts({ proposals: [], engine });
+    expect(result).toEqual({ created: 0, deduped: 0, total: 0, createdIds: [] });
+    expect(engine.listProposals({})).toHaveLength(0);
+  });
+
+  test("(e) within-batch structural duplicates are collapsed", () => {
+    const engine = createProposalEngine();
+    // Two structurally-identical proposals in ONE batch.
+    const result = persistCycleProposalsAsDrafts({
+      proposals: [cycleProposal(), cycleProposal()],
+      engine,
+    });
+    expect(result.created).toBe(1);
+    expect(result.deduped).toBe(1);
+    expect(result.total).toBe(2);
+    expect(engine.listProposals({})).toHaveLength(1);
+  });
+
+  test("(f) same capability but different changes are NOT deduped", () => {
+    const engine = createProposalEngine();
+    const result = persistCycleProposalsAsDrafts({
+      proposals: [
+        cycleProposal(),
+        cycleProposal({
+          changes: [
+            { target: "rule", operation: "create", name: "order_status_required", diff: "req" },
+          ],
+        }),
+      ],
+      engine,
+    });
+    expect(result.created).toBe(2);
+    expect(result.deduped).toBe(0);
+    expect(engine.listProposals({})).toHaveLength(2);
+  });
+
+  test("(g) dedup ignores terminal-status proposals (rejected re-surfaces)", async () => {
+    const engine = createProposalEngine();
+    // Drive a seed to terminal "rejected" via the real lifecycle
+    // (create → submit → reject). rejectProposal requires status "validated",
+    // so the seed must be a payload that passes validation. Dedup keys on
+    // capability + change NAMES (not target/operation), so a valid entity-create
+    // whose change name matches cycleProposal()'s shares the same dedup key.
+    const seed = engine.createProposal({
+      title: "seed",
+      description: "seed",
+      author: { type: "ai", id: "x", name: "x" },
+      capability: "order",
+      changeType: "minor",
+      changes: [
+        {
+          target: "entity",
+          operation: "create",
+          name: "order_currency_default",
+          definition: { name: "order_currency_default", fields: { amount: { type: "number" } } },
+        },
+      ],
+    });
+    engine.submitProposal({ proposalId: seed.id });
+    expect(engine.getProposal(seed.id).status).toBe("validated"); // guard: rejectable
+    await engine.rejectProposal({ proposalId: seed.id, reason: "not now" });
+    expect(engine.getProposal(seed.id).status).toBe("rejected");
+
+    // The rejected seed is terminal (not pending), so an identical-keyed cycle
+    // proposal must re-surface as a fresh draft rather than being deduped.
+    const result = persistCycleProposalsAsDrafts({ proposals: [cycleProposal()], engine });
+    expect(result.created).toBe(1);
+    expect(result.deduped).toBe(0);
+  });
+
+  test("(h) dedup includes approved (not-yet-graduated) proposals", async () => {
+    const engine = createProposalEngine();
+    // An approved-but-not-graduated proposal is accepted work — re-running the
+    // cycle must NOT re-surface a duplicate draft for it. Drive a same-keyed
+    // seed to "approved" via the real lifecycle.
+    const seed = engine.createProposal({
+      title: "seed",
+      description: "seed",
+      author: { type: "ai", id: "x", name: "x" },
+      capability: "order",
+      changeType: "minor",
+      changes: [
+        {
+          target: "entity",
+          operation: "create",
+          name: "order_currency_default",
+          definition: { name: "order_currency_default", fields: { amount: { type: "number" } } },
+        },
+      ],
+    });
+    engine.submitProposal({ proposalId: seed.id });
+    expect(engine.getProposal(seed.id).status).toBe("validated");
+    await engine.approveProposal({
+      proposalId: seed.id,
+      approvedBy: { type: "human", id: "admin" },
+    });
+    expect(engine.getProposal(seed.id).status).toBe("approved");
+
+    const result = persistCycleProposalsAsDrafts({ proposals: [cycleProposal()], engine });
+    expect(result.created).toBe(0);
+    expect(result.deduped).toBe(1);
+  });
+});

--- a/packages/core/src/engine/evolution-cycle-drafts.ts
+++ b/packages/core/src/engine/evolution-cycle-drafts.ts
@@ -107,7 +107,10 @@ export function persistCycleProposalsAsDrafts(
       pendingKeys.add(
         dedupKey(
           existing.capability,
-          existing.changes.map((c) => c.name),
+          // Defensive: `changes` is required by the type, but a proposal loaded
+          // from persistent/external storage could be malformed. One bad row
+          // must not crash dedup over the whole pending set.
+          (existing.changes ?? []).map((c) => c.name),
         ),
       );
     }
@@ -119,7 +122,9 @@ export function persistCycleProposalsAsDrafts(
   for (const proposal of proposals) {
     const key = dedupKey(
       proposal.capability,
-      proposal.changes.map((c) => c.name),
+      // Defensive: guard a malformed cycle proposal with no `changes` so a
+      // partially-initialized translator output can't crash the batch.
+      (proposal.changes ?? []).map((c) => c.name),
     );
     if (pendingKeys.has(key)) {
       deduped += 1;

--- a/packages/core/src/engine/evolution-cycle-drafts.ts
+++ b/packages/core/src/engine/evolution-cycle-drafts.ts
@@ -1,0 +1,149 @@
+/**
+ * Evolution-cycle → governance-draft bridge (Spec 55 §7).
+ *
+ * The Spec 55 evolution loop produces `ProposalDefinition[]` as TRANSIENT
+ * cycle output (`EvolutionCycleResult.proposals`). Those objects never reach
+ * the governance review pipeline on their own, so a human can never review
+ * them. This helper closes that gap on the SAFE side: it persists each cycle
+ * proposal as a NEW `draft` in the shared {@link ProposalEngine}, deduping
+ * against the engine's already-pending set so re-running a cycle does not pile
+ * up duplicate drafts.
+ *
+ * Hard safety boundary (matches the repo principle "AI Never Modifies
+ * Production Directly"):
+ *  - Drafts are created via `ProposalEngine.createProposal`, which ALWAYS lands
+ *    them in `draft` status. This helper NEVER submits, validates, approves,
+ *    commits, deploys, or graduates a proposal. The existing human review →
+ *    approval pipeline stays untouched.
+ *  - There is no scheduler/timer here — invocation cadence is the caller's
+ *    concern (this is an on-demand bridge only).
+ */
+
+import type { ProposalDefinition } from "../types/proposal";
+import type { CreateProposalOptions, ProposalEngine } from "./proposal-engine";
+
+/**
+ * Statuses considered "active" for dedup purposes — a proposal already in, or
+ * already accepted by, the human review pipeline. `approved` is included: an
+ * approved-but-not-yet-graduated proposal is accepted work, so re-running the
+ * cycle must not surface a duplicate draft for it. We do NOT dedup against
+ * `rejected` (a previously-rejected but recurring insight should re-surface a
+ * fresh draft for re-review), nor against the landed terminal statuses
+ * `committed` / `deployed` (a regression after landing may legitimately
+ * re-propose the same change).
+ */
+const PENDING_STATUSES: ReadonlySet<string> = new Set([
+  "draft",
+  "validating",
+  "validated",
+  "approved",
+]);
+
+/** Summary returned by {@link persistCycleProposalsAsDrafts}. */
+export interface PersistCycleDraftsResult {
+  /** Number of cycle proposals newly persisted as `draft`. */
+  created: number;
+  /** Number of cycle proposals skipped because an equivalent draft is already pending. */
+  deduped: number;
+  /** Total cycle proposals considered (`created + deduped`). */
+  total: number;
+  /** Engine ids of the drafts created this run (in input order). */
+  createdIds: string[];
+}
+
+/** Options for {@link persistCycleProposalsAsDrafts}. */
+export interface PersistCycleDraftsOptions {
+  /** Proposals emitted by an evolution cycle (`EvolutionCycleResult.proposals`). */
+  proposals: ProposalDefinition[];
+  /** Shared governance engine the review UI reads from. */
+  engine: ProposalEngine;
+}
+
+/**
+ * Build a stable dedup key for a proposal: its capability plus the sorted set
+ * of its change names. This mirrors the existing PatternDetector dedup
+ * heuristic in `proposal-api.ts` (capability + change-name match) but extends
+ * it to the full change set so two proposals touching the same capability with
+ * different changes are NOT collapsed.
+ */
+function dedupKey(capability: string, changeNames: string[]): string {
+  const sorted = [...changeNames].sort();
+  return `${capability}::${sorted.join(",")}`;
+}
+
+/**
+ * Persist each cycle proposal as a `draft` in the shared {@link ProposalEngine},
+ * skipping any that duplicate an already-pending draft.
+ *
+ * Dedup heuristic: a cycle proposal is considered a duplicate when the engine
+ * already holds a PENDING proposal (`draft` / `validating` / `validated`) with
+ * the same {@link dedupKey} (capability + change-name set). This mirrors the
+ * pre-create dedup the `POST /api/proposals` insight path uses, applied to the
+ * batch so re-running the same cycle is idempotent.
+ *
+ * The source `ProposalDefinition` is mapped onto `createProposal` faithfully:
+ * `title`, `description`, `author`, `capability`, `changeType`, and `changes`
+ * carry over verbatim. The engine assigns a fresh id, recomputes auto-impact,
+ * and stamps `status: "draft"` — we never copy the source id or status, so a
+ * cycle proposal can only ever ENTER the pipeline as a new draft.
+ *
+ * Note on pre-analysis: `EvolutionCycleResult.proposalAnalyses` is intentionally
+ * NOT attached here — neither `CreateProposalOptions` nor `ProposalDefinition`
+ * has a slot for it, and wiring new plumbing for it is out of scope. See the
+ * route/spec notes.
+ */
+export function persistCycleProposalsAsDrafts(
+  options: PersistCycleDraftsOptions,
+): PersistCycleDraftsResult {
+  const { proposals, engine } = options;
+
+  // Snapshot the engine's currently-pending dedup keys ONCE up front. We then
+  // augment this set as we create new drafts so duplicates WITHIN a single
+  // cycle batch are also collapsed (a translator could, in principle, emit two
+  // structurally-identical proposals in one run).
+  const pendingKeys = new Set<string>();
+  for (const existing of engine.listProposals({})) {
+    if (PENDING_STATUSES.has(existing.status)) {
+      pendingKeys.add(
+        dedupKey(
+          existing.capability,
+          existing.changes.map((c) => c.name),
+        ),
+      );
+    }
+  }
+
+  const createdIds: string[] = [];
+  let deduped = 0;
+
+  for (const proposal of proposals) {
+    const key = dedupKey(
+      proposal.capability,
+      proposal.changes.map((c) => c.name),
+    );
+    if (pendingKeys.has(key)) {
+      deduped += 1;
+      continue;
+    }
+
+    const createOptions: CreateProposalOptions = {
+      title: proposal.title,
+      description: proposal.description,
+      author: proposal.author,
+      capability: proposal.capability,
+      changeType: proposal.changeType,
+      changes: proposal.changes,
+    };
+    const draft = engine.createProposal(createOptions);
+    createdIds.push(draft.id);
+    // Record the key so a duplicate later in THIS batch is also deduped.
+    pendingKeys.add(key);
+  }
+
+  return {
+    created: createdIds.length,
+    deduped,
+    total: proposals.length,
+    createdIds,
+  };
+}

--- a/packages/core/src/exports/server/engines.ts
+++ b/packages/core/src/exports/server/engines.ts
@@ -43,6 +43,11 @@ export {
   PipelineError,
   type SlotName,
 } from "../../engine/command-layer";
+export {
+  type PersistCycleDraftsOptions,
+  type PersistCycleDraftsResult,
+  persistCycleProposalsAsDrafts,
+} from "../../engine/evolution-cycle-drafts";
 // Generator priority aggregator (Spec 55 §7.7 Phase 3)
 export {
   createGeneratorPriorityAggregator,


### PR DESCRIPTION
## What & why

The Spec-55 evolution cycle could PRODUCE proposals (after the runtime was wired in #485), but **`runCycle()` was never invoked at runtime** and its proposals were transient — they never reached the human review pipeline. This closes that gap on the SAFE side: cycle proposals now reach review as **drafts**.

## Change

- **`persistCycleProposalsAsDrafts` (`@linchkit/core`)** — maps each cycle `ProposalDefinition` → a governance `draft` via `ProposalEngine.createProposal`, deduped against the already-**active** set (capability + change names), idempotent. Never copies source id/status — only ENTERS as a fresh `draft`.
- **`POST /api/evolution/run-cycle` (`@linchkit/cap-adapter-server`)** — runs one cycle on demand through **CommandLayer** (permission slot never skipped; 501/503 degradation, canonical authz envelope), propagates the resolved **tenant** into the cycle, persists drafts, returns `{ created, deduped, total, createdIds }`.

## Safety boundary
**Drafts only** — nothing submitted/validated/approved/committed/deployed/graduated. **No scheduler** (cadence deferred). **No file-write/git/PR.**

## Review
Cross-model (codex), both findings fixed: [P1] propagate CommandLayer-resolved tenant into runCycle (was discarded); [P2] include `approved` in dedup set (was duplicating accepted work). Regression tests added.

## Tests
`evolution-cycle-drafts.test.ts` — 8 tests (draft-only, idempotent, within-batch dedup, distinct-not-deduped, rejected re-surfaces, approved dedups). check / typecheck / full `bun run test` green. Spec 55 §7 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand evolution cycle endpoint to trigger a single run
  * Cycle proposals are persisted as governance draft records with idempotent deduplication

* **Documentation**
  * Clarified evolution system docs: on-demand run behavior, draft-only path, and separation from scheduling/graduation

* **Tests**
  * Added tests validating draft persistence, deduplication, and summary reporting (created/deduped/total/ids)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->