### PR TITLE
feat(adapter-server): manual graduation of approved proposals to a PR (G4)

### DIFF
--- a/.changeset/proposal-manual-graduate.md
+++ b/.changeset/proposal-manual-graduate.md
@@ -1,0 +1,7 @@
+---
+"@linchkit/cap-adapter-server": minor
+---
+
+Add a manual, admin-triggered graduation path for approved proposals (Spec 55 §7.6/§7.7). New `POST /api/proposals/:id/graduate` writes an already-`approved` proposal's definition files to disk (`ProposalFileWriter`) and opens a GitHub PR (`ProposalGitCommitter.commitAndOpenPR`). It **never auto-fires on approval** (no `onApproved` wiring, no scheduler) and **never auto-merges** — graduation is human-triggered and the resulting PR is human-reviewed, preserving "AI never modifies production directly".
+
+Guards: `404` if the proposal is missing; `422` if it is not `approved` (the guard runs before any side effect); `503` `GRADUATION.NOT_CONFIGURED` (resolved before touching the engine, no existence leak) when git/GitHub is not configured. Config is sourced from the environment (`GITHUB_TOKEN`/`GH_TOKEN` required; optional `PROPOSAL_GRADUATE_ROOT_DIR`/`_BASE_BRANCH`/`_REMOTE`). On success it records the graduation (approved→committed) best-effort and returns `{ prUrl, branch, commitSha, committed }`.

--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-graduate-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-graduate-api.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Manual proposal graduation — unit + endpoint tests.
+ *
+ * Covers the injectable orchestrator (`graduateProposal`) and the Elysia route
+ * (`mountProposalGraduateAPI`). The file writer and git committer are ALWAYS
+ * injected stubs — no real filesystem, `git`, or `gh` is touched. A spy asserts
+ * the committer is only ever asked to OPEN a PR (commitAndOpenPR), never merge.
+ *
+ * Endpoint tests dispatch via `app.handle(new Request(...))` (in-process,
+ * port-free). `app.listen(PORT)` is intentionally avoided — a bound socket per
+ * suite SEGFAULTS the batched addons run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CommandLayer, ProposalDefinition } from "@linchkit/core";
+import type { ProposalGitCommitResult } from "@linchkit/core/server";
+import { Elysia } from "elysia";
+import {
+  type GraduationConfig,
+  type GraduationEngine,
+  type GraduationFileWriter,
+  type GraduationGitCommitter,
+  graduateProposal,
+  mountProposalGraduateAPI,
+  resolveGraduationConfig,
+} from "../src/proposal-graduate-api";
+
+const BASE = "http://local.test";
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+function makeProposal(overrides: Partial<ProposalDefinition> = {}): ProposalDefinition {
+  const now = new Date();
+  return {
+    id: "prop-abc12345",
+    title: "Add late-fee rule",
+    description: "Adds a rule for late fees",
+    author: { type: "ai", id: "pattern-detector", name: "Pattern Detector" },
+    capability: "cap-demo",
+    changeType: "minor",
+    changes: [{ target: "rule", operation: "create", name: "late_fee" }],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: ["late_fee"],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "approved",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as ProposalDefinition;
+}
+
+const PR_RESULT: ProposalGitCommitResult = {
+  branch: "proposal/abc12345-add-late-fee-rule",
+  prUrl: "https://github.com/acme/repo/pull/42",
+  commitSha: "deadbeefcafef00d",
+};
+
+/** Committer stub that records calls and EXPOSES NO merge method. */
+function makeCommitterSpy(result: ProposalGitCommitResult = PR_RESULT): {
+  committer: GraduationGitCommitter;
+  calls: Array<{ proposalId: string; files: readonly string[] }>;
+} {
+  const calls: Array<{ proposalId: string; files: readonly string[] }> = [];
+  const committer: GraduationGitCommitter = {
+    async commitAndOpenPR(proposal, writtenFiles) {
+      calls.push({ proposalId: proposal.id, files: writtenFiles });
+      return result;
+    },
+  };
+  return { committer, calls };
+}
+
+function makeWriterSpy(
+  files: string[] = ["/repo/addons/demo/cap-demo/src/rules/late_fee.rule.ts"],
+): {
+  writer: GraduationFileWriter;
+  calls: ProposalDefinition[];
+} {
+  const calls: ProposalDefinition[] = [];
+  const writer: GraduationFileWriter = {
+    async writeApprovedProposal(proposal) {
+      calls.push(proposal);
+      return files;
+    },
+  };
+  return { writer, calls };
+}
+
+function makeEngine(
+  proposal: ProposalDefinition | undefined,
+  opts: { withCommit?: boolean; commitThrows?: boolean } = {},
+): { engine: GraduationEngine; committedIds: string[] } {
+  const committedIds: string[] = [];
+  const engine: GraduationEngine = {
+    getProposal(id) {
+      if (!proposal || proposal.id !== id) throw new Error(`Proposal "${id}" not found`);
+      return proposal;
+    },
+  };
+  if (opts.withCommit !== false) {
+    engine.commitProposal = ({ proposalId }) => {
+      if (opts.commitThrows) throw new Error("commit bookkeeping failed");
+      committedIds.push(proposalId);
+      return undefined;
+    };
+  }
+  return { engine, committedIds };
+}
+
+const CONFIG: GraduationConfig = { rootDir: "/repo" };
+
+// ── graduateProposal (orchestrator) ──────────────────────────
+
+describe("graduateProposal — approved-only guard", () => {
+  test("non-approved proposal → not_approved; writer/committer NOT called", async () => {
+    const proposal = makeProposal({ status: "draft" });
+    const { engine } = makeEngine(proposal);
+    const { writer, calls: writerCalls } = makeWriterSpy();
+    const { committer, calls: committerCalls } = makeCommitterSpy();
+
+    const outcome = await graduateProposal(proposal.id, { engine, writer, committer });
+
+    expect(outcome.kind).toBe("not_approved");
+    if (outcome.kind === "not_approved") expect(outcome.status).toBe("draft");
+    expect(writerCalls).toHaveLength(0);
+    expect(committerCalls).toHaveLength(0);
+  });
+
+  test("missing proposal → not_found; writer/committer NOT called", async () => {
+    const { engine } = makeEngine(undefined);
+    const { writer, calls: writerCalls } = makeWriterSpy();
+    const { committer, calls: committerCalls } = makeCommitterSpy();
+
+    const outcome = await graduateProposal("does-not-exist", { engine, writer, committer });
+
+    expect(outcome.kind).toBe("not_found");
+    expect(writerCalls).toHaveLength(0);
+    expect(committerCalls).toHaveLength(0);
+  });
+});
+
+describe("graduateProposal — approved happy path", () => {
+  test("calls writeApprovedProposal then commitAndOpenPR; returns PR result", async () => {
+    const proposal = makeProposal();
+    const { engine, committedIds } = makeEngine(proposal);
+    const { writer, calls: writerCalls } = makeWriterSpy(["/repo/a.ts", "/repo/b.ts"]);
+    const { committer, calls: committerCalls } = makeCommitterSpy();
+
+    const outcome = await graduateProposal(proposal.id, { engine, writer, committer });
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.result).toEqual(PR_RESULT);
+      expect(outcome.committed).toBe(true);
+    }
+    // writer ran, then committer received the EXACT files the writer returned
+    expect(writerCalls).toHaveLength(1);
+    expect(writerCalls[0]?.id).toBe(proposal.id);
+    expect(committerCalls).toHaveLength(1);
+    expect(committerCalls[0]?.files).toEqual(["/repo/a.ts", "/repo/b.ts"]);
+    // graduation recorded (approved → committed)
+    expect(committedIds).toEqual([proposal.id]);
+  });
+
+  test("committer is ONLY asked to open a PR — never merge", async () => {
+    const proposal = makeProposal();
+    const { engine } = makeEngine(proposal);
+    const { writer } = makeWriterSpy();
+    const { committer, calls } = makeCommitterSpy();
+
+    // The committer contract exposes exactly one method: commitAndOpenPR.
+    // There is no merge surface to call, and the only invocation is the PR open.
+    expect(Object.keys(committer)).toEqual(["commitAndOpenPR"]);
+    expect(committer).not.toHaveProperty("merge");
+    expect(committer).not.toHaveProperty("mergePR");
+
+    await graduateProposal(proposal.id, { engine, writer, committer });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("engine without commitProposal → ok with committed=false (status untouched)", async () => {
+    const proposal = makeProposal();
+    const { engine } = makeEngine(proposal, { withCommit: false });
+    const { writer } = makeWriterSpy();
+    const { committer } = makeCommitterSpy();
+
+    const outcome = await graduateProposal(proposal.id, { engine, writer, committer });
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") expect(outcome.committed).toBe(false);
+  });
+
+  test("commitProposal throwing does NOT fail graduation (PR already open)", async () => {
+    const proposal = makeProposal();
+    const { engine } = makeEngine(proposal, { commitThrows: true });
+    const { writer } = makeWriterSpy();
+    const { committer } = makeCommitterSpy();
+
+    const outcome = await graduateProposal(proposal.id, { engine, writer, committer });
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") expect(outcome.committed).toBe(false);
+  });
+});
+
+describe("graduateProposal — failure surfaces as error", () => {
+  test("writer throwing → error; committer NOT reached", async () => {
+    const proposal = makeProposal();
+    const { engine } = makeEngine(proposal);
+    const failingWriter: GraduationFileWriter = {
+      async writeApprovedProposal() {
+        throw new Error("disk full");
+      },
+    };
+    const { committer, calls } = makeCommitterSpy();
+
+    const outcome = await graduateProposal(proposal.id, {
+      engine,
+      writer: failingWriter,
+      committer,
+    });
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.message).toContain("disk full");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("committer throwing (e.g. gh failure) → error", async () => {
+    const proposal = makeProposal();
+    const { engine } = makeEngine(proposal);
+    const { writer } = makeWriterSpy();
+    const failingCommitter: GraduationGitCommitter = {
+      async commitAndOpenPR() {
+        throw new Error("gh pr create failed");
+      },
+    };
+    const outcome = await graduateProposal(proposal.id, {
+      engine,
+      writer,
+      committer: failingCommitter,
+    });
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.message).toContain("gh pr create failed");
+  });
+});
+
+// ── resolveGraduationConfig (env sourcing) ───────────────────
+
+describe("resolveGraduationConfig", () => {
+  test("no GitHub token → null (graduation not configured)", () => {
+    expect(resolveGraduationConfig({})).toBeNull();
+    expect(resolveGraduationConfig({ GITHUB_TOKEN: "  " })).toBeNull();
+  });
+
+  test("GITHUB_TOKEN present → config with cwd rootDir default", () => {
+    const config = resolveGraduationConfig({ GITHUB_TOKEN: "ghp_x" });
+    expect(config).not.toBeNull();
+    expect(config?.rootDir).toBe(process.cwd());
+  });
+
+  test("GH_TOKEN + overrides honoured", () => {
+    const config = resolveGraduationConfig({
+      GH_TOKEN: "ghp_y",
+      PROPOSAL_GRADUATE_ROOT_DIR: "/srv/repo",
+      PROPOSAL_GRADUATE_BASE_BRANCH: "develop",
+      PROPOSAL_GRADUATE_REMOTE: "upstream",
+    });
+    expect(config).toEqual({
+      rootDir: "/srv/repo",
+      baseBranch: "develop",
+      remote: "upstream",
+    });
+  });
+});
+
+// ── Endpoint: POST /api/proposals/:id/graduate ───────────────
+
+interface GraduateJson {
+  success: boolean;
+  data?: { prUrl?: string; branch?: string; commitSha?: string; committed?: boolean };
+  error?: { message?: string; code?: string };
+}
+
+/** A permissive command layer so endpoint tests exercise the graduation logic. */
+const PASS_COMMAND_LAYER = {
+  execute: async () => ({ success: true, data: { skipped: true } }),
+} as unknown as CommandLayer;
+
+function mountTestApp(opts: {
+  proposal?: ProposalDefinition;
+  config?: GraduationConfig | null;
+  committer?: GraduationGitCommitter;
+  writer?: GraduationFileWriter;
+  commandLayer?: CommandLayer;
+}): { app: Elysia; committerCalls: Array<{ proposalId: string; files: readonly string[] }> } {
+  const { engine } = makeEngine(opts.proposal);
+  const { committer, calls } =
+    opts.committer === undefined
+      ? makeCommitterSpy()
+      : {
+          committer: opts.committer,
+          calls: [] as Array<{ proposalId: string; files: readonly string[] }>,
+        };
+  const { writer } = opts.writer === undefined ? makeWriterSpy() : { writer: opts.writer };
+  const app = new Elysia();
+  mountProposalGraduateAPI(app, {
+    commandLayer: opts.commandLayer ?? PASS_COMMAND_LAYER,
+    engine,
+    resolveConfig: () => (opts.config === undefined ? CONFIG : opts.config),
+    createWriter: () => writer,
+    createCommitter: () => committer,
+  });
+  return { app, committerCalls: calls };
+}
+
+async function postGraduate(
+  app: Elysia,
+  id: string,
+): Promise<{ status: number; json: GraduateJson }> {
+  const res = await app.handle(
+    new Request(`${BASE}/api/proposals/${id}/graduate`, { method: "POST" }),
+  );
+  return { status: res.status, json: (await res.json()) as GraduateJson };
+}
+
+describe("POST /api/proposals/:id/graduate", () => {
+  test("approved → 200 with PR data; committer asked to open exactly one PR", async () => {
+    const proposal = makeProposal();
+    const { app, committerCalls } = mountTestApp({ proposal });
+    const { status, json } = await postGraduate(app, proposal.id);
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.prUrl).toBe(PR_RESULT.prUrl);
+    expect(json.data?.branch).toBe(PR_RESULT.branch);
+    expect(json.data?.commitSha).toBe(PR_RESULT.commitSha);
+    expect(json.data?.committed).toBe(true);
+    expect(committerCalls).toHaveLength(1);
+  });
+
+  test("unauthorized caller → 403 canonical AUTHZ_DENIED; nothing written/committed", async () => {
+    const proposal = makeProposal();
+    const denying = {
+      execute: async () => ({ success: false, data: { error: "not allowed" } }),
+    } as unknown as CommandLayer;
+    const { app, committerCalls } = mountTestApp({ proposal, commandLayer: denying });
+    const { status, json } = await postGraduate(app, proposal.id);
+    expect(status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+    expect(committerCalls).toHaveLength(0);
+  });
+
+  test("command layer absent → 503 (cannot authorize); committer NOT called", async () => {
+    const proposal = makeProposal();
+    const { committer, calls } = makeCommitterSpy();
+    // Mount WITHOUT a command layer — the permission slot cannot run, so the
+    // endpoint must fail closed rather than authorize a high-impact mutation.
+    const app = new Elysia();
+    mountProposalGraduateAPI(app, {
+      engine: makeEngine(proposal).engine,
+      resolveConfig: () => CONFIG,
+      createWriter: () => makeWriterSpy().writer,
+      createCommitter: () => committer,
+    });
+    const { status, json } = await postGraduate(app, proposal.id);
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("not approved → 422; committer NOT called", async () => {
+    const proposal = makeProposal({ status: "validated" });
+    const { app, committerCalls } = mountTestApp({ proposal });
+    const { status, json } = await postGraduate(app, proposal.id);
+
+    expect(status).toBe(422);
+    expect(json.success).toBe(false);
+    expect(json.error?.message).toContain("approved");
+    expect(committerCalls).toHaveLength(0);
+  });
+
+  test("missing proposal → 404", async () => {
+    const { app } = mountTestApp({ proposal: makeProposal() });
+    const { status, json } = await postGraduate(app, "nope");
+    expect(status).toBe(404);
+    expect(json.success).toBe(false);
+  });
+
+  test("git not configured → 503 graceful envelope; no write/commit attempted", async () => {
+    const proposal = makeProposal();
+    const failWriter: GraduationFileWriter = {
+      async writeApprovedProposal() {
+        throw new Error("should not be called when unconfigured");
+      },
+    };
+    const { app, committerCalls } = mountTestApp({ proposal, config: null, writer: failWriter });
+    const { status, json } = await postGraduate(app, proposal.id);
+
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("GRADUATION.NOT_CONFIGURED");
+    expect(committerCalls).toHaveLength(0);
+  });
+
+  test("write/commit failure → 500", async () => {
+    const proposal = makeProposal();
+    const failingCommitter: GraduationGitCommitter = {
+      async commitAndOpenPR() {
+        throw new Error("push rejected");
+      },
+    };
+    const { app } = mountTestApp({ proposal, committer: failingCommitter });
+    const { status, json } = await postGraduate(app, proposal.id);
+
+    expect(status).toBe(500);
+    expect(json.success).toBe(false);
+    expect(json.error?.message).toContain("push rejected");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/proposal-graduate-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-graduate-api.ts
@@ -1,0 +1,359 @@
+/**
+ * Manual proposal graduation REST endpoint — Spec 55 §7.6 + §7.7.
+ *
+ * Adds `POST /api/proposals/:id/graduate`: an ADMIN-triggered, on-demand path
+ * that takes an ALREADY-APPROVED proposal, writes its definition files to disk
+ * (`ProposalFileWriter`), and opens a GitHub PR (`ProposalGitCommitter`).
+ *
+ * SAFETY BOUNDARY (do NOT cross — see CLAUDE.md "AI Never Modifies Production Directly"):
+ *   - Graduation is MANUAL only. This endpoint is the sole trigger. We do NOT
+ *     wire `ProposalEngine.onApproved` to auto-graduate, and there is no
+ *     background scheduler.
+ *   - We NEVER auto-merge. `ProposalGitCommitter.commitAndOpenPR` only opens a
+ *     PR for human review; this module never calls any merge path.
+ *   - Approved-only. A non-approved proposal is refused with a 4xx and nothing
+ *     is written or committed.
+ *
+ * The HTTP handler is a thin shell around the injectable {@link graduateProposal}
+ * orchestrator so the core flow can be unit-tested with fake writer/committer
+ * stubs (no real `git`/`gh`/filesystem). The route mirrors the error envelope,
+ * handler shape, and `set.status` discipline of the approve/reject routes in
+ * `proposal-api.ts`.
+ */
+
+import type { Actor, CommandLayer, ProposalDefinition } from "@linchkit/core";
+import {
+  createProposalGitCommitter,
+  ProposalFileWriter,
+  type ProposalGitCommitResult,
+} from "@linchkit/core/server";
+import { getSharedProposalEngine } from "./proposal-api";
+import { resolveActor, resolveStatusCode } from "./routes/shared";
+
+/** Synthetic command name for the graduate dispatch (metrics/tracing only). */
+const GRADUATE_COMMAND_NAME = "proposal.graduate";
+
+/**
+ * Canonical authorization-denied envelope — every 401/403 path returns the SAME
+ * payload so the response text cannot be used as a side channel (e.g. to probe
+ * whether a given proposal id exists).
+ */
+const AUTHZ_DENIED_BODY = {
+  success: false as const,
+  error: { code: "AUTHZ_DENIED", message: "Access denied" },
+} as const;
+
+// ── Injectable seams (for testing) ───────────────────────────
+
+/** Minimal writer contract — `ProposalFileWriter` satisfies this. */
+export interface GraduationFileWriter {
+  writeApprovedProposal(proposal: ProposalDefinition): Promise<string[]>;
+}
+
+/** Minimal committer contract — `ProposalGitCommitter` satisfies this. */
+export interface GraduationGitCommitter {
+  commitAndOpenPR(
+    proposal: ProposalDefinition,
+    writtenFiles: readonly string[],
+  ): Promise<ProposalGitCommitResult>;
+}
+
+/** Engine surface the orchestrator depends on (subset of `ProposalEngine`). */
+export interface GraduationEngine {
+  getProposal(id: string): ProposalDefinition;
+  commitProposal?: (options: { proposalId: string }) => unknown;
+}
+
+// ── Result envelope ──────────────────────────────────────────
+
+/** Discriminated outcome of a graduation attempt. */
+export type GraduationOutcome =
+  | { kind: "ok"; result: ProposalGitCommitResult; committed: boolean }
+  | { kind: "not_found" }
+  | { kind: "not_approved"; status: string }
+  | { kind: "not_configured"; message: string }
+  | { kind: "error"; message: string };
+
+// ── Config resolution ────────────────────────────────────────
+
+/** Resolved git/GitHub settings needed to construct the FileWriter + GitCommitter. */
+export interface GraduationConfig {
+  /** Absolute repository root (cwd of every git/gh subprocess + file writes). */
+  rootDir: string;
+  /** Base branch the PR targets (default "main"). */
+  baseBranch?: string;
+  /** Git remote name (default "origin"). */
+  remote?: string;
+}
+
+/**
+ * Source graduation config from the environment.
+ *
+ * Returns `null` when graduation is NOT configured, which the handler maps to a
+ * graceful 503 rather than crashing or guessing credentials. Graduation needs
+ * to push a branch and open a PR via the `gh` CLI, which requires a GitHub
+ * token to be present in the environment (`GITHUB_TOKEN` or `GH_TOKEN`). When
+ * neither is set we treat graduation as unconfigured.
+ *
+ * Overrides:
+ *   - `PROPOSAL_GRADUATE_ROOT_DIR` — repo root (defaults to `process.cwd()`).
+ *   - `PROPOSAL_GRADUATE_BASE_BRANCH` — PR base branch (defaults to committer's "main").
+ *   - `PROPOSAL_GRADUATE_REMOTE` — git remote (defaults to committer's "origin").
+ */
+export function resolveGraduationConfig(
+  env: Record<string, string | undefined> = process.env,
+): GraduationConfig | null {
+  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN;
+  if (!token || token.trim().length === 0) {
+    return null;
+  }
+  const rootDir = env.PROPOSAL_GRADUATE_ROOT_DIR?.trim() || process.cwd();
+  const config: GraduationConfig = { rootDir };
+  const baseBranch = env.PROPOSAL_GRADUATE_BASE_BRANCH?.trim();
+  if (baseBranch) config.baseBranch = baseBranch;
+  const remote = env.PROPOSAL_GRADUATE_REMOTE?.trim();
+  if (remote) config.remote = remote;
+  return config;
+}
+
+// ── Core orchestrator (injectable, framework-free) ───────────
+
+export interface GraduateProposalDeps {
+  engine: GraduationEngine;
+  writer: GraduationFileWriter;
+  committer: GraduationGitCommitter;
+}
+
+/**
+ * Graduate a single approved proposal: write its files, then open a PR.
+ *
+ * Returns a discriminated {@link GraduationOutcome} instead of throwing so the
+ * HTTP handler can map each case to the right status code. The approved-only
+ * guard runs FIRST — when it trips, neither the writer nor the committer is
+ * invoked (no partial state).
+ */
+export async function graduateProposal(
+  proposalId: string,
+  deps: GraduateProposalDeps,
+): Promise<GraduationOutcome> {
+  let proposal: ProposalDefinition;
+  try {
+    proposal = deps.engine.getProposal(proposalId);
+  } catch {
+    return { kind: "not_found" };
+  }
+
+  // ── Approved-only guard (REQUIRED) ──
+  // Graduation only ever acts on an approved proposal. Anything else is
+  // refused before any disk/git side effect.
+  if (proposal.status !== "approved") {
+    return { kind: "not_approved", status: proposal.status };
+  }
+
+  // ── Write files, then open a PR (NEVER merge) ──
+  let writtenFiles: string[];
+  let result: ProposalGitCommitResult;
+  try {
+    writtenFiles = await deps.writer.writeApprovedProposal(proposal);
+    result = await deps.committer.commitAndOpenPR(proposal, writtenFiles);
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+
+  // ── Record graduation (approved → committed) when the engine supports it ──
+  // Best-effort: the PR is already open, so a bookkeeping failure here must not
+  // surface as a graduation failure. We only flip the flag on success.
+  let committed = false;
+  if (typeof deps.engine.commitProposal === "function") {
+    try {
+      deps.engine.commitProposal({ proposalId });
+      committed = true;
+    } catch {
+      committed = false;
+    }
+  }
+
+  return { kind: "ok", result, committed };
+}
+
+// ── Mount the Elysia route ───────────────────────────────────
+
+export interface MountProposalGraduateAPIOptions {
+  /**
+   * CommandLayer used to run the permission slot before any side effect.
+   * REQUIRED in production — graduation writes files and opens a PR, so an
+   * unauthorized caller must be rejected. When absent the endpoint returns 503.
+   */
+  commandLayer?: CommandLayer;
+  /** Resolve the request actor for the permission slot (defaults to anonymous). */
+  resolveRequestActor?: (request: Request) => Promise<Actor | undefined> | Actor | undefined;
+  /**
+   * Override the proposal engine (defaults to the shared governed engine).
+   * Exposed mainly for tests.
+   */
+  engine?: GraduationEngine;
+  /**
+   * Override config resolution (defaults to {@link resolveGraduationConfig}
+   * over `process.env`). Return `null` to force the "not configured" path.
+   */
+  resolveConfig?: () => GraduationConfig | null;
+  /**
+   * Override how the writer is built from config (defaults to a real
+   * `ProposalFileWriter`). Exposed for tests so no real filesystem is touched.
+   */
+  createWriter?: (config: GraduationConfig) => GraduationFileWriter;
+  /**
+   * Override how the committer is built from config (defaults to a real
+   * `ProposalGitCommitter`). Exposed for tests so no real `git`/`gh` runs.
+   */
+  createCommitter?: (config: GraduationConfig) => GraduationGitCommitter;
+}
+
+/**
+ * Register `POST /api/proposals/:id/graduate` on the given Elysia app.
+ *
+ * Contract:
+ *   - 404 `{ success: false, error }` — proposal not found.
+ *   - 422 `{ success: false, error }` — proposal not approved (approved-only guard).
+ *   - 503 `{ success: false, error }` — git/GitHub not configured (graceful degradation).
+ *   - 500 `{ success: false, error }` — write/commit/PR failure.
+ *   - 200 `{ success: true, data: { prUrl, branch, commitSha, committed } }` — PR opened.
+ *
+ * @param app Elysia app instance
+ * @param options Engine + construction overrides (all optional; production uses defaults).
+ */
+export function mountProposalGraduateAPI(
+  // biome-ignore lint/suspicious/noExplicitAny: Elysia plugin typing
+  app: any,
+  options?: MountProposalGraduateAPIOptions,
+): void {
+  const commandLayer = options?.commandLayer;
+  const resolveRequestActor = options?.resolveRequestActor;
+  const engine: GraduationEngine = options?.engine ?? getSharedProposalEngine();
+  const resolveConfig = options?.resolveConfig ?? (() => resolveGraduationConfig());
+  const createWriter =
+    options?.createWriter ?? ((config: GraduationConfig) => new ProposalFileWriter(config));
+  const createCommitter =
+    options?.createCommitter ??
+    ((config: GraduationConfig) =>
+      createProposalGitCommitter({
+        rootDir: config.rootDir,
+        baseBranch: config.baseBranch,
+        remote: config.remote,
+      }));
+
+  app.post(
+    "/api/proposals/:id/graduate",
+    async ({
+      params,
+      set,
+      request,
+    }: {
+      params: { id: string };
+      set: { status: number };
+      request: Request;
+    }) => {
+      // ── Permission slot (CommandLayer) — run FIRST, before any config probe,
+      // engine read, disk write, or git/PR side effect. Graduation is a
+      // high-impact mutation (writes files + opens a PR), so the permission slot
+      // is NEVER skipped; an unauthorized caller must learn nothing (not even
+      // whether the proposal exists). Mirrors the onchange route convention.
+      if (!commandLayer) {
+        set.status = 503;
+        return {
+          success: false,
+          error: {
+            code: "GRADUATION.NOT_CONFIGURED",
+            message: "Command layer is not configured — cannot authorize proposal graduation.",
+          },
+        };
+      }
+      const actor = await resolveActor(request, resolveRequestActor);
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+      }
+      const commandResult = await commandLayer.execute({
+        command: GRADUATE_COMMAND_NAME,
+        input: { proposalId: params.id },
+        actor,
+        channel: "http",
+        headers,
+        traceId: request.headers.get("x-trace-id") ?? undefined,
+        meta: { proposal: { operation: "graduate", proposalId: params.id } },
+        skipActionSlots: true,
+      });
+      if (!commandResult.success) {
+        const status = resolveStatusCode(commandResult);
+        set.status = status;
+        if (status === 401 || status === 403) {
+          return AUTHZ_DENIED_BODY;
+        }
+        const errData = commandResult.data as Record<string, unknown> | undefined;
+        return {
+          success: false,
+          error: {
+            code: (errData?.code as string) ?? "GRADUATION.BLOCKED",
+            message: (errData?.error as string) ?? "Proposal graduation blocked",
+          },
+        };
+      }
+
+      // ── Pre-flight: is graduation configured? ──
+      // Resolve config BEFORE touching the engine so an unconfigured server
+      // degrades gracefully without leaking proposal existence/state.
+      const config = resolveConfig();
+      if (!config) {
+        set.status = 503;
+        return {
+          success: false,
+          error: {
+            code: "GRADUATION.NOT_CONFIGURED",
+            message:
+              "Proposal graduation is not configured. Set a GitHub token " +
+              "(GITHUB_TOKEN or GH_TOKEN) so the server can push a branch and open a PR.",
+          },
+        };
+      }
+
+      const outcome = await graduateProposal(params.id, {
+        engine,
+        writer: createWriter(config),
+        committer: createCommitter(config),
+      });
+
+      switch (outcome.kind) {
+        case "not_found":
+          set.status = 404;
+          return { success: false, error: { message: `Proposal "${params.id}" not found.` } };
+        case "not_approved":
+          set.status = 422;
+          return {
+            success: false,
+            error: {
+              message: `Graduation requires an approved proposal — "${params.id}" is "${outcome.status}".`,
+            },
+          };
+        case "not_configured":
+          // Defensive: graduateProposal never emits this today, but keep the
+          // mapping so a future config check inside the orchestrator degrades
+          // to 503 rather than an unhandled case.
+          set.status = 503;
+          return { success: false, error: { message: outcome.message } };
+        case "error":
+          set.status = 500;
+          return { success: false, error: { message: outcome.message } };
+        case "ok":
+          return {
+            success: true,
+            data: {
+              prUrl: outcome.result.prUrl,
+              branch: outcome.result.branch,
+              commitSha: outcome.result.commitSha,
+              committed: outcome.committed,
+            },
+          };
+      }
+    },
+  );
+}

--- a/addons/adapter-server/cap-adapter-server/src/proposal-graduate-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-graduate-api.ts
@@ -142,6 +142,13 @@ export async function graduateProposal(
   } catch {
     return { kind: "not_found" };
   }
+  // Defensive: the engine contract returns a `ProposalDefinition`, but a custom
+  // or future `GraduationEngine` impl could return `null`/`undefined` for a
+  // missing id instead of throwing. Treat that as not-found so the next line's
+  // `proposal.status` read can never throw an unhandled (non-envelope) 500.
+  if (!proposal) {
+    return { kind: "not_found" };
+  }
 
   // ── Approved-only guard (REQUIRED) ──
   // Graduation only ever acts on an approved proposal. Anything else is
@@ -232,7 +239,13 @@ export function mountProposalGraduateAPI(
   const engine: GraduationEngine = options?.engine ?? getSharedProposalEngine();
   const resolveConfig = options?.resolveConfig ?? (() => resolveGraduationConfig());
   const createWriter =
-    options?.createWriter ?? ((config: GraduationConfig) => new ProposalFileWriter(config));
+    options?.createWriter ??
+    ((config: GraduationConfig) =>
+      // Format generated source through Biome so the graduation PR's files pass
+      // the same Code Quality gate every other PR faces. Formatting failures are
+      // swallowed by the writer (it falls back to un-formatted source), so this
+      // can never block graduation.
+      new ProposalFileWriter({ ...config, formatter: true }));
   const createCommitter =
     options?.createCommitter ??
     ((config: GraduationConfig) =>

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -52,6 +52,7 @@ import { type GraphQLSchema, NoSchemaIntrospectionCustomRule } from "graphql";
 import { createYoga, type Plugin } from "graphql-yoga";
 import { createRelationDataLoaders } from "./graphql/relation-dataloader";
 import { mountProposalAPI } from "./proposal-api";
+import { mountProposalGraduateAPI } from "./proposal-graduate-api";
 import { mountActionRoutes } from "./routes/action-api";
 import { mountAdminRoutes } from "./routes/admin-api";
 import { mountAIRoutes } from "./routes/ai-api";
@@ -449,6 +450,15 @@ export function createServer(
     executionLogger,
     ontology: opts.ontologyRegistry,
     strictCompatibility: environment.features.strictCompatibility,
+  });
+  // Manual, admin-triggered graduation: POST /api/proposals/:id/graduate writes
+  // an approved proposal to disk and opens a PR (Spec 55 §7.6/§7.7). It NEVER
+  // auto-fires on approval and NEVER auto-merges — graduation is human-triggered
+  // and the resulting PR is human-reviewed. Uses the SAME shared governed engine
+  // as mountProposalAPI; config/credentials are sourced from the environment.
+  mountProposalGraduateAPI(app, {
+    commandLayer: opts.commandLayer,
+    resolveRequestActor: opts.resolveRequestActor,
   });
 
   // ── SSE Subscription endpoint (/api/subscribe) ────────────────


### PR DESCRIPTION
## What & why

Approved proposals had no path to the repo. Per the chosen gated model, add a **manual, admin-triggered** graduation (Spec 55 §7.6/§7.7): `POST /api/proposals/:id/graduate` writes an already-`approved` proposal's definition files (`ProposalFileWriter`) and opens a GitHub PR (`ProposalGitCommitter.commitAndOpenPR`).

## Safety boundary (preserves "AI never modifies production directly")

- **Permission-gated** — the request runs through **CommandLayer** (`skipActionSlots`, permission slot never skipped) BEFORE any config probe / engine read / disk / git side effect. Unauthorized callers get a canonical `403 AUTHZ_DENIED` (no proposal-existence leak); `503` if the command layer is absent (fail closed).
- **Manual-only** — the endpoint is the sole trigger. No `onApproved` auto-wire, no scheduler.
- **Never auto-merges** — only opens a PR for human review (a test asserts the committer surface exposes only `commitAndOpenPR`, never a merge path).
- **Approved-only** — `404` missing · `422` not-approved (guard before any side effect) · `503 GRADUATION.NOT_CONFIGURED` when git/GitHub unconfigured · `500` on write/commit failure.

## Config

From env (`GITHUB_TOKEN`/`GH_TOKEN` required; optional `PROPOSAL_GRADUATE_ROOT_DIR`/`_BASE_BRANCH`/`_REMOTE`); degrades to 503 when unconfigured. On success records graduation (approved→committed) best-effort; returns `{ prUrl, branch, commitSha, committed }`.

## Review

Cross-model reviewed (codex). **P1 fixed**: the first cut mounted the route with a bare `app.post` and never resolved the actor or ran a permission check — with a token configured, any reachable caller could trigger file writes + a git push/PR. Now gated through CommandLayer exactly like the onchange / run-cycle routes. Regression tests added (unauthorized → 403 canonical envelope, no write/commit; command-layer-absent → 503).

## Tests

`proposal-graduate-api.test.ts` — 18 tests (orchestrator + endpoint via `app.handle`): approved-only guard, happy path (writeApprovedProposal → commitAndOpenPR, exact files), committer-only-opens-PR (never merge), config resolution + 503 degradation, write/commit failures → 500, **authz denied → 403**, **command-layer absent → 503**.

## Gates

`bun run check`, `bun run typecheck`, full `bun run test` (batched) all green.

> Note: touches `server.ts` (import + mount), which also changes in #490 — whichever lands second will need a trivial rebase on that one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)