### PR TITLE
feat(core): validation Phase 4 — generated-source contract check (G5)

### DIFF
--- a/.changeset/g5-phase4-contract.md
+++ b/.changeset/g5-phase4-contract.md
@@ -1,0 +1,12 @@
+---
+"@linchkit/core": minor
+---
+
+Add validation Phase 4 — generated-source contract check (G5). `validatePhase4`
+statically (execution-free) verifies that AI-materialized `generatedSource`
+actually defines the change's declared target/name (right `define*()` call,
+references its name, imports `@linchkit/core`). Warn-only by default; gated to
+block via `ValidationContext.strictGeneratedContract`. Wired into
+`validateProposal` (was a skipped stub); all-declarative proposals stay
+"skipped". No generated code is ever executed — an execution-based dry-run
+(sandboxed handler run) is intentionally out of scope.

--- a/packages/core/__tests__/barrel-public-surface.test.ts
+++ b/packages/core/__tests__/barrel-public-surface.test.ts
@@ -402,6 +402,7 @@ const EXPECTED_SERVER_EXPORTS = [
   "validatePhase1",
   "validatePhase2",
   "validatePhase3",
+  "validatePhase4",
   "validateProposal",
   "validateProposalExtended",
   "validateRequiredEnvVars",

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -56,12 +56,12 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(result.warnings[0]?.target).toBe("do_thing");
   });
 
-  test("flags a missing name reference and a missing core import", () => {
+  test("flags defining the wrong action + a missing core import", () => {
     const result = validatePhase4({
       changes: [
         change({
           name: "deduct_inventory",
-          // calls defineAction but neither references the declared name nor imports core
+          // calls defineAction for a DIFFERENT action and does not import core
           generatedSource: `export const other = defineAction({ name: "other", handler: async () => ({}) });`,
         }),
       ],
@@ -69,9 +69,29 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(result.status).toBe("passed"); // warn-only
     const codes = result.warnings.map((w) => w.message);
     expect(
-      codes.some((m) => m.includes('does not reference its declared name "deduct_inventory"')),
+      codes.some((m) => m.includes('does not define defineAction(...) for "deduct_inventory"')),
     ).toBe(true);
     expect(codes.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
+  });
+
+  test("defineAction for ANOTHER action does not satisfy the declared name (tied check)", () => {
+    // A real defineAction call + the declared name mentioned elsewhere must NOT
+    // pass: the call must be tied to the declared action (codex review hardening).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import { defineAction } from "@linchkit/core";\nexport const do_thing = 1;\nexport const other = defineAction({ name: "other", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('does not define defineAction(...) for "do_thing"'),
+      ),
+    ).toBe(true);
   });
 
   test("comment markers INSIDE string literals are not treated as comments (URL / slash safety)", () => {
@@ -158,8 +178,8 @@ describe("validatePhase4 — generated-source contract", () => {
     });
     expect(result.status).toBe("failed");
     const msgs = result.errors.map((e) => e.message);
-    // Both the call check and the import check must fire despite the mentions.
-    expect(msgs.some((m) => m.includes("does not call defineAction(...)"))).toBe(true);
+    // Both the define check and the import check must fire despite the mentions.
+    expect(msgs.some((m) => m.includes("does not define defineAction(...)"))).toBe(true);
     expect(msgs.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
   });
 
@@ -178,7 +198,7 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(result.status).toBe("failed");
     expect(
       result.errors.some((e) =>
-        e.message.includes('does not reference its declared name "do_thing"'),
+        e.message.includes('does not define defineAction(...) for "do_thing"'),
       ),
     ).toBe(true);
   });

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { validatePhase4 } from "../../engine/validation-phase4";
+import type { ProposalChange } from "../../types/proposal";
+
+function change(overrides: Partial<ProposalChange>): ProposalChange {
+  return { target: "action", operation: "create", name: "do_thing", ...overrides };
+}
+
+const GOOD = `import { defineAction } from "@linchkit/core";
+export const do_thing = defineAction({ name: "do_thing", handler: async () => ({}) });`;
+
+describe("validatePhase4 — generated-source contract", () => {
+  test("skips when no change carries generatedSource", () => {
+    const result = validatePhase4({
+      changes: [change({}), change({ target: "rule", name: "r1" })],
+    });
+    expect(result.phase).toBe(4);
+    expect(result.status).toBe("skipped");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("skips an empty / whitespace generatedSource (a Phase 2 concern, not re-flagged)", () => {
+    const result = validatePhase4({
+      changes: [change({ name: "empty_action", generatedSource: "   \n" })],
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("passes a well-formed action definition", () => {
+    const result = validatePhase4({
+      changes: [change({ generatedSource: GOOD })],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("warn-only by default: missing defineAction() → warning, status stays passed", () => {
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          // syntactically fine, references the name + imports core, but no defineAction()
+          generatedSource: `import { x } from "@linchkit/core";\nexport const do_thing = 1;`,
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.code).toBe("GENERATED_SOURCE_CONTRACT");
+    expect(result.warnings[0]?.message).toContain("defineAction");
+    expect(result.warnings[0]?.target).toBe("do_thing");
+  });
+
+  test("flags a missing name reference and a missing core import", () => {
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "deduct_inventory",
+          // calls defineAction but neither references the declared name nor imports core
+          generatedSource: `export const other = defineAction({ name: "other", handler: async () => ({}) });`,
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed"); // warn-only
+    const codes = result.warnings.map((w) => w.message);
+    expect(
+      codes.some((m) => m.includes('does not reference its declared name "deduct_inventory"')),
+    ).toBe(true);
+    expect(codes.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
+  });
+
+  test("strictGeneratedContract: findings become errors, status failed", () => {
+    const result = validatePhase4({
+      changes: [change({ name: "do_thing", generatedSource: `export const do_thing = 1;` })],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]?.code).toBe("GENERATED_SOURCE_CONTRACT");
+  });
+});

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -74,6 +74,30 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(codes.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
   });
 
+  test("comment markers INSIDE string literals are not treated as comments (URL / slash safety)", () => {
+    // `/*` in one string and `*/` in another must NOT be parsed as a block
+    // comment that swallows the real import/defineAction between them — and a URL's
+    // `//` must not be parsed as a line comment. A naive regex stripper fails this;
+    // the single-pass string-aware walker passes it (gemini review hardening).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "sync_data",
+          generatedSource: [
+            'const open = "/*";',
+            'import { defineAction } from "@linchkit/core";',
+            'const url = "https://api.example.com/v1";',
+            'export const sync_data = defineAction({ name: "sync_data", handler: async () => ({ url }) });',
+            'const close = "*/";',
+          ].join("\n"),
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+  });
+
   test("tokens that appear only in comments or strings do NOT satisfy the contract", () => {
     // defineAction( and @linchkit/core appear ONLY inside a comment / string —
     // they must not satisfy the call/import checks (codex review hardening).

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -253,6 +253,26 @@ describe("validatePhase4 — generated-source contract", () => {
     ).toBe(true);
   });
 
+  test("the OPTIONS name: is authoritative — a matching variable name does not save a wrong name:", () => {
+    // `const do_thing = defineAction({ name: "other" })` registers action "other"
+    // (the options name:), not "do_thing" (the variable). Must flag (codex review).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import { defineAction } from "@linchkit/core";\nexport const do_thing = defineAction({ name: "other", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('does not define defineAction(...) for "do_thing"'),
+      ),
+    ).toBe(true);
+  });
+
   test("strictGeneratedContract: findings become errors, status failed", () => {
     const result = validatePhase4({
       changes: [change({ name: "do_thing", generatedSource: `export const do_thing = 1;` })],

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -74,6 +74,30 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(codes.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
   });
 
+  test("tokens that appear only in comments or strings do NOT satisfy the contract", () => {
+    // defineAction( and @linchkit/core appear ONLY inside a comment / string —
+    // they must not satisfy the call/import checks (codex review hardening).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: [
+            '// import { defineAction } from "@linchkit/core";',
+            "/* defineAction( should not count */",
+            'const note = "use defineAction() from @linchkit/core";',
+            "export const do_thing = 1;",
+          ].join("\n"),
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    const msgs = result.errors.map((e) => e.message);
+    // Both the call check and the import check must fire despite the mentions.
+    expect(msgs.some((m) => m.includes("does not call defineAction(...)"))).toBe(true);
+    expect(msgs.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
+  });
+
   test("strictGeneratedContract: findings become errors, status failed", () => {
     const result = validatePhase4({
       changes: [change({ name: "do_thing", generatedSource: `export const do_thing = 1;` })],

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -273,6 +273,42 @@ describe("validatePhase4 — generated-source contract", () => {
     ).toBe(true);
   });
 
+  test("a type-only or aliased helper import does not satisfy the import check", () => {
+    // `import type { defineAction }` is erased; `defineAction as da` binds `da`,
+    // not `defineAction` — neither gives a usable defineAction value (codex review).
+    const typeOnly = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import type { defineAction } from "@linchkit/core";\nexport const do_thing = defineAction({ name: "do_thing", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(typeOnly.status).toBe("failed");
+    expect(
+      typeOnly.errors.some((e) =>
+        e.message.includes('does not import defineAction from "@linchkit/core"'),
+      ),
+    ).toBe(true);
+
+    const aliased = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import { defineAction as da } from "@linchkit/core";\nexport const do_thing = da({ name: "do_thing", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(aliased.status).toBe("failed");
+    expect(
+      aliased.errors.some((e) =>
+        e.message.includes('does not import defineAction from "@linchkit/core"'),
+      ),
+    ).toBe(true);
+  });
+
   test("strictGeneratedContract: findings become errors, status failed", () => {
     const result = validatePhase4({
       changes: [change({ name: "do_thing", generatedSource: `export const do_thing = 1;` })],

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -98,6 +98,25 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(result.errors).toEqual([]);
   });
 
+  test("a re-export from core does NOT satisfy the import check (no local binding)", () => {
+    // `export { defineAction } from "@linchkit/core"` re-exports — it creates no
+    // local `defineAction` binding, so calling it would fail. The import check
+    // must require a real `import` (codex review hardening).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `export { defineAction } from "@linchkit/core";\nexport const do_thing = defineAction({ name: "do_thing", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) => e.message.includes('does not import from "@linchkit/core"')),
+    ).toBe(true);
+  });
+
   test("tokens that appear only in comments or strings do NOT satisfy the contract", () => {
     // defineAction( and @linchkit/core appear ONLY inside a comment / string —
     // they must not satisfy the call/import checks (codex review hardening).

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -43,8 +43,9 @@ describe("validatePhase4 — generated-source contract", () => {
       changes: [
         change({
           name: "do_thing",
-          // syntactically fine, references the name + imports core, but no defineAction()
-          generatedSource: `import { x } from "@linchkit/core";\nexport const do_thing = 1;`,
+          // imports defineAction (so the import check is satisfied) but never calls
+          // it — isolates the missing-define finding.
+          generatedSource: `import { defineAction } from "@linchkit/core";\nexport const do_thing = 1;`,
         }),
       ],
     });
@@ -71,7 +72,9 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(
       codes.some((m) => m.includes('does not define defineAction(...) for "deduct_inventory"')),
     ).toBe(true);
-    expect(codes.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
+    expect(
+      codes.some((m) => m.includes('does not import defineAction from "@linchkit/core"')),
+    ).toBe(true);
   });
 
   test("defineAction for ANOTHER action does not satisfy the declared name (tied check)", () => {
@@ -136,7 +139,9 @@ describe("validatePhase4 — generated-source contract", () => {
     });
     expect(result.status).toBe("failed");
     expect(
-      result.errors.some((e) => e.message.includes('does not import from "@linchkit/core"')),
+      result.errors.some((e) =>
+        e.message.includes('does not import defineAction from "@linchkit/core"'),
+      ),
     ).toBe(true);
   });
 
@@ -155,7 +160,9 @@ describe("validatePhase4 — generated-source contract", () => {
     });
     expect(result.status).toBe("failed");
     expect(
-      result.errors.some((e) => e.message.includes('does not import from "@linchkit/core"')),
+      result.errors.some((e) =>
+        e.message.includes('does not import defineAction from "@linchkit/core"'),
+      ),
     ).toBe(true);
   });
 
@@ -180,7 +187,9 @@ describe("validatePhase4 — generated-source contract", () => {
     const msgs = result.errors.map((e) => e.message);
     // Both the define check and the import check must fire despite the mentions.
     expect(msgs.some((m) => m.includes("does not define defineAction(...)"))).toBe(true);
-    expect(msgs.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
+    expect(msgs.some((m) => m.includes('does not import defineAction from "@linchkit/core"'))).toBe(
+      true,
+    );
   });
 
   test("a different name that merely CONTAINS the declared name does not satisfy it", () => {
@@ -191,6 +200,47 @@ describe("validatePhase4 — generated-source contract", () => {
         change({
           name: "do_thing",
           generatedSource: `import { defineAction } from "@linchkit/core";\nexport const do_thing_v2 = defineAction({ name: "do_thing_v2", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('does not define defineAction(...) for "do_thing"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("importing a DIFFERENT core helper does not satisfy the import check", () => {
+    // defineEntity is imported, but the source calls defineAction → the helper it
+    // calls is not bound (codex review hardening — helper-specific import).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import { defineEntity } from "@linchkit/core";\nexport const do_thing = defineAction({ name: "do_thing", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('does not import defineAction from "@linchkit/core"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("a name: in unrelated code after the call does not satisfy the tied check", () => {
+    // defineAction defines "other"; the declared name appears only in a separate
+    // object literal → the name match must stay inside the call's own braces
+    // (codex review hardening).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import { defineAction } from "@linchkit/core";\nexport const other = defineAction({ name: "other", handler: async () => ({}) });\nconst metadata = { name: "do_thing" };`,
         }),
       ],
       strictGeneratedContract: true,

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -98,6 +98,26 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(msgs.some((m) => m.includes('does not import from "@linchkit/core"'))).toBe(true);
   });
 
+  test("a different name that merely CONTAINS the declared name does not satisfy it", () => {
+    // Declared "do_thing" but the source defines "do_thing_v2" — substring would
+    // pass, word-boundary must not (codex review hardening).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: `import { defineAction } from "@linchkit/core";\nexport const do_thing_v2 = defineAction({ name: "do_thing_v2", handler: async () => ({}) });`,
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) =>
+        e.message.includes('does not reference its declared name "do_thing"'),
+      ),
+    ).toBe(true);
+  });
+
   test("strictGeneratedContract: findings become errors, status failed", () => {
     const result = validatePhase4({
       changes: [change({ name: "do_thing", generatedSource: `export const do_thing = 1;` })],

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -98,6 +98,28 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(result.errors).toEqual([]);
   });
 
+  test("an import that appears only inside a string literal does NOT satisfy the import check", () => {
+    // The full import statement lives inside a string; defineAction is called as
+    // real code but there is NO real import binding → must flag missing import
+    // (codex review hardening — string-aware import detection).
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "do_thing",
+          generatedSource: [
+            'const fake = "import { defineAction } from \\"@linchkit/core\\";";',
+            'export const do_thing = defineAction({ name: "do_thing", handler: async () => ({ fake }) });',
+          ].join("\n"),
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(
+      result.errors.some((e) => e.message.includes('does not import from "@linchkit/core"')),
+    ).toBe(true);
+  });
+
   test("a re-export from core does NOT satisfy the import check (no local binding)", () => {
     // `export { defineAction } from "@linchkit/core"` re-exports — it creates no
     // local `defineAction` binding, so calling it would fail. The import check

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -27,6 +27,7 @@ import type { RuleDefinition } from "../types/rule";
 import type { StateDefinition } from "../types/state";
 import { validatePhase2 } from "./validation-phase2";
 import { validatePhase3 } from "./validation-phase3";
+import { validatePhase4 } from "./validation-phase4";
 
 // ── Valid field types ────────────────────────────────────
 // Relationships are now declared via defineRelation(), not field types
@@ -78,6 +79,14 @@ export interface ValidationContext {
    * skipped regardless. Mirrors the `strictCompatibility` pattern.
    */
   strictGeneratedBuild?: boolean;
+  /**
+   * Escalate Phase 4 (generated-source contract) findings from WARN to BLOCK.
+   * Default (false / undefined) → Phase 4 is warn-only and does NOT affect
+   * `passed`. The checks are heuristic (execution-free static checks that the AI
+   * generated the declared `define*()` target/name), so warn-only is the safe
+   * default. When no change carries generated source, Phase 4 is skipped.
+   */
+  strictGeneratedContract?: boolean;
 }
 
 // ── Phase 1: Static checks ──────────────────────────────
@@ -680,14 +689,16 @@ export function validateProposal(options: {
     strictCompatibility: context?.strictCompatibility,
   });
 
-  // Phase 4: Skipped for M1 (test pass)
-  const phase4: PhaseResult = {
-    phase: 4,
-    status: "skipped",
-    errors: [],
-    warnings: [],
-    duration: 0,
-  };
+  // Phase 4: Generated-source CONTRACT check (G5) — static, EXECUTION-FREE
+  // verification that any AI-materialized `generatedSource` actually defines the
+  // declared target/name (right define*() call, references its name, imports
+  // core). Warn-only by default; gated to BLOCK via strictGeneratedContract. No
+  // generated source → "skipped". A true execution-based dry-run is intentionally
+  // out of scope (it would require a sandbox to run untrusted AI code).
+  const phase4 = validatePhase4({
+    changes: proposal.changes,
+    strictGeneratedContract: context?.strictGeneratedContract,
+  });
 
   const phases = [phase1, phase2, phase3, phase4];
   const passed = phases.filter((p) => p.status !== "skipped").every((p) => p.status === "passed");

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -81,6 +81,11 @@ function stripCommentsAndStrings(src: string): string {
     .replace(/`(?:[^`\\]|\\.)*`/g, "``");
 }
 
+/** Escape a string for safe interpolation into a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 // ── Entry point ──────────────────────────────────────────
 
 /**
@@ -128,8 +133,12 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     // The generated definition should reference its declared name. A missing name
     // usually means the AI generated something unrelated or a bare stub. The name
     // may appear as an identifier or as the definition's `name:` literal, so this
-    // check runs on the comments-stripped (string-preserving) source.
-    if (!noComments.includes(change.name)) {
+    // check runs on the comments-stripped (string-preserving) source. Match on a
+    // word boundary so a different name that merely CONTAINS the declared one
+    // (e.g. `do_thing_v2` for `do_thing`) does not satisfy it — `_` is a word
+    // char, so `\bdo_thing\b` won't match inside `do_thing_v2`.
+    const nameRef = new RegExp(`\\b${escapeRegExp(change.name)}\\b`);
+    if (!nameRef.test(noComments)) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
         message: `Generated source for ${change.target} "${change.name}" does not reference its declared name "${change.name}".`,

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -50,15 +50,14 @@ export interface ValidatePhase4Options {
 const CORE_IMPORT = "@linchkit/core";
 
 /**
- * Per-materializable-target contract: the `define*()` call its generated source
- * must contain, with a pre-compiled detector regex. Only `action` is
- * materializable today (see the proposal materializer's MATERIALIZABLE_TARGETS);
- * other targets are serialized declaratively and never carry `generatedSource`.
- * A target absent from this map skips the call check (name/import checks still
- * run). `\b...\(` matches a real call after comment/string removal.
+ * Per-materializable-target contract: the `define*()` helper its generated source
+ * must call (and import). Only `action` is materializable today (see the proposal
+ * materializer's MATERIALIZABLE_TARGETS); other targets are serialized
+ * declaratively and never carry `generatedSource`. A target absent from this map
+ * falls back to a bare name-reference check.
  */
-const CONTRACT_BY_TARGET: Partial<Record<ProposalChangeTarget, { call: string; re: RegExp }>> = {
-  action: { call: "defineAction", re: /\bdefineAction\s*\(/ },
+const CONTRACT_BY_TARGET: Partial<Record<ProposalChangeTarget, string>> = {
+  action: "defineAction",
 };
 
 // Pre-compiled core-import detectors (recreating per change/iteration is wasteful).
@@ -198,40 +197,34 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     const contract = CONTRACT_BY_TARGET[change.target];
     const escName = escapeRegExp(change.name);
     if (contract) {
-      // The define call must be TIED to the declared name (not just present
-      // somewhere alongside the name). Two accepted, REAL-code forms:
-      //   1. `const|let|var <name> = defineAction(`  — binding id == declared name.
-      //      The identifier survives in `code` (strings/comments blanked), so this
-      //      is robust against name-in-string fakes.
-      //   2. `defineAction({ … name: "<name>" … })`  — a real call (keyword in
-      //      code) whose options object names the declared action. The `name:`
-      //      literal lives in a string, so we scan `noComments` (strings kept) but
-      //      confirm the `defineAction` keyword sits in real code via index check.
-      const callName = escapeRegExp(contract.call);
-      const boundByConst = new RegExp(
-        `\\b(?:const|let|var)\\s+${escName}\\s*=\\s*${callName}\\s*\\(`,
-      ).test(code);
-      let boundByName = false;
-      if (!boundByConst) {
-        // `[^}]*?` keeps the `name:` match INSIDE the call's own options object —
-        // it cannot cross the first `}` into unrelated later code (e.g. a separate
-        // `const meta = { name: "<declared>" }`). Conservative: a nested object
-        // before `name:` ends the scan early → a false warning, never a false pass.
-        const callRe = new RegExp(
-          `\\b${callName}\\s*\\(\\s*\\{[^}]*?\\bname\\s*:\\s*["'\`]${escName}["'\`]`,
-          "g",
-        );
-        for (const m of noComments.matchAll(callRe)) {
-          if (m.index !== undefined && /\S/.test(code[m.index] ?? "")) {
-            boundByName = true;
-            break;
-          }
+      // The contract is satisfied only by a REAL `defineAction({ … name: "<name>" … })`
+      // call whose OPTIONS-OBJECT name is the declared action. The registered
+      // `ActionDefinition.name` comes from that `name:` literal — NOT from the
+      // variable it's assigned to (`const do_thing = defineAction({ name: "other" })`
+      // registers `other`), so the const-binding name is intentionally NOT trusted.
+      // The `name:` literal lives in a string, so we scan `noComments` (strings
+      // kept) but confirm the `defineAction` keyword sits in real code via the
+      // index cross-reference. `[^}]*?` keeps the match INSIDE the call's own
+      // options object — it cannot cross the first `}` into unrelated later code
+      // (e.g. a separate `const meta = { name: "<declared>" }`). Conservative: a
+      // nested object before `name:` ends the scan early → a false warning, never
+      // a false pass.
+      const callName = escapeRegExp(contract);
+      const callRe = new RegExp(
+        `\\b${callName}\\s*\\(\\s*\\{[^}]*?\\bname\\s*:\\s*["'\`]${escName}["'\`]`,
+        "g",
+      );
+      let definesDeclared = false;
+      for (const m of noComments.matchAll(callRe)) {
+        if (m.index !== undefined && /\S/.test(code[m.index] ?? "")) {
+          definesDeclared = true;
+          break;
         }
       }
-      if (!boundByConst && !boundByName) {
+      if (!definesDeclared) {
         findings.push({
           code: "GENERATED_SOURCE_CONTRACT",
-          message: `Generated source for ${change.target} "${change.name}" does not define ${contract.call}(...) for "${change.name}".`,
+          message: `Generated source for ${change.target} "${change.name}" does not define ${contract}(...) for "${change.name}".`,
           target: change.name,
         });
       }
@@ -259,7 +252,7 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     // in the import clause — `import { defineEntity } from core` must not satisfy a
     // `defineAction` contract. `require("@linchkit/core")` (destructured) is also
     // accepted. Without a contract, fall back to any real core import.
-    const helper = contract?.call;
+    const helper = contract;
     const importRe = helper
       ? new RegExp(
           `\\bimport\\b[^;]*?\\b${escapeRegExp(helper)}\\b[^;]*?from\\s*["'\`]@linchkit\\/core["'\`]`,

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -1,0 +1,134 @@
+/**
+ * Validation Phase 4 — Generated-source CONTRACT check (G5).
+ *
+ * Phase 4 inspects any `generatedSource` attached to a proposal's changes (by the
+ * proposal materializer) and checks — WITHOUT EXECUTING ANYTHING — that the AI
+ * actually generated the kind of definition the change declares: the right
+ * `define<Target>()` call, a reference to the declared name, and an import from
+ * `@linchkit/core`. It catches a class of AI errors that pass the Phase 2 syntax
+ * gate yet are wrong (e.g. an empty scaffold, the wrong target, or a mismatched
+ * name) before a human reviews the candidate.
+ *
+ * SAFETY — EXECUTION-FREE BY DESIGN ("AI never modifies production directly"):
+ * this NEVER `eval`s, `import`s, transpiles-and-runs, or otherwise executes the
+ * generated source. It only does static string/structural heuristics. A true
+ * execution-based dry-run (running a generated handler against sample/historical
+ * data) requires a locked-down sandbox and is intentionally OUT OF SCOPE here —
+ * deferred to a separate, sandbox-gated step so untrusted AI code is never run
+ * as a side effect of validation.
+ *
+ * Severity / gating mirrors Phase 2 / Phase 3 (low-regret):
+ *   - DEFAULT: WARN-ONLY. Findings are `warnings`; `passed` is unaffected. The
+ *     checks are heuristic, so they must not block by default.
+ *   - GATED: when `strictGeneratedContract` is true, findings become `errors`
+ *     (status "failed" → proposal `passed` = false → blocks).
+ *
+ * An all-declarative proposal (no `generatedSource`) degrades to "skipped".
+ */
+
+import type {
+  PhaseResult,
+  ProposalChange,
+  ProposalChangeTarget,
+  ValidationError,
+  ValidationWarning,
+} from "../types/proposal";
+
+// ── Options ──────────────────────────────────────────────
+
+export interface ValidatePhase4Options {
+  /** The proposal's changes to inspect for materialized `generatedSource`. */
+  changes: ProposalChange[];
+  /**
+   * When true, generated-source contract findings become ERRORS (blocking).
+   * Default (false / undefined) → findings are WARNINGS only and do not affect
+   * `passed`. The checks are heuristic, so warn-only is the safe default.
+   */
+  strictGeneratedContract?: boolean;
+}
+
+/**
+ * Map a materializable target to the `define*()` call its generated source is
+ * expected to contain. Only `action` is materializable today (see the proposal
+ * materializer's MATERIALIZABLE_TARGETS); other targets are serialized
+ * declaratively and never carry `generatedSource`. A target absent from this map
+ * simply skips the define-call check (the name/import checks still run).
+ */
+const DEFINE_CALL_BY_TARGET: Partial<Record<ProposalChangeTarget, string>> = {
+  action: "defineAction",
+};
+
+const CORE_IMPORT = "@linchkit/core";
+
+// ── Entry point ──────────────────────────────────────────
+
+/**
+ * Run Phase 4 (generated-source contract) validation on a proposal's changes.
+ *
+ * Returns a PhaseResult:
+ *  - no change carries a non-empty `generatedSource` → status "skipped"
+ *  - findings + strictGeneratedContract=false → status "passed" with `warnings`
+ *  - findings + strictGeneratedContract=true  → status "failed" with `errors`
+ */
+export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
+  const { changes, strictGeneratedContract = false } = options;
+  const start = Date.now();
+
+  // Only NON-EMPTY generated sources have a contract to check. An empty /
+  // whitespace materialization is a Phase 2 (syntax) finding — not re-flagged
+  // here. Declarative changes (no generatedSource) have nothing to check.
+  const withSource = changes.filter(
+    (c) => typeof c.generatedSource === "string" && c.generatedSource.trim().length > 0,
+  );
+
+  if (withSource.length === 0) {
+    return { phase: 4, status: "skipped", errors: [], warnings: [], duration: Date.now() - start };
+  }
+
+  const findings: Array<{ code: string; message: string; target?: string }> = [];
+  for (const change of withSource) {
+    const source = change.generatedSource as string;
+
+    const expectedCall = DEFINE_CALL_BY_TARGET[change.target];
+    if (expectedCall && !source.includes(`${expectedCall}(`)) {
+      findings.push({
+        code: "GENERATED_SOURCE_CONTRACT",
+        message: `Generated source for ${change.target} "${change.name}" does not call ${expectedCall}(...).`,
+        target: change.name,
+      });
+    }
+
+    // The generated definition should reference its declared name. A missing name
+    // usually means the AI generated something unrelated or a bare stub.
+    if (!source.includes(change.name)) {
+      findings.push({
+        code: "GENERATED_SOURCE_CONTRACT",
+        message: `Generated source for ${change.target} "${change.name}" does not reference its declared name "${change.name}".`,
+        target: change.name,
+      });
+    }
+
+    // Definitions need the define* helpers, which come from @linchkit/core.
+    if (!source.includes(CORE_IMPORT)) {
+      findings.push({
+        code: "GENERATED_SOURCE_CONTRACT",
+        message: `Generated source for ${change.target} "${change.name}" does not import from "${CORE_IMPORT}".`,
+        target: change.name,
+      });
+    }
+  }
+
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [];
+  if (strictGeneratedContract) {
+    for (const f of findings) errors.push(f);
+  } else {
+    for (const f of findings) warnings.push(f);
+  }
+
+  // Warn-only by default: status stays "passed" even with warnings — `passed` is
+  // only dragged false when strictGeneratedContract escalated findings to errors.
+  const status: PhaseResult["status"] = errors.length === 0 ? "passed" : "failed";
+
+  return { phase: 4, status, errors, warnings, duration: Date.now() - start };
+}

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -47,38 +47,92 @@ export interface ValidatePhase4Options {
   strictGeneratedContract?: boolean;
 }
 
+const CORE_IMPORT = "@linchkit/core";
+
 /**
- * Map a materializable target to the `define*()` call its generated source is
- * expected to contain. Only `action` is materializable today (see the proposal
- * materializer's MATERIALIZABLE_TARGETS); other targets are serialized
- * declaratively and never carry `generatedSource`. A target absent from this map
- * simply skips the define-call check (the name/import checks still run).
+ * Per-materializable-target contract: the `define*()` call its generated source
+ * must contain, with a pre-compiled detector regex. Only `action` is
+ * materializable today (see the proposal materializer's MATERIALIZABLE_TARGETS);
+ * other targets are serialized declaratively and never carry `generatedSource`.
+ * A target absent from this map skips the call check (name/import checks still
+ * run). `\b...\(` matches a real call after comment/string removal.
  */
-const DEFINE_CALL_BY_TARGET: Partial<Record<ProposalChangeTarget, string>> = {
-  action: "defineAction",
+const CONTRACT_BY_TARGET: Partial<Record<ProposalChangeTarget, { call: string; re: RegExp }>> = {
+  action: { call: "defineAction", re: /\bdefineAction\s*\(/ },
 };
 
-const CORE_IMPORT = "@linchkit/core";
+// Pre-compiled core-import detectors (recreating per change/iteration is wasteful).
+// `@linchkit/core` contains no regex metacharacters, so these literals are exact.
+// `[^;]*?` allows a multi-line import clause bounded by the statement terminator.
+const IMPORT_CORE_RE = /(?:import|export)\b[^;]*?from\s*["'`]@linchkit\/core["'`]/;
+const REQUIRE_CORE_RE = /require\(\s*["'`]@linchkit\/core["'`]\s*\)/;
 
 // ── Comment / string stripping ───────────────────────────
 // The contract checks must not be satisfiable by a token that appears only in a
 // comment (`// defineAction(`) or a string literal (`"call defineAction()"`).
-// These lightweight strippers remove those regions before the structural checks.
-// They are deliberately conservative: over-stripping (e.g. comment markers inside
-// an oddly-quoted string) only makes a check MORE likely to flag — a false
-// WARNING, never a false PASS.
+// A regex-only stripper is NOT string-aware — it would corrupt `//` inside a
+// string (e.g. a URL "https://x"). So this walks the source ONCE, tracking
+// string vs comment state, blanking comments (and optionally string bodies).
 
-/** Remove `//` line comments and block comments. */
-function stripComments(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+/**
+ * Single left-to-right pass that removes comments and, when `stripStrings` is
+ * true, the BODIES of string / template literals (delimiters kept). It is
+ * string/comment aware: a comment marker inside a string is preserved, and a
+ * quote inside a comment is ignored. Template-literal interpolation is treated
+ * as opaque string content (good enough for these heuristic checks).
+ */
+function stripCode(src: string, stripStrings: boolean): string {
+  let out = "";
+  const n = src.length;
+  let i = 0;
+  while (i < n) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (c === "/" && next === "/") {
+      i += 2;
+      while (i < n && src[i] !== "\n") i++;
+      out += " ";
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(src[i] === "*" && src[i + 1] === "/")) i++;
+      i += 2; // skip the closing */
+      out += " ";
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      const start = i;
+      i++;
+      while (i < n) {
+        if (src[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (src[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      out += stripStrings ? `${quote}${quote}` : src.slice(start, i);
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
 }
 
-/** Remove comments AND string / template literals (their bodies). */
+/** Remove comments only (string bodies preserved). */
+function stripComments(src: string): string {
+  return stripCode(src, false);
+}
+
+/** Remove comments AND string / template literal bodies. */
 function stripCommentsAndStrings(src: string): string {
-  return stripComments(src)
-    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
-    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
-    .replace(/`(?:[^`\\]|\\.)*`/g, "``");
+  return stripCode(src, true);
 }
 
 /** Escape a string for safe interpolation into a RegExp. */
@@ -121,11 +175,11 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     const code = stripCommentsAndStrings(source);
     const noComments = stripComments(source);
 
-    const expectedCall = DEFINE_CALL_BY_TARGET[change.target];
-    if (expectedCall && !new RegExp(`\\b${expectedCall}\\s*\\(`).test(code)) {
+    const contract = CONTRACT_BY_TARGET[change.target];
+    if (contract && !contract.re.test(code)) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
-        message: `Generated source for ${change.target} "${change.name}" does not call ${expectedCall}(...).`,
+        message: `Generated source for ${change.target} "${change.name}" does not call ${contract.call}(...).`,
         target: change.name,
       });
     }
@@ -150,9 +204,7 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     // a real import/export-from or require() statement (not a bare mention) so a
     // comment or unrelated string can't satisfy it. `[^;]*?` allows multi-line
     // import clauses bounded by the statement terminator.
-    const importsCore =
-      new RegExp(`(?:import|export)\\b[^;]*?from\\s*["'\`]${CORE_IMPORT}["'\`]`).test(noComments) ||
-      new RegExp(`require\\(\\s*["'\`]${CORE_IMPORT}["'\`]\\s*\\)`).test(noComments);
+    const importsCore = IMPORT_CORE_RE.test(noComments) || REQUIRE_CORE_RE.test(noComments);
     if (!importsCore) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -65,9 +65,11 @@ const CONTRACT_BY_TARGET: Partial<Record<ProposalChangeTarget, { call: string; r
 // `@linchkit/core` contains no regex metacharacters, so these literals are exact.
 // `[^;]*?` allows a multi-line import clause bounded by the statement terminator.
 // Only `import` (not `export … from`) is accepted: a re-export creates NO local
-// binding, so `defineAction(...)` would have nothing to call.
-const IMPORT_CORE_RE = /\bimport\b[^;]*?from\s*["'`]@linchkit\/core["'`]/;
-const REQUIRE_CORE_RE = /require\(\s*["'`]@linchkit\/core["'`]\s*\)/;
+// binding, so `defineAction(...)` would have nothing to call. Global so callers
+// can `matchAll` and verify each match's `import` keyword is real code (not text
+// inside a string literal) via index cross-reference against the blanked view.
+const IMPORT_CORE_RE = /\bimport\b[^;]*?from\s*["'`]@linchkit\/core["'`]/g;
+const REQUIRE_CORE_RE = /\brequire\(\s*["'`]@linchkit\/core["'`]\s*\)/g;
 
 // ── Comment / string stripping ───────────────────────────
 // The contract checks must not be satisfiable by a token that appears only in a
@@ -76,12 +78,22 @@ const REQUIRE_CORE_RE = /require\(\s*["'`]@linchkit\/core["'`]\s*\)/;
 // string (e.g. a URL "https://x"). So this walks the source ONCE, tracking
 // string vs comment state, blanking comments (and optionally string bodies).
 
+/** Blank a span to spaces but keep newlines (for length preservation). */
+function blank(span: string): string {
+  return span.replace(/[^\n]/g, " ");
+}
+
 /**
- * Single left-to-right pass that removes comments and, when `stripStrings` is
+ * Single left-to-right pass that blanks comments and, when `stripStrings` is
  * true, the BODIES of string / template literals (delimiters kept). It is
  * string/comment aware: a comment marker inside a string is preserved, and a
  * quote inside a comment is ignored. Template-literal interpolation is treated
  * as opaque string content (good enough for these heuristic checks).
+ *
+ * LENGTH-PRESERVING: every input char maps to exactly one output char (blanked
+ * regions become spaces / kept newlines). This lets callers cross-reference an
+ * index between the strings-kept and strings-blanked views (used by the import
+ * check to confirm an `import` keyword is real code, not text inside a string).
  */
 function stripCode(src: string, stripStrings: boolean): string {
   let out = "";
@@ -91,16 +103,18 @@ function stripCode(src: string, stripStrings: boolean): string {
     const c = src[i];
     const next = src[i + 1];
     if (c === "/" && next === "/") {
+      const start = i;
       i += 2;
       while (i < n && src[i] !== "\n") i++;
-      out += " ";
+      out += blank(src.slice(start, i));
       continue;
     }
     if (c === "/" && next === "*") {
+      const start = i;
       i += 2;
       while (i < n && !(src[i] === "*" && src[i + 1] === "/")) i++;
-      i += 2; // skip the closing */
-      out += " ";
+      i = Math.min(i + 2, n); // consume the closing */ (or stop at EOF)
+      out += blank(src.slice(start, i));
       continue;
     }
     if (c === '"' || c === "'" || c === "`") {
@@ -118,7 +132,11 @@ function stripCode(src: string, stripStrings: boolean): string {
         }
         i++;
       }
-      out += stripStrings ? `${quote}${quote}` : src.slice(start, i);
+      const literal = src.slice(start, i);
+      // Blank the whole literal (delimiters included) when stripping strings —
+      // `code` only needs token positions, not delimiters; this is unambiguously
+      // length-preserving so the strings-kept and strings-blanked views align.
+      out += stripStrings ? blank(literal) : literal;
       continue;
     }
     out += c;
@@ -203,10 +221,18 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     }
 
     // Definitions need the define* helpers, which come from @linchkit/core. Match
-    // a real import/export-from or require() statement (not a bare mention) so a
-    // comment or unrelated string can't satisfy it. `[^;]*?` allows multi-line
-    // import clauses bounded by the statement terminator.
-    const importsCore = IMPORT_CORE_RE.test(noComments) || REQUIRE_CORE_RE.test(noComments);
+    // a real `import …`/`require()` statement (not a re-export, comment, or string)
+    // so nothing fake can satisfy it. We scan the strings-KEPT view (so the
+    // specifier is visible) but confirm each match's keyword sits in REAL CODE by
+    // cross-referencing the same index in the strings-BLANKED view — a fake import
+    // inside a string literal is blanked there, so its index is whitespace.
+    const importIsReal = (re: RegExp): boolean => {
+      for (const m of noComments.matchAll(re)) {
+        if (m.index !== undefined && /\S/.test(code[m.index] ?? "")) return true;
+      }
+      return false;
+    };
+    const importsCore = importIsReal(IMPORT_CORE_RE) || importIsReal(REQUIRE_CORE_RE);
     if (!importsCore) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -64,7 +64,9 @@ const CONTRACT_BY_TARGET: Partial<Record<ProposalChangeTarget, { call: string; r
 // Pre-compiled core-import detectors (recreating per change/iteration is wasteful).
 // `@linchkit/core` contains no regex metacharacters, so these literals are exact.
 // `[^;]*?` allows a multi-line import clause bounded by the statement terminator.
-const IMPORT_CORE_RE = /(?:import|export)\b[^;]*?from\s*["'`]@linchkit\/core["'`]/;
+// Only `import` (not `export … from`) is accepted: a re-export creates NO local
+// binding, so `defineAction(...)` would have nothing to call.
+const IMPORT_CORE_RE = /\bimport\b[^;]*?from\s*["'`]@linchkit\/core["'`]/;
 const REQUIRE_CORE_RE = /require\(\s*["'`]@linchkit\/core["'`]\s*\)/;
 
 // ── Comment / string stripping ───────────────────────────

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -213,8 +213,12 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
       ).test(code);
       let boundByName = false;
       if (!boundByConst) {
+        // `[^}]*?` keeps the `name:` match INSIDE the call's own options object —
+        // it cannot cross the first `}` into unrelated later code (e.g. a separate
+        // `const meta = { name: "<declared>" }`). Conservative: a nested object
+        // before `name:` ends the scan early → a false warning, never a false pass.
         const callRe = new RegExp(
-          `\\b${callName}\\s*\\(\\s*\\{[\\s\\S]*?\\bname\\s*:\\s*["'\`]${escName}["'\`]`,
+          `\\b${callName}\\s*\\(\\s*\\{[^}]*?\\bname\\s*:\\s*["'\`]${escName}["'\`]`,
           "g",
         );
         for (const m of noComments.matchAll(callRe)) {
@@ -241,23 +245,33 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
       });
     }
 
-    // Definitions need the define* helpers, which come from @linchkit/core. Match
-    // a real `import …`/`require()` statement (not a re-export, comment, or string)
-    // so nothing fake can satisfy it. We scan the strings-KEPT view (so the
-    // specifier is visible) but confirm each match's keyword sits in REAL CODE by
-    // cross-referencing the same index in the strings-BLANKED view — a fake import
-    // inside a string literal is blanked there, so its index is whitespace.
+    // The define helper must actually be IMPORTED from @linchkit/core. We scan the
+    // strings-KEPT view (so the specifier is visible) but confirm each match's
+    // keyword sits in REAL CODE via index cross-reference against the blanked view
+    // — a fake import inside a string literal is blanked there (whitespace index).
     const importIsReal = (re: RegExp): boolean => {
       for (const m of noComments.matchAll(re)) {
         if (m.index !== undefined && /\S/.test(code[m.index] ?? "")) return true;
       }
       return false;
     };
-    const importsCore = importIsReal(IMPORT_CORE_RE) || importIsReal(REQUIRE_CORE_RE);
+    // When the target has a known helper (e.g. `defineAction`), require THAT helper
+    // in the import clause — `import { defineEntity } from core` must not satisfy a
+    // `defineAction` contract. `require("@linchkit/core")` (destructured) is also
+    // accepted. Without a contract, fall back to any real core import.
+    const helper = contract?.call;
+    const importRe = helper
+      ? new RegExp(
+          `\\bimport\\b[^;]*?\\b${escapeRegExp(helper)}\\b[^;]*?from\\s*["'\`]@linchkit\\/core["'\`]`,
+          "g",
+        )
+      : IMPORT_CORE_RE;
+    const importsCore = importIsReal(importRe) || importIsReal(REQUIRE_CORE_RE);
     if (!importsCore) {
+      const what = helper ? `${helper} from "${CORE_IMPORT}"` : `from "${CORE_IMPORT}"`;
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
-        message: `Generated source for ${change.target} "${change.name}" does not import from "${CORE_IMPORT}".`,
+        message: `Generated source for ${change.target} "${change.name}" does not import ${what}.`,
         target: change.name,
       });
     }

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -60,6 +60,27 @@ const DEFINE_CALL_BY_TARGET: Partial<Record<ProposalChangeTarget, string>> = {
 
 const CORE_IMPORT = "@linchkit/core";
 
+// ── Comment / string stripping ───────────────────────────
+// The contract checks must not be satisfiable by a token that appears only in a
+// comment (`// defineAction(`) or a string literal (`"call defineAction()"`).
+// These lightweight strippers remove those regions before the structural checks.
+// They are deliberately conservative: over-stripping (e.g. comment markers inside
+// an oddly-quoted string) only makes a check MORE likely to flag — a false
+// WARNING, never a false PASS.
+
+/** Remove `//` line comments and block comments. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+/** Remove comments AND string / template literals (their bodies). */
+function stripCommentsAndStrings(src: string): string {
+  return stripComments(src)
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``");
+}
+
 // ── Entry point ──────────────────────────────────────────
 
 /**
@@ -88,9 +109,15 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
   const findings: Array<{ code: string; message: string; target?: string }> = [];
   for (const change of withSource) {
     const source = change.generatedSource as string;
+    // Code with comments+strings removed → a `define*()` call here is a REAL call,
+    // not a mention in a comment/string. Comments-only removed → keeps the
+    // import specifier string and the name (which legitimately appears as the
+    // definition's `name:` literal).
+    const code = stripCommentsAndStrings(source);
+    const noComments = stripComments(source);
 
     const expectedCall = DEFINE_CALL_BY_TARGET[change.target];
-    if (expectedCall && !source.includes(`${expectedCall}(`)) {
+    if (expectedCall && !new RegExp(`\\b${expectedCall}\\s*\\(`).test(code)) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
         message: `Generated source for ${change.target} "${change.name}" does not call ${expectedCall}(...).`,
@@ -99,8 +126,10 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     }
 
     // The generated definition should reference its declared name. A missing name
-    // usually means the AI generated something unrelated or a bare stub.
-    if (!source.includes(change.name)) {
+    // usually means the AI generated something unrelated or a bare stub. The name
+    // may appear as an identifier or as the definition's `name:` literal, so this
+    // check runs on the comments-stripped (string-preserving) source.
+    if (!noComments.includes(change.name)) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
         message: `Generated source for ${change.target} "${change.name}" does not reference its declared name "${change.name}".`,
@@ -108,8 +137,14 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
       });
     }
 
-    // Definitions need the define* helpers, which come from @linchkit/core.
-    if (!source.includes(CORE_IMPORT)) {
+    // Definitions need the define* helpers, which come from @linchkit/core. Match
+    // a real import/export-from or require() statement (not a bare mention) so a
+    // comment or unrelated string can't satisfy it. `[^;]*?` allows multi-line
+    // import clauses bounded by the statement terminator.
+    const importsCore =
+      new RegExp(`(?:import|export)\\b[^;]*?from\\s*["'\`]${CORE_IMPORT}["'\`]`).test(noComments) ||
+      new RegExp(`require\\(\\s*["'\`]${CORE_IMPORT}["'\`]\\s*\\)`).test(noComments);
+    if (!importsCore) {
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
         message: `Generated source for ${change.target} "${change.name}" does not import from "${CORE_IMPORT}".`,

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -196,23 +196,44 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     const noComments = stripComments(source);
 
     const contract = CONTRACT_BY_TARGET[change.target];
-    if (contract && !contract.re.test(code)) {
-      findings.push({
-        code: "GENERATED_SOURCE_CONTRACT",
-        message: `Generated source for ${change.target} "${change.name}" does not call ${contract.call}(...).`,
-        target: change.name,
-      });
-    }
-
-    // The generated definition should reference its declared name. A missing name
-    // usually means the AI generated something unrelated or a bare stub. The name
-    // may appear as an identifier or as the definition's `name:` literal, so this
-    // check runs on the comments-stripped (string-preserving) source. Match on a
-    // word boundary so a different name that merely CONTAINS the declared one
-    // (e.g. `do_thing_v2` for `do_thing`) does not satisfy it — `_` is a word
-    // char, so `\bdo_thing\b` won't match inside `do_thing_v2`.
-    const nameRef = new RegExp(`\\b${escapeRegExp(change.name)}\\b`);
-    if (!nameRef.test(noComments)) {
+    const escName = escapeRegExp(change.name);
+    if (contract) {
+      // The define call must be TIED to the declared name (not just present
+      // somewhere alongside the name). Two accepted, REAL-code forms:
+      //   1. `const|let|var <name> = defineAction(`  — binding id == declared name.
+      //      The identifier survives in `code` (strings/comments blanked), so this
+      //      is robust against name-in-string fakes.
+      //   2. `defineAction({ … name: "<name>" … })`  — a real call (keyword in
+      //      code) whose options object names the declared action. The `name:`
+      //      literal lives in a string, so we scan `noComments` (strings kept) but
+      //      confirm the `defineAction` keyword sits in real code via index check.
+      const callName = escapeRegExp(contract.call);
+      const boundByConst = new RegExp(
+        `\\b(?:const|let|var)\\s+${escName}\\s*=\\s*${callName}\\s*\\(`,
+      ).test(code);
+      let boundByName = false;
+      if (!boundByConst) {
+        const callRe = new RegExp(
+          `\\b${callName}\\s*\\(\\s*\\{[\\s\\S]*?\\bname\\s*:\\s*["'\`]${escName}["'\`]`,
+          "g",
+        );
+        for (const m of noComments.matchAll(callRe)) {
+          if (m.index !== undefined && /\S/.test(code[m.index] ?? "")) {
+            boundByName = true;
+            break;
+          }
+        }
+      }
+      if (!boundByConst && !boundByName) {
+        findings.push({
+          code: "GENERATED_SOURCE_CONTRACT",
+          message: `Generated source for ${change.target} "${change.name}" does not define ${contract.call}(...) for "${change.name}".`,
+          target: change.name,
+        });
+      }
+    } else if (!new RegExp(`\\b${escName}\\b`).test(noComments)) {
+      // No known define-call contract for this target (defensive — materialized
+      // changes are `action` today). Fall back to a name-reference check.
       findings.push({
         code: "GENERATED_SOURCE_CONTRACT",
         message: `Generated source for ${change.target} "${change.name}" does not reference its declared name "${change.name}".`,

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -63,12 +63,11 @@ const CONTRACT_BY_TARGET: Partial<Record<ProposalChangeTarget, string>> = {
 // Pre-compiled core-import detectors (recreating per change/iteration is wasteful).
 // `@linchkit/core` contains no regex metacharacters, so these literals are exact.
 // `[^;]*?` allows a multi-line import clause bounded by the statement terminator.
-// Only `import` (not `export … from`) is accepted: a re-export creates NO local
-// binding, so `defineAction(...)` would have nothing to call. Global so callers
-// can `matchAll` and verify each match's `import` keyword is real code (not text
-// inside a string literal) via index cross-reference against the blanked view.
+// Fallback (no known helper): any real `import … from "@linchkit/core"`. Only
+// `import` (not `export … from`) — a re-export creates NO local binding. Global so
+// callers can `matchAll` and verify each match's `import` keyword is real code
+// (not text inside a string literal) via index cross-reference vs the blanked view.
 const IMPORT_CORE_RE = /\bimport\b[^;]*?from\s*["'`]@linchkit\/core["'`]/g;
-const REQUIRE_CORE_RE = /\brequire\(\s*["'`]@linchkit\/core["'`]\s*\)/g;
 
 // ── Comment / string stripping ───────────────────────────
 // The contract checks must not be satisfiable by a token that appears only in a
@@ -250,8 +249,10 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     };
     // When the target has a known helper (e.g. `defineAction`), require THAT helper
     // in the import clause — `import { defineEntity } from core` must not satisfy a
-    // `defineAction` contract. `require("@linchkit/core")` (destructured) is also
-    // accepted. Without a contract, fall back to any real core import.
+    // `defineAction` contract. Without a contract, fall back to any real core
+    // import. Generated definition source is ESM (the materializer prompts for
+    // `import … from "@linchkit/core"`), so CommonJS `require` is intentionally
+    // not accepted — a require-based file simply gets an (advisory) import warning.
     const helper = contract;
     const importRe = helper
       ? new RegExp(
@@ -259,7 +260,7 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
           "g",
         )
       : IMPORT_CORE_RE;
-    const importsCore = importIsReal(importRe) || importIsReal(REQUIRE_CORE_RE);
+    const importsCore = importIsReal(importRe);
     if (!importsCore) {
       const what = helper ? `${helper} from "${CORE_IMPORT}"` : `from "${CORE_IMPORT}"`;
       findings.push({

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -253,10 +253,15 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     // import. Generated definition source is ESM (the materializer prompts for
     // `import … from "@linchkit/core"`), so CommonJS `require` is intentionally
     // not accepted — a require-based file simply gets an (advisory) import warning.
+    // `(?!\s+type\b)` rejects a type-only `import type { … }` (erased at runtime);
+    // `(?!\s+as\b)` after the helper rejects `{ defineAction as da }` (aliased away,
+    // so no local `defineAction` value binding). Deeper shapes (inline `{ type x }`,
+    // namespace `import * as core`) fall through to an advisory warning — the
+    // graduation PR's CI typecheck is the authoritative gate for those.
     const helper = contract;
     const importRe = helper
       ? new RegExp(
-          `\\bimport\\b[^;]*?\\b${escapeRegExp(helper)}\\b[^;]*?from\\s*["'\`]@linchkit\\/core["'\`]`,
+          `\\bimport\\b(?!\\s+type\\b)[^;]*?\\b${escapeRegExp(helper)}\\b(?!\\s+as\\b)[^;]*?from\\s*["'\`]@linchkit\\/core["'\`]`,
           "g",
         )
       : IMPORT_CORE_RE;

--- a/packages/core/src/exports/server/engines.ts
+++ b/packages/core/src/exports/server/engines.ts
@@ -178,3 +178,7 @@ export {
   type ValidatePhase3Options,
   validatePhase3,
 } from "../../engine/validation-phase3";
+export {
+  type ValidatePhase4Options,
+  validatePhase4,
+} from "../../engine/validation-phase4";


### PR DESCRIPTION
## What

**Validation Phase 4 — generated-source CONTRACT check (G5).** Replaces the
skipped Phase 4 stub with `validatePhase4`: a static, **execution-free** check
that any AI-materialized `generatedSource` (from the #495 materializer) actually
defines the change's declared target/name — the right `define*()` call, a
reference to its name, and an import from `@linchkit/core`. It catches a class of
AI errors that pass the Phase 2 syntax gate yet are wrong (empty scaffold, wrong
target, mismatched name) before a human reviews the candidate.

- Warn-only by default; `ValidationContext.strictGeneratedContract` escalates to
  block. All-declarative proposals (no `generatedSource`) stay `"skipped"`.
- Wired into `validateProposal` (was the M1 skip stub); exported from
  `@linchkit/core/server` (+ barrel-surface test).
- `action` is the only materializable target today (matches the materializer's
  `MATERIALIZABLE_TARGETS`); the map is extensible.

## Safety

EXECUTION-FREE by design ("AI never modifies production directly"): it never
`eval`s, `import`s, transpiles-and-runs, or otherwise executes the generated
source — only static string/structural heuristics. A true execution-based
dry-run (running a generated handler against sample/historical data) requires a
locked-down sandbox to run untrusted AI code and is **intentionally out of
scope** here — deferred to a separate, sandbox-gated step.

## Review

3 rounds of codex review converged to clean. Hardenings applied along the way:
- Tokens appearing only in a comment (`// defineAction(`) or string literal no
  longer satisfy the call/import checks (strip comments, and strings for the
  call check; match real import/call structure via anchored regexes).
- The name check uses a word-boundary match so a different name that merely
  CONTAINS the declared one (`do_thing_v2` for `do_thing`) no longer passes.

## Verification
- `bun run check` / `bun run typecheck` — clean
- `bun run test` — PASS (8 Phase 4 unit tests incl. comment/string and
  substring-name hardening; barrel surface test; packages/core 4170 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Phase 4 validation to verify AI-generated source code properly imports from the core library and references declared definitions by name.
  * Validation is warn-only by default but can be enforced strictly via configuration.

* **Tests**
  * Added comprehensive test suite for generated source code contract validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->