### PR TITLE
feat(adapter): proposal code materialization endpoint + review UI (G5 Phase 4)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-api.test.ts
@@ -156,6 +156,25 @@ describe("runProposalMaterialization — happy path", () => {
     expect(proposal.changes[0]?.generatedSource).toBeUndefined();
   });
 
+  test("engine returning no proposal from updateProposal → error (not a crash)", async () => {
+    const proposal = makeProposal();
+    const { provider } = makeProvider();
+    // A custom engine whose updateProposal returns undefined instead of the row.
+    const engine: MaterializeEngine = {
+      getProposal: () => proposal,
+      updateProposal: () => undefined as unknown as ProposalDefinition,
+    };
+
+    const outcome = await runProposalMaterialization(proposal.id, {
+      engine,
+      provider,
+      qualityGate: PASS_GATE,
+    });
+
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.message).toContain("no proposal");
+  });
+
   test("provider throwing surfaces as error (caught, not leaked)", async () => {
     const proposal = makeProposal();
     const { engine, updates } = makeEngine(proposal);

--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-api.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Proposal code materialization — unit + endpoint tests (G5 Phase 4).
+ *
+ * Covers the injectable orchestrator (`runProposalMaterialization`) and the
+ * Elysia route (`mountProposalMaterializeAPI`). The code-generation provider is
+ * ALWAYS an injected fake — no real model is called. A spy asserts the provider
+ * is never invoked when a guard (draft-only / authz / not-configured) trips, and
+ * that nothing is written back on those paths.
+ *
+ * Endpoint tests dispatch via `app.handle(new Request(...))` (in-process,
+ * port-free). `app.listen(PORT)` is intentionally avoided — a bound socket per
+ * suite SEGFAULTS the batched addons run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CommandLayer, ProposalChange, ProposalDefinition } from "@linchkit/core";
+import type { CodeGenerationProvider, QualityGateRunner } from "@linchkit/core/server";
+import { Elysia } from "elysia";
+import {
+  type MaterializeEngine,
+  mountProposalMaterializeAPI,
+  runProposalMaterialization,
+} from "../src/proposal-materialize-api";
+
+const BASE = "http://local.test";
+const GOOD = "export const deduct_inventory = 1;";
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+function makeProposal(overrides: Partial<ProposalDefinition> = {}): ProposalDefinition {
+  const now = new Date();
+  return {
+    id: "prop-abc12345",
+    title: "Add deduct_inventory action",
+    description: "When an order is approved, deduct inventory",
+    author: { type: "ai", id: "pattern-detector", name: "Pattern Detector" },
+    capability: "cap-demo",
+    changeType: "minor",
+    changes: [{ target: "action", operation: "create", name: "deduct_inventory" }],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: ["deduct_inventory"],
+      rulesAffected: [],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as ProposalDefinition;
+}
+
+/** Provider spy returning a fixed source (or throwing). Records call count. */
+function makeProvider(opts: { source?: string; throws?: boolean } = {}): {
+  provider: CodeGenerationProvider;
+  calls: { count: number };
+} {
+  const calls = { count: 0 };
+  const provider: CodeGenerationProvider = {
+    async generateCode() {
+      calls.count += 1;
+      if (opts.throws) throw new Error("model exploded");
+      return opts.source ?? GOOD;
+    },
+  };
+  return { provider, calls };
+}
+
+/** A gate that passes everything (no Bun transpiler dependency in unit tests). */
+const PASS_GATE: QualityGateRunner = { check: async () => [] };
+
+/** Engine fake that mirrors the real draft-only `updateProposal` contract. */
+function makeEngine(proposal: ProposalDefinition | undefined): {
+  engine: MaterializeEngine;
+  updates: Array<{ id: string; changes?: ProposalChange[] }>;
+} {
+  const updates: Array<{ id: string; changes?: ProposalChange[] }> = [];
+  let current = proposal;
+  const engine: MaterializeEngine = {
+    getProposal(id) {
+      if (!current || current.id !== id) throw new Error(`Proposal "${id}" not found`);
+      return current;
+    },
+    updateProposal(id, u) {
+      if (!current || current.id !== id) throw new Error(`Proposal "${id}" not found`);
+      if (current.status !== "draft") {
+        throw new Error(`Cannot update proposal "${id}": expected status "draft"`);
+      }
+      updates.push({ id, changes: u.changes });
+      current = { ...current, changes: u.changes ?? current.changes };
+      return current;
+    },
+  };
+  return { engine, updates };
+}
+
+// ── runProposalMaterialization (orchestrator) ────────────────
+
+describe("runProposalMaterialization — guards", () => {
+  test("non-draft proposal → not_draft; provider NOT called, nothing written", async () => {
+    const proposal = makeProposal({ status: "approved" });
+    const { engine, updates } = makeEngine(proposal);
+    const { provider, calls } = makeProvider();
+
+    const outcome = await runProposalMaterialization(proposal.id, {
+      engine,
+      provider,
+      qualityGate: PASS_GATE,
+    });
+
+    expect(outcome.kind).toBe("not_draft");
+    if (outcome.kind === "not_draft") expect(outcome.status).toBe("approved");
+    expect(calls.count).toBe(0);
+    expect(updates).toHaveLength(0);
+  });
+
+  test("missing proposal → not_found; provider NOT called", async () => {
+    const { engine } = makeEngine(undefined);
+    const { provider, calls } = makeProvider();
+
+    const outcome = await runProposalMaterialization("nope", {
+      engine,
+      provider,
+      qualityGate: PASS_GATE,
+    });
+
+    expect(outcome.kind).toBe("not_found");
+    expect(calls.count).toBe(0);
+  });
+});
+
+describe("runProposalMaterialization — happy path", () => {
+  test("generates source, writes it back onto the draft, returns outcomes", async () => {
+    const proposal = makeProposal();
+    const { engine, updates } = makeEngine(proposal);
+    const { provider, calls } = makeProvider();
+
+    const outcome = await runProposalMaterialization(proposal.id, {
+      engine,
+      provider,
+      qualityGate: PASS_GATE,
+    });
+
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.allMaterialized).toBe(true);
+      expect(outcome.outcomes[0]?.status).toBe("materialized");
+      expect(outcome.proposal.changes[0]?.generatedSource).toBe(GOOD);
+    }
+    expect(calls.count).toBe(1);
+    // The candidate source was persisted back onto the draft via updateProposal.
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.changes?.[0]?.generatedSource).toBe(GOOD);
+    // Input proposal is never mutated.
+    expect(proposal.changes[0]?.generatedSource).toBeUndefined();
+  });
+
+  test("provider throwing surfaces as error (caught, not leaked)", async () => {
+    const proposal = makeProposal();
+    const { engine, updates } = makeEngine(proposal);
+    const { provider } = makeProvider({ throws: true });
+
+    const outcome = await runProposalMaterialization(proposal.id, {
+      engine,
+      provider,
+      qualityGate: PASS_GATE,
+    });
+
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") expect(outcome.message).toContain("model exploded");
+    expect(updates).toHaveLength(0);
+  });
+});
+
+// ── Endpoint: POST /api/proposals/:id/materialize ────────────
+
+interface MaterializeJson {
+  success: boolean;
+  data?: {
+    proposalId?: string;
+    allMaterialized?: boolean;
+    outcomes?: Array<{ changeName: string; status: string }>;
+    proposal?: { changes?: ProposalChange[] };
+  };
+  error?: { message?: string; code?: string };
+}
+
+/** A permissive command layer so endpoint tests exercise the materialize logic. */
+const PASS_COMMAND_LAYER = {
+  execute: async () => ({ success: true, data: { skipped: true } }),
+} as unknown as CommandLayer;
+
+function mountTestApp(opts: {
+  proposal?: ProposalDefinition;
+  provider?: CodeGenerationProvider | null;
+  commandLayer?: CommandLayer | null;
+}): { app: Elysia; engine: MaterializeEngine; providerCalls: { count: number } } {
+  const { engine } = makeEngine(opts.proposal);
+  const built =
+    opts.provider === undefined ? makeProvider() : { provider: opts.provider, calls: { count: 0 } };
+  const app = new Elysia();
+  mountProposalMaterializeAPI(app, {
+    commandLayer:
+      opts.commandLayer === undefined ? PASS_COMMAND_LAYER : (opts.commandLayer ?? undefined),
+    engine,
+    qualityGate: PASS_GATE,
+    resolveProvider: () => (opts.provider === undefined ? built.provider : opts.provider),
+  });
+  return { app, engine, providerCalls: built.calls };
+}
+
+async function postMaterialize(
+  app: Elysia,
+  id: string,
+): Promise<{ status: number; json: MaterializeJson }> {
+  const res = await app.handle(
+    new Request(`${BASE}/api/proposals/${id}/materialize`, { method: "POST" }),
+  );
+  return { status: res.status, json: (await res.json()) as MaterializeJson };
+}
+
+describe("POST /api/proposals/:id/materialize", () => {
+  test("draft → 200 with outcomes + generatedSource on the returned proposal", async () => {
+    const proposal = makeProposal();
+    const { app, providerCalls } = mountTestApp({ proposal });
+    const { status, json } = await postMaterialize(app, proposal.id);
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.proposalId).toBe(proposal.id);
+    expect(json.data?.allMaterialized).toBe(true);
+    expect(json.data?.outcomes?.[0]?.status).toBe("materialized");
+    expect(json.data?.proposal?.changes?.[0]?.generatedSource).toBe(GOOD);
+    expect(providerCalls.count).toBe(1);
+  });
+
+  test("unauthorized caller → 403 canonical AUTHZ_DENIED; provider NOT called", async () => {
+    const proposal = makeProposal();
+    const denying = {
+      execute: async () => ({ success: false, data: { error: "not allowed" } }),
+    } as unknown as CommandLayer;
+    const { app, providerCalls } = mountTestApp({ proposal, commandLayer: denying });
+    const { status, json } = await postMaterialize(app, proposal.id);
+
+    expect(status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+    expect(providerCalls.count).toBe(0);
+  });
+
+  test("command layer absent → 503 (cannot authorize); provider NOT called", async () => {
+    const proposal = makeProposal();
+    const { app, providerCalls } = mountTestApp({ proposal, commandLayer: null });
+    const { status, json } = await postMaterialize(app, proposal.id);
+
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("MATERIALIZE.NOT_CONFIGURED");
+    expect(providerCalls.count).toBe(0);
+  });
+
+  test("AI provider not configured → 503 graceful envelope; engine untouched", async () => {
+    const proposal = makeProposal();
+    // resolveProvider returns null → not configured.
+    const { app } = mountTestApp({ proposal, provider: null });
+    const { status, json } = await postMaterialize(app, proposal.id);
+
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("MATERIALIZE.NOT_CONFIGURED");
+  });
+
+  test("non-draft proposal → 422; provider NOT called", async () => {
+    const proposal = makeProposal({ status: "validated" });
+    const { app, providerCalls } = mountTestApp({ proposal });
+    const { status, json } = await postMaterialize(app, proposal.id);
+
+    expect(status).toBe(422);
+    expect(json.success).toBe(false);
+    expect(json.error?.message).toContain("draft");
+    expect(providerCalls.count).toBe(0);
+  });
+
+  test("missing proposal → 404", async () => {
+    const { app } = mountTestApp({ proposal: makeProposal() });
+    const { status, json } = await postMaterialize(app, "nope");
+    expect(status).toBe(404);
+    expect(json.success).toBe(false);
+  });
+
+  test("generation failure → 500", async () => {
+    const proposal = makeProposal();
+    const throwing: CodeGenerationProvider = {
+      async generateCode() {
+        throw new Error("model exploded");
+      },
+    };
+    const { app } = mountTestApp({ proposal, provider: throwing });
+    const { status, json } = await postMaterialize(app, proposal.id);
+
+    expect(status).toBe(500);
+    expect(json.success).toBe(false);
+    expect(json.error?.message).toContain("model exploded");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
@@ -394,7 +394,7 @@ export function mountProposalAPI(
 
 // ── Serialization helper ─────────────────────────────────
 
-function serializeProposal(p: ProposalDefinition): Record<string, unknown> {
+export function serializeProposal(p: ProposalDefinition): Record<string, unknown> {
   return {
     id: p.id,
     title: p.title,

--- a/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
@@ -1,0 +1,337 @@
+/**
+ * Proposal code-materialization REST endpoint — G5 Phase 4 (live wiring).
+ *
+ * Adds `POST /api/proposals/:id/materialize`: an on-demand path that takes a
+ * DRAFT proposal and generates the irreducibly-code parts of its changes (today
+ * the `ActionDefinition.handler` body) via a `CodeGenerationProvider` over the
+ * configured AI provider, build-checks the output (Phase 2 syntax gate), and
+ * attaches the candidate source to each change as `generatedSource`.
+ *
+ * SAFETY BOUNDARY (do NOT cross — see CLAUDE.md "AI Never Modifies Production Directly"):
+ *   - DRAFT-only. A non-draft proposal is refused with a 422 and nothing is
+ *     generated or written. Materialization is meaningful only before review.
+ *   - Candidate source ONLY. The generated code is attached to the draft so it
+ *     enters the existing human review pipeline. This endpoint NEVER submits,
+ *     validates-to-approve, approves, commits, graduates, writes files, or runs
+ *     the generated code. Double human review (draft review + graduation PR)
+ *     still gates whether it ever lands.
+ *   - ON-DEMAND only. There is NO scheduler / cron / timer that auto-materializes
+ *     — cadence is a deferred product decision.
+ *   - The permission slot (CommandLayer) is NEVER skipped: it runs FIRST, before
+ *     any engine read or AI call, so an unauthorized caller learns nothing (not
+ *     even whether the proposal exists).
+ *
+ * The HTTP handler is a thin shell around the injectable {@link runProposalMaterialization}
+ * orchestrator so the core flow can be unit-tested with a fake provider (no real
+ * model call). The route mirrors the error envelope, handler shape, and
+ * `set.status` discipline of `proposal-graduate-api.ts`.
+ */
+
+import { createCodeGenerationProvider } from "@linchkit/cap-ai-provider";
+import type {
+  Actor,
+  AIService,
+  CommandLayer,
+  ProposalChange,
+  ProposalDefinition,
+} from "@linchkit/core";
+import {
+  type CodeGenerationProvider,
+  createSyntaxQualityGate,
+  type MaterializeChangeOutcome,
+  materializeProposalChanges,
+  type QualityGateRunner,
+} from "@linchkit/core/server";
+import { getSharedProposalEngine, serializeProposal } from "./proposal-api";
+import { resolveActor, resolveStatusCode } from "./routes/shared";
+
+/** Synthetic command name for the materialize dispatch (metrics/tracing only). */
+const MATERIALIZE_COMMAND_NAME = "proposal.materialize";
+
+/**
+ * Canonical authorization-denied envelope — every 401/403 path returns the SAME
+ * payload so the response text cannot be used as a side channel (e.g. to probe
+ * whether a given proposal id exists).
+ */
+const AUTHZ_DENIED_BODY = {
+  success: false as const,
+  error: { code: "AUTHZ_DENIED", message: "Access denied" },
+} as const;
+
+// ── Injectable seams (for testing) ───────────────────────────
+
+/**
+ * Engine surface the orchestrator depends on (subset of `ProposalEngine`).
+ * `updateProposal` is draft-only in the engine and replaces `changes`, so the
+ * materialized changes (carrying `generatedSource`) are persisted back onto the
+ * draft.
+ */
+export interface MaterializeEngine {
+  getProposal(id: string): ProposalDefinition;
+  updateProposal(id: string, updates: { changes?: ProposalChange[] }): ProposalDefinition;
+}
+
+// ── Result envelope ──────────────────────────────────────────
+
+/** Discriminated outcome of a materialization attempt. */
+export type MaterializeOutcome =
+  | {
+      kind: "ok";
+      proposal: ProposalDefinition;
+      outcomes: MaterializeChangeOutcome[];
+      allMaterialized: boolean;
+    }
+  | { kind: "not_found" }
+  | { kind: "not_draft"; status: string }
+  | { kind: "error"; message: string };
+
+// ── Core orchestrator (injectable, framework-free) ───────────
+
+export interface RunProposalMaterializationDeps {
+  engine: MaterializeEngine;
+  /** AI code generation provider (e.g. cap-ai-provider's createCodeGenerationProvider). */
+  provider: CodeGenerationProvider;
+  /** Build/quality gate (Phase 2). Defaults to a syntax-only gate at the route. */
+  qualityGate?: QualityGateRunner;
+  /** Project conventions / context passed as the system message to the provider. */
+  context?: string;
+  /** Max generation attempts per change (defaults to the materializer's default). */
+  maxRetries?: number;
+}
+
+/**
+ * Materialize a single DRAFT proposal: generate candidate source for its
+ * materializable changes and persist it back onto the draft via
+ * `engine.updateProposal`.
+ *
+ * Returns a discriminated {@link MaterializeOutcome} instead of throwing so the
+ * HTTP handler can map each case to the right status code. The draft-only guard
+ * runs FIRST — when it trips, the provider is never called and nothing is
+ * written.
+ */
+export async function runProposalMaterialization(
+  proposalId: string,
+  deps: RunProposalMaterializationDeps,
+): Promise<MaterializeOutcome> {
+  let proposal: ProposalDefinition;
+  try {
+    proposal = deps.engine.getProposal(proposalId);
+  } catch {
+    return { kind: "not_found" };
+  }
+  // Defensive: the engine contract returns a `ProposalDefinition`, but a custom
+  // or future `MaterializeEngine` impl could return `null`/`undefined` for a
+  // missing id instead of throwing. Treat that as not-found so the next line's
+  // `proposal.status` read can never throw an unhandled (non-envelope) 500.
+  if (!proposal) {
+    return { kind: "not_found" };
+  }
+
+  // ── Draft-only guard (REQUIRED) ──
+  // Materialization only ever acts on a draft (pre-review). Anything else is
+  // refused before any AI call or write — and `updateProposal` itself rejects a
+  // non-draft, so this also keeps the engine contract happy.
+  if (proposal.status !== "draft") {
+    return { kind: "not_draft", status: proposal.status };
+  }
+
+  try {
+    const result = await materializeProposalChanges({
+      proposal,
+      provider: deps.provider,
+      qualityGate: deps.qualityGate,
+      context: deps.context,
+      maxRetries: deps.maxRetries,
+    });
+    // Persist the candidate source back onto the draft. `updateProposal` replaces
+    // `changes` (recomputing impact) and is draft-only — never approves/graduates.
+    const updated = deps.engine.updateProposal(proposalId, { changes: result.proposal.changes });
+    return {
+      kind: "ok",
+      proposal: updated,
+      outcomes: result.outcomes,
+      allMaterialized: result.allMaterialized,
+    };
+  } catch (err) {
+    return { kind: "error", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ── Mount the Elysia route ───────────────────────────────────
+
+export interface MountProposalMaterializeAPIOptions {
+  /**
+   * CommandLayer used to run the permission slot before any side effect.
+   * REQUIRED in production — materialization calls the AI provider and mutates a
+   * draft, so an unauthorized caller must be rejected. When absent the endpoint
+   * returns 503.
+   */
+  commandLayer?: CommandLayer;
+  /** Resolve the request actor for the permission slot (defaults to anonymous). */
+  resolveRequestActor?: (request: Request) => Promise<Actor | undefined> | Actor | undefined;
+  /**
+   * AI service used to build the default `CodeGenerationProvider`. When absent or
+   * not `configured`, the endpoint returns 503 (graceful degradation) rather than
+   * calling an unconfigured provider.
+   */
+  aiService?: AIService;
+  /**
+   * Override the proposal engine (defaults to the shared governed engine).
+   * Exposed mainly for tests.
+   */
+  engine?: MaterializeEngine;
+  /**
+   * Override how the provider is built (defaults to
+   * `createCodeGenerationProvider(aiService)`). Return `null` to force the
+   * "not configured" 503 path. Exposed for tests so no real model is called.
+   */
+  resolveProvider?: () => CodeGenerationProvider | null;
+  /** Override the build/quality gate (defaults to {@link createSyntaxQualityGate}). */
+  qualityGate?: QualityGateRunner;
+  /** Optional project context forwarded to the provider on every attempt. */
+  context?: string;
+}
+
+/**
+ * Register `POST /api/proposals/:id/materialize` on the given Elysia app.
+ *
+ * Contract:
+ *   - 404 `{ success: false, error }` — proposal not found.
+ *   - 422 `{ success: false, error }` — proposal not a draft (draft-only guard).
+ *   - 503 `{ success: false, error }` — command layer or AI provider not configured.
+ *   - 500 `{ success: false, error }` — unexpected generation failure.
+ *   - 200 `{ success: true, data: { proposalId, allMaterialized, outcomes, proposal } }`.
+ *
+ * @param app Elysia app instance
+ * @param options Engine + provider overrides (all optional; production uses defaults).
+ */
+export function mountProposalMaterializeAPI(
+  // biome-ignore lint/suspicious/noExplicitAny: Elysia plugin typing
+  app: any,
+  options?: MountProposalMaterializeAPIOptions,
+): void {
+  const commandLayer = options?.commandLayer;
+  const resolveRequestActor = options?.resolveRequestActor;
+  const engine: MaterializeEngine = options?.engine ?? getSharedProposalEngine();
+  const qualityGate = options?.qualityGate ?? createSyntaxQualityGate();
+  const context = options?.context;
+  const resolveProvider =
+    options?.resolveProvider ??
+    (() => {
+      const ai = options?.aiService;
+      // No service, or a noop/unconfigured one → degrade to 503 instead of
+      // calling a provider that would throw "AIService is not configured".
+      // (`ai?.configured !== true` also covers `ai === undefined`.)
+      if (ai?.configured !== true) return null;
+      return createCodeGenerationProvider(ai);
+    });
+
+  app.post(
+    "/api/proposals/:id/materialize",
+    async ({
+      params,
+      set,
+      request,
+    }: {
+      params: { id: string };
+      set: { status: number };
+      request: Request;
+    }) => {
+      // ── Permission slot (CommandLayer) — run FIRST, before any provider build,
+      // engine read, or AI call. Materialization invokes the AI and mutates a
+      // draft, so the permission slot is NEVER skipped; an unauthorized caller
+      // must learn nothing (not even whether the proposal exists).
+      if (!commandLayer) {
+        set.status = 503;
+        return {
+          success: false,
+          error: {
+            code: "MATERIALIZE.NOT_CONFIGURED",
+            message: "Command layer is not configured — cannot authorize proposal materialization.",
+          },
+        };
+      }
+      const actor = await resolveActor(request, resolveRequestActor);
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+      }
+      const commandResult = await commandLayer.execute({
+        command: MATERIALIZE_COMMAND_NAME,
+        input: { proposalId: params.id },
+        actor,
+        channel: "http",
+        headers,
+        traceId: request.headers.get("x-trace-id") ?? undefined,
+        meta: { proposal: { operation: "materialize", proposalId: params.id } },
+        skipActionSlots: true,
+      });
+      if (!commandResult.success) {
+        const status = resolveStatusCode(commandResult);
+        set.status = status;
+        if (status === 401 || status === 403) {
+          return AUTHZ_DENIED_BODY;
+        }
+        const errData = commandResult.data as Record<string, unknown> | undefined;
+        return {
+          success: false,
+          error: {
+            code: (errData?.code as string) ?? "MATERIALIZE.BLOCKED",
+            message: (errData?.error as string) ?? "Proposal materialization blocked",
+          },
+        };
+      }
+
+      // ── Pre-flight: is an AI provider configured? ──
+      // Resolve the provider BEFORE touching the engine so an unconfigured server
+      // degrades gracefully without leaking proposal existence/state.
+      const provider = resolveProvider();
+      if (!provider) {
+        set.status = 503;
+        return {
+          success: false,
+          error: {
+            code: "MATERIALIZE.NOT_CONFIGURED",
+            message:
+              "AI code generation is not configured. Configure an AI provider " +
+              "(linchkit.config `ai`) so the server can generate proposal source.",
+          },
+        };
+      }
+
+      const outcome = await runProposalMaterialization(params.id, {
+        engine,
+        provider,
+        qualityGate,
+        context,
+      });
+
+      switch (outcome.kind) {
+        case "not_found":
+          set.status = 404;
+          return { success: false, error: { message: `Proposal "${params.id}" not found.` } };
+        case "not_draft":
+          set.status = 422;
+          return {
+            success: false,
+            error: {
+              message: `Materialization requires a draft proposal — "${params.id}" is "${outcome.status}".`,
+            },
+          };
+        case "error":
+          set.status = 500;
+          return { success: false, error: { message: outcome.message } };
+        case "ok":
+          return {
+            success: true,
+            data: {
+              proposalId: params.id,
+              allMaterialized: outcome.allMaterialized,
+              outcomes: outcome.outcomes,
+              proposal: serializeProposal(outcome.proposal),
+            },
+          };
+      }
+    },
+  );
+}

--- a/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
@@ -146,6 +146,15 @@ export async function runProposalMaterialization(
     // Persist the candidate source back onto the draft. `updateProposal` replaces
     // `changes` (recomputing impact) and is draft-only — never approves/graduates.
     const updated = deps.engine.updateProposal(proposalId, { changes: result.proposal.changes });
+    // Defensive: the engine contract returns the updated `ProposalDefinition`, but
+    // a custom/future impl could return null/undefined. Surfacing that as an error
+    // keeps the route from later dereferencing `proposal.id` in serializeProposal.
+    if (!updated) {
+      return {
+        kind: "error",
+        message: "Proposal update returned no proposal after materialization.",
+      };
+    }
     return {
       kind: "ok",
       proposal: updated,

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -53,6 +53,7 @@ import { createYoga, type Plugin } from "graphql-yoga";
 import { createRelationDataLoaders } from "./graphql/relation-dataloader";
 import { mountProposalAPI } from "./proposal-api";
 import { mountProposalGraduateAPI } from "./proposal-graduate-api";
+import { mountProposalMaterializeAPI } from "./proposal-materialize-api";
 import { mountActionRoutes } from "./routes/action-api";
 import { mountAdminRoutes } from "./routes/admin-api";
 import { mountAIRoutes } from "./routes/ai-api";
@@ -467,6 +468,15 @@ export function createServer(
   mountProposalGraduateAPI(app, {
     commandLayer: opts.commandLayer,
     resolveRequestActor: opts.resolveRequestActor,
+  });
+  // On-demand AI code materialization: POST /api/proposals/:id/materialize
+  // generates candidate source for a DRAFT proposal's code parts (G5 Phase 4).
+  // It NEVER approves/graduates/writes-files — the candidate enters the same
+  // human review pipeline. Degrades to 503 when no AI provider is configured.
+  mountProposalMaterializeAPI(app, {
+    commandLayer: opts.commandLayer,
+    resolveRequestActor: opts.resolveRequestActor,
+    aiService: opts.aiService,
   });
 
   // ── Evolution cycle trigger (Spec 55 §7) ─────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-graduate-api.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-graduate-api.test.ts
@@ -31,7 +31,7 @@ if (typeof globalThis.localStorage === "undefined") {
   });
 }
 
-import { graduateProposal, runEvolutionCycle } from "../src/lib/proposal-api";
+import { graduateProposal, materializeProposal, runEvolutionCycle } from "../src/lib/proposal-api";
 
 /** Build a JSON Response with a given status + body. */
 function jsonResponse(status: number, body: unknown): Response {
@@ -296,6 +296,159 @@ describe("graduateProposal client", () => {
   test("maps invalid JSON on a 200 to error", async () => {
     const { fetchImpl } = stubFetch(new Response("<<<", { status: 200 }));
     const result = await graduateProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("error");
+  });
+});
+
+// ── materializeProposal ───────────────────────────────────
+
+describe("materializeProposal client", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("POSTs to the materialize endpoint with the encoded id", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonResponse(200, {
+        success: true,
+        data: { proposalId: "prop 1/odd", allMaterialized: true, outcomes: [], proposal: null },
+      }),
+    );
+    await materializeProposal("prop 1/odd", { fetchImpl });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("/api/proposals/prop%201%2Fodd/materialize");
+    expect(calls[0]?.init?.method).toBe("POST");
+  });
+
+  test("maps 200 to ok with outcomes + the returned proposal", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, {
+        success: true,
+        data: {
+          proposalId: "prop_1",
+          allMaterialized: true,
+          outcomes: [
+            {
+              changeName: "deduct_inventory",
+              target: "action",
+              status: "materialized",
+              attempts: 1,
+            },
+          ],
+          proposal: {
+            id: "prop_1",
+            changes: [
+              {
+                target: "action",
+                operation: "create",
+                name: "deduct_inventory",
+                generatedSource: "export const x = 1;",
+              },
+            ],
+          },
+        },
+      }),
+    );
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.allMaterialized).toBe(true);
+    expect(result.outcomes[0]?.status).toBe("materialized");
+    expect(result.proposal?.changes[0]?.generatedSource).toBe("export const x = 1;");
+  });
+
+  test("defaults missing data fields on a 200 ok result", async () => {
+    const { fetchImpl } = stubFetch(jsonResponse(200, { success: true }));
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.proposal).toBeNull();
+    expect(result.outcomes).toEqual([]);
+    expect(result.allMaterialized).toBe(false);
+  });
+
+  test("maps 404 to not_found", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(404, { success: false, error: { message: "not found" } }),
+    );
+    const result = await materializeProposal("prop_x", { fetchImpl });
+    expect(result.kind).toBe("not_found");
+  });
+
+  test("maps 422 to not_draft with the message", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(422, {
+        success: false,
+        error: { message: "Materialization requires a draft proposal." },
+      }),
+    );
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("not_draft");
+    if (result.kind !== "not_draft") return;
+    expect(result.message).toBe("Materialization requires a draft proposal.");
+  });
+
+  test("maps 503 to unavailable with the message", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(503, {
+        success: false,
+        error: {
+          code: "MATERIALIZE.NOT_CONFIGURED",
+          message: "AI code generation is not configured.",
+        },
+      }),
+    );
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.message).toBe("AI code generation is not configured.");
+  });
+
+  test("maps 401 to denied", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(401, {
+        success: false,
+        error: { code: "AUTHZ_DENIED", message: "Access denied" },
+      }),
+    );
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("denied");
+  });
+
+  test("maps 403 to denied", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(403, {
+        success: false,
+        error: { code: "AUTHZ_DENIED", message: "Access denied" },
+      }),
+    );
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("denied");
+  });
+
+  test("maps 500 to error with the message", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(500, { success: false, error: { message: "internal error" } }),
+    );
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("internal error");
+  });
+
+  test("maps a transport throw to error", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("connection refused");
+    }) as typeof fetch;
+    const result = await materializeProposal("prop_1", { fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("connection refused");
+  });
+
+  test("maps invalid JSON on a 200 to error", async () => {
+    const { fetchImpl } = stubFetch(new Response("<<<", { status: 200 }));
+    const result = await materializeProposal("prop_1", { fetchImpl });
     expect(result.kind).toBe("error");
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -20,6 +20,11 @@ export interface ProposalChange {
   name: string;
   definition?: unknown;
   diff?: string;
+  /**
+   * AI-generated candidate source for this change's code parts (G5). Present
+   * after materialization on a draft; still gated by validation + human review.
+   */
+  generatedSource?: string;
 }
 
 export interface ProposalImpact {
@@ -223,6 +228,41 @@ export type GraduateProposalResult =
   | { kind: "denied" }
   | { kind: "error"; message: string };
 
+/** Per-change result of a materialization attempt (UI mirror of the wire shape). */
+export interface MaterializeChangeOutcome {
+  changeName: string;
+  target: string;
+  /** `materialized` = source attached; `skipped` = declarative target; `failed` = gate never passed. */
+  status: "materialized" | "skipped" | "failed";
+  attempts: number;
+  errors?: string[];
+}
+
+/**
+ * Discriminated result of `materializeProposal`.
+ *
+ *  - `{ kind: "ok" }` — generation ran; `proposal` carries the candidate source
+ *    on its changes' `generatedSource`. `allMaterialized` is false if any
+ *    materializable change failed the build gate.
+ *  - `{ kind: "not_found" }` — 404 (proposal not found).
+ *  - `{ kind: "not_draft" }` — 422 (proposal is not a draft — materialize is pre-review only).
+ *  - `{ kind: "unavailable" }` — 503 (no AI provider, or no command layer).
+ *  - `{ kind: "denied" }` — 401 / 403 (AUTHZ_DENIED).
+ *  - `{ kind: "error" }` — transport error / 500 / other non-2xx / invalid JSON.
+ */
+export type MaterializeProposalResult =
+  | {
+      kind: "ok";
+      proposal: Proposal | null;
+      outcomes: MaterializeChangeOutcome[];
+      allMaterialized: boolean;
+    }
+  | { kind: "not_found" }
+  | { kind: "not_draft"; message?: string }
+  | { kind: "unavailable"; message?: string }
+  | { kind: "denied" }
+  | { kind: "error"; message: string };
+
 /** Shape of the `run-cycle` JSON envelope. Local mirror of the wire contract. */
 interface RunCycleWireResponse {
   success?: boolean;
@@ -407,5 +447,100 @@ export async function graduateProposal(
     branch: data?.branch ?? "",
     commitSha: data?.commitSha ?? "",
     committed: data?.committed ?? false,
+  };
+}
+
+/** Shape of the `materialize` JSON envelope. Local mirror of the wire contract. */
+interface MaterializeWireResponse {
+  success?: boolean;
+  data?: {
+    proposalId?: string;
+    allMaterialized?: boolean;
+    outcomes?: MaterializeChangeOutcome[];
+    proposal?: Proposal;
+  };
+  error?: { code?: string; message?: string };
+}
+
+/**
+ * Materialize a DRAFT Proposal: ask the server to AI-generate candidate source
+ * for the proposal's code parts (today, action handler bodies) and attach it to
+ * the draft. This NEVER approves, graduates, writes files, or runs code — the
+ * candidate stays on the draft inside the human-gated review pipeline.
+ *
+ * Wire contract (POST /api/proposals/:id/materialize):
+ *   200 → { success: true, data: { proposalId, allMaterialized, outcomes, proposal } }
+ *   404 → not found (mapped to `not_found`)
+ *   422 → not a draft (mapped to `not_draft`)
+ *   503 → AI provider / command layer not configured (mapped to `unavailable`)
+ *   401/403 → AUTHZ_DENIED (mapped to `denied`)
+ *   500 → `error`
+ *
+ * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
+ * global mock across the batched suite.
+ */
+export async function materializeProposal(
+  id: string,
+  opts: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
+): Promise<MaterializeProposalResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch(`/api/proposals/${encodeURIComponent(id)}/materialize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+      signal: opts.signal,
+    });
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : "Materialization failed",
+    };
+  }
+
+  // 401 / 403 — access denied.
+  if (res.status === 401 || res.status === 403) {
+    return { kind: "denied" };
+  }
+
+  // 404 — proposal not found.
+  if (res.status === 404) {
+    return { kind: "not_found" };
+  }
+
+  // 422 — proposal is not in `draft` state.
+  if (res.status === 422) {
+    return { kind: "not_draft", message: await readErrorMessage(res) };
+  }
+
+  // 503 — AI provider or command layer not configured.
+  if (res.status === 503) {
+    return { kind: "unavailable", message: await readErrorMessage(res) };
+  }
+
+  // 500 / other non-2xx — surface a user-friendly error.
+  if (!res.ok) {
+    return { kind: "error", message: (await readErrorMessage(res)) ?? "Materialization failed" };
+  }
+
+  let json: MaterializeWireResponse;
+  try {
+    json = (await res.json()) as MaterializeWireResponse;
+  } catch {
+    return { kind: "error", message: "Materialization returned an invalid response" };
+  }
+
+  // A `null` body is valid JSON but not a usable envelope — guard before reading
+  // `.data` so this can't throw an unhandled TypeError outside the catch above.
+  if (!json || typeof json !== "object") {
+    return { kind: "error", message: "Materialization returned an invalid response" };
+  }
+
+  const data = json.data;
+  return {
+    kind: "ok",
+    proposal: data?.proposal ?? null,
+    outcomes: Array.isArray(data?.outcomes) ? data.outcomes : [],
+    allMaterialized: data?.allMaterialized ?? false,
   };
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -169,7 +169,7 @@ function ProposalCard({
   // Prefer the freshly-materialized proposal's changes (if any) over the prop so
   // generated source shows immediately after a click without a manual refresh.
   const sourcedChanges: ProposalChange[] = (
-    mat?.kind === "ok" && mat.proposal ? mat.proposal.changes : proposal.changes
+    (mat?.kind === "ok" && mat.proposal ? mat.proposal.changes : proposal.changes) ?? []
   ).filter((c) => typeof c.generatedSource === "string" && c.generatedSource.trim().length > 0);
 
   return (
@@ -331,7 +331,10 @@ function ProposalCard({
               {t("proposals.generatedSource", "Generated source (candidate)")}
             </h5>
             {sourcedChanges.map((c) => (
-              <details key={`${c.target}:${c.name}`} className="rounded-md border bg-muted/30">
+              <details
+                key={`${c.target}:${c.operation}:${c.name}`}
+                className="rounded-md border bg-muted/30"
+              >
                 <summary className="cursor-pointer px-3 py-2 text-xs font-medium">
                   {c.target}/{c.name}
                 </summary>

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -24,10 +24,12 @@ import {
   AlertTriangleIcon,
   CheckCircle2Icon,
   ClipboardListIcon,
+  Code2Icon,
   ExternalLinkIcon,
   GitPullRequestIcon,
   Loader2Icon,
   RefreshCwIcon,
+  SparklesIcon,
   ThumbsDownIcon,
   ThumbsUpIcon,
   XCircleIcon,
@@ -39,7 +41,10 @@ import {
   fetchProposals,
   type GraduateProposalResult,
   graduateProposal,
+  type MaterializeProposalResult,
+  materializeProposal,
   type Proposal,
+  type ProposalChange,
   rejectProposal,
 } from "@/lib/proposal-api";
 import {
@@ -66,6 +71,7 @@ function ProposalCard({
   const [rejecting, setRejecting] = useState(false);
   const [reason, setReason] = useState("");
   const [grad, setGrad] = useState<GraduateProposalResult | null>(null);
+  const [mat, setMat] = useState<MaterializeProposalResult | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const handleApprove = useCallback(async () => {
@@ -130,8 +136,41 @@ function ProposalCard({
     // refreshes the list manually when ready.
   }, [proposal.id, t]);
 
+  const handleMaterialize = useCallback(async () => {
+    setBusy(true);
+    setActionError(null);
+    setMat(null);
+    try {
+      // materializeProposal maps every failure to a discriminated result, but
+      // wrap defensively so an unexpected throw still surfaces and never leaves
+      // the button stuck disabled. Mirrors handleGraduate.
+      const result = await materializeProposal(proposal.id);
+      setMat(result);
+    } catch (err) {
+      setMat({
+        kind: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : t("proposals.materializeFailed", "Materialization failed"),
+      });
+    } finally {
+      setBusy(false);
+    }
+    // Do NOT auto-refresh: the generated source is rendered from the returned
+    // result so the reviewer sees it immediately. The draft stays a draft
+    // server-side (the candidate source is persisted on it); a manual refresh
+    // re-loads it via `proposal.changes`.
+  }, [proposal.id, t]);
+
   const pending = isPending(proposal.status);
   const graduatable = canGraduate(proposal.status);
+  const isDraft = proposal.status === "draft";
+  // Prefer the freshly-materialized proposal's changes (if any) over the prop so
+  // generated source shows immediately after a click without a manual refresh.
+  const sourcedChanges: ProposalChange[] = (
+    mat?.kind === "ok" && mat.proposal ? mat.proposal.changes : proposal.changes
+  ).filter((c) => typeof c.generatedSource === "string" && c.generatedSource.trim().length > 0);
 
   return (
     <Card data-testid="proposal-card">
@@ -252,6 +291,55 @@ function ProposalCard({
                 </Button>
               </div>
             )}
+          </div>
+        )}
+
+        {/* Draft: materialize → AI-generate candidate source for the proposal's
+            code parts and attach it to this draft. NEVER approves/applies — the
+            candidate stays on the draft inside the human-gated review pipeline. */}
+        {isDraft && (
+          <div className="space-y-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => void handleMaterialize()}
+              disabled={busy}
+            >
+              {busy ? (
+                <Loader2Icon className="mr-1 size-3.5 animate-spin" />
+              ) : (
+                <SparklesIcon className="mr-1 size-3.5" />
+              )}
+              {t("proposals.materialize", "Materialize code")}
+            </Button>
+            <p className="text-[11px] text-muted-foreground">
+              {t(
+                "proposals.materializeHint",
+                "Uses AI to generate candidate source for this proposal's code parts and attaches it to the draft for review. It never approves or applies anything.",
+              )}
+            </p>
+            {mat && <MaterializeOutcome result={mat} t={t} />}
+          </div>
+        )}
+
+        {/* Generated candidate source (read-only). Present after materialization;
+            shown for any proposal whose changes carry generatedSource. */}
+        {sourcedChanges.length > 0 && (
+          <div className="space-y-2" data-testid="generated-source">
+            <h5 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Code2Icon className="size-3.5" />
+              {t("proposals.generatedSource", "Generated source (candidate)")}
+            </h5>
+            {sourcedChanges.map((c) => (
+              <details key={`${c.target}:${c.name}`} className="rounded-md border bg-muted/30">
+                <summary className="cursor-pointer px-3 py-2 text-xs font-medium">
+                  {c.target}/{c.name}
+                </summary>
+                <pre className="overflow-x-auto border-t px-3 py-2 text-[11px] leading-relaxed">
+                  <code>{c.generatedSource}</code>
+                </pre>
+              </details>
+            ))}
           </div>
         )}
 
@@ -379,6 +467,112 @@ function GraduateOutcome({
         <div
           className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
           data-testid="graduate-error"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">{result.message}</p>
+        </div>
+      );
+  }
+}
+
+// ── Materialize outcome renderer ──────────────────────────
+
+function MaterializeOutcome({
+  result,
+  t,
+}: {
+  result: MaterializeProposalResult;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  switch (result.kind) {
+    case "ok": {
+      const materialized = result.outcomes.filter((o) => o.status === "materialized").length;
+      const skipped = result.outcomes.filter((o) => o.status === "skipped").length;
+      const failed = result.outcomes.filter((o) => o.status === "failed").length;
+      const ok = result.allMaterialized;
+      return (
+        <div
+          className={`flex items-start gap-2 rounded-md border p-3 ${
+            ok
+              ? "border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30"
+              : "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30"
+          }`}
+          data-testid="materialize-ok"
+        >
+          {ok ? (
+            <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-green-500" />
+          ) : (
+            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-amber-500" />
+          )}
+          <p className="text-sm">
+            {t("proposals.materializeSummary", "Generated {{m}}, skipped {{s}}, failed {{f}}.", {
+              m: materialized,
+              s: skipped,
+              f: failed,
+            })}
+          </p>
+        </div>
+      );
+    }
+
+    case "unavailable":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-3"
+          data-testid="materialize-unavailable"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            {result.message ??
+              t("proposals.materializeNotConfigured", "AI code generation is not configured.")}
+          </p>
+        </div>
+      );
+
+    case "denied":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-denied"
+        >
+          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {t("proposals.notAuthorized", "Not authorized.")}
+          </p>
+        </div>
+      );
+
+    case "not_draft":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-not-draft"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {result.message ?? t("proposals.notDraft", "Proposal is not a draft.")}
+          </p>
+        </div>
+      );
+
+    case "not_found":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-not-found"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {t("proposals.notFound", "Proposal not found.")}
+          </p>
+        </div>
+      );
+
+    case "error":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-error"
         >
           <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
           <p className="text-sm text-destructive">{result.message}</p>


### PR DESCRIPTION
## What

**G5 Phase 4 (live wiring)** — make the materializer from #495 reachable on a
real, human-driven path, so an operator can turn a draft proposal's
irreducibly-code parts (today the `ActionDefinition.handler` body) into AI-generated
candidate source and review it before anything lands.

### Server — `POST /api/proposals/:id/materialize`
`proposal-materialize-api.ts` (mirrors `proposal-graduate-api.ts`):
- Injectable orchestrator `runProposalMaterialization`: load draft → generate
  source via a `CodeGenerationProvider` (the #494 cap-ai-provider impl, over the
  configured AI) → Phase 2 syntax gate → persist `generatedSource` back onto the
  draft via `ProposalEngine.updateProposal`. Returns a discriminated outcome.
- The CommandLayer permission slot runs **FIRST** and is never skipped; an
  unauthorized caller learns nothing (canonical `AUTHZ_DENIED`).
- Graceful **503** when the command layer or AI provider is unconfigured
  (degrade, don't throw).
- Wired in `server.ts` with `aiService` from `ServerOptions`.

### UI — proposal-review page
- A **"Materialize code"** button on draft cards + an outcome banner
  (materialized / skipped / failed counts) and a read-only viewer of the
  generated candidate source per change.
- `materializeProposal` client mirrors the graduate client: discriminated
  result, injectable `fetchImpl`, `encodeURIComponent(id)`.

`serializeProposal` is exported for the route; it already carries `changes`
(hence `generatedSource`), so the UI renders source with no extra fetch.

## Safety boundary

DRAFT-only (422 otherwise). Candidate source ONLY — the endpoint NEVER submits,
approves, commits, graduates, writes files, or runs code. The candidate flows
through validation (Phase 2) and **double human review** (draft review +
graduation PR) before it can land. "AI never modifies production directly." It is
ON-DEMAND only — no scheduler / cron / cadence (a deferred product decision).

## Review

Codex review (`origin/main..HEAD`): clean — "enforces the intended draft-only and
authorization/configuration guards, persists generated source through the
proposal engine, and the UI/client mappings align with the server contract."

## Verification
- `bun run check` / `bun run typecheck` — clean
- `bun run test` — PASS (11 server: orchestrator guards + endpoint
  200/403/503/422/404/500 + write-back; 11 UI client: status mapping; fake
  provider — no real model called)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
