### PR TITLE
docs(spec55): document G5 materialization + gated real-GLM smoke test

### DIFF
--- a/addons/ai-provider/cap-ai-provider/__tests__/materialize-e2e.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/materialize-e2e.test.ts
@@ -1,0 +1,117 @@
+/**
+ * E2E smoke test for G5 code materialization — real model call.
+ *
+ * Exercises the full live materialize path with a REAL AI provider:
+ *   createAIService → createCodeGenerationProvider → materializeProposalChanges
+ *   → Phase-2 syntax gate.
+ * It proves the configured provider actually returns USABLE source (not just
+ * syntactically valid in unit fakes).
+ *
+ * GATED: requires VOLCENGINE_API_KEY. Without it the suite is skipped, so CI
+ * (no key) never calls a real model. Run:
+ *   VOLCENGINE_API_KEY=sk-xxx bun test addons/ai-provider/cap-ai-provider/__tests__/materialize-e2e.test.ts
+ *
+ * Mirrors `ai-service-e2e.test.ts`: a Volcengine subscription/auth/billing
+ * failure SKIPS (returns early) rather than failing, so an expired key doesn't
+ * turn this into a red build.
+ */
+import { describe, expect, it } from "bun:test";
+import type { AIServiceConfig, ProposalDefinition } from "@linchkit/core";
+import { createSyntaxQualityGate, materializeProposalChanges } from "@linchkit/core/server";
+import { createAIService } from "../src/ai-service";
+import { createCodeGenerationProvider } from "../src/code-generation-provider";
+
+const apiKey = process.env.VOLCENGINE_API_KEY;
+
+const config: AIServiceConfig = {
+  defaultProvider: "volcengine",
+  providers: {
+    volcengine: {
+      type: "openai",
+      apiKey,
+      endpoint: "https://ark.cn-beijing.volces.com/api/coding/v3",
+      defaultModel: "ark-code-latest",
+    },
+  },
+};
+
+/** True if the error is a Volcengine subscription/auth/billing failure → skip. */
+function isSubscriptionError(err: unknown): boolean {
+  const messages: string[] = [];
+  let current: unknown = err;
+  for (let i = 0; i < 3 && current != null; i++) {
+    if (current instanceof Error) {
+      messages.push(current.message);
+      const code = (current as { code?: unknown }).code;
+      if (code != null) messages.push(String(code));
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      messages.push(String(current));
+      break;
+    }
+  }
+  return /subscription|coding plan|\b(unauthorized|forbidden)\b|\b40[13]\b|payment required|billing/i.test(
+    messages.join(" | "),
+  );
+}
+
+async function runWithSubscriptionSkip<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isSubscriptionError(err)) {
+      console.warn("[e2e] skipped: Volcengine subscription/auth error");
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+function makeDraft(): ProposalDefinition {
+  const now = new Date();
+  return {
+    id: "prop-e2e-materialize",
+    title: "Add deduct_inventory action",
+    description:
+      "When a purchase order is approved, deduct the ordered quantity from the " +
+      "product's inventory. Implement the handler fully.",
+    author: { type: "ai", id: "pattern-detector", name: "Pattern Detector" },
+    capability: "cap-demo",
+    changeType: "minor",
+    changes: [{ target: "action", operation: "create", name: "deduct_inventory" }],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: ["deduct_inventory"],
+      rulesAffected: [],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+  } as ProposalDefinition;
+}
+
+describe.skipIf(!apiKey)("G5 materialize E2E — Volcengine", () => {
+  const ai = createAIService(config);
+  const provider = createCodeGenerationProvider(ai);
+
+  it("generates syntactically-valid candidate source for an action change", async () => {
+    const result = await runWithSubscriptionSkip(() =>
+      materializeProposalChanges({
+        proposal: makeDraft(),
+        provider,
+        qualityGate: createSyntaxQualityGate(),
+        maxRetries: 3,
+      }),
+    );
+    if (!result) return; // subscription/auth skip
+
+    expect(result.allMaterialized).toBe(true);
+    expect(result.outcomes[0]?.status).toBe("materialized");
+    const source = result.proposal.changes[0]?.generatedSource;
+    expect(typeof source).toBe("string");
+    expect((source ?? "").trim().length).toBeGreaterThan(0);
+    // Passed the syntax gate (allMaterialized), so it's at least buildable TS.
+  }, 60_000);
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/materialize-e2e.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/materialize-e2e.test.ts
@@ -46,7 +46,21 @@ function isSubscriptionError(err: unknown): boolean {
       if (code != null) messages.push(String(code));
       current = (current as { cause?: unknown }).cause;
     } else {
-      messages.push(String(current));
+      // A non-Error throw (e.g. a plain `{ error, status }` object) — stringify it
+      // so its fields are searchable. `String({})` is "[object Object]", which the
+      // regex can't match, so JSON-serialize objects; fall back to String() for
+      // primitives / circular structures.
+      let text: string;
+      if (typeof current === "object") {
+        try {
+          text = JSON.stringify(current);
+        } catch {
+          text = String(current);
+        }
+      } else {
+        text = String(current);
+      }
+      messages.push(text);
       break;
     }
   }

--- a/docs/specs/55_evolution_system.md
+++ b/docs/specs/55_evolution_system.md
@@ -543,7 +543,60 @@ Proposal 验证通过 + successMetric 达标
 
 **半自动毕业**：当某个 Layer 2 覆写被多个租户/用户独立采用时，系统可以建议将其毕业为 Layer 0 的默认值——"这个调整已经被80%的用户采用，要不要变成系统默认？"
 
-### 7.7 反馈回路
+> **声明式产出 vs 逻辑产出**：上表的产出大多是**声明式**的（实体/规则/视图/状态/事件/覆写），确定性序列化即可生成完整 TS。唯一的例外是 Action 的 `handler` 函数体——它是真正的逻辑，无法序列化，确定性路径只能产出脚手架壳。这部分逻辑由 §7.7 的代码物化（Materialization）填充，而非留空 stub。
+
+### 7.7 代码物化（Materialization）：从声明到逻辑（G5）
+
+#### 问题
+
+§7.6 的毕业把声明式 `ChangeDefinition` 序列化为 TS 文件——对实体、规则、视图等**声明式**产出完全够用。但 `ActionDefinition.handler` 是真正的**函数体（逻辑）**，无法被声明式描述：确定性序列化只能产出一个脚手架壳，写不出逻辑。这是"声明 → 代码"路径上最后一段不可序列化的缺口。
+
+#### 方案（G5）
+
+AI 只为**不可声明化的代码部分**生成候选 TypeScript 源码。当前唯一可物化的目标是 `action`——Event 是声明式的 name + payload，`defineFlow` API 尚不存在。三段流水线：
+
+```
+CodeGenerationProvider（生成）→ materializeProposalChanges（编排+质量门）→ Phase 2 构建门（语法校验）
+                                          ↓
+                          候选源码挂到 ProposalChange.generatedSource
+                                          ↓
+                          毕业时 ProposalFileWriter 原样写入（优先于脚手架）
+```
+
+- **CodeGenerationProvider** — `@linchkit/cap-ai-provider` 的 `createCodeGenerationProvider`，跑在配置的 AI provider 上（本仓库为 GLM）。
+- **物化器 `materializeProposalChanges`** — `@linchkit/core`。每个可物化 change：生成 → 去 markdown 代码围栏（`stripCodeFence`，容忍裸源码 / 围栏 / 围栏外夹带散文三种形态）→ 质量门校验 → 失败时把错误反馈喂回下一次重试（默认 `maxRetries` 3 次）。把候选源码挂到 `ProposalChange.generatedSource`，**返回输入的 COPY**，绝不写文件 / 运行代码 / 提交 / 审批 / 毕业。
+- **构建门（Phase 2）`checkSourceSyntax` / `validatePhase2`** — 用 Bun 的转译器做**语法级**校验，不做项目级类型解析（避免对项目内符号引用产生误报；完整类型检查留给毕业 PR 的 CI）。默认 warn-only；`features.strictGeneratedBuild` 为真时升级为阻断（findings → errors）。空白 / 纯空格源码本身就是一条 finding。
+- **毕业消费** — `ProposalFileWriter` 在 change 携带非空 `generatedSource` 时**原样写入**（优先于确定性脚手架）；空白源码视为缺失，回退脚手架生成，绝不写空文件。
+
+#### 实时入口（live）
+
+- `POST /api/proposals/:id/materialize`（`cap-adapter-server`）——按需触发物化。
+- 审查页 `/admin/proposals` 的 **"Materialize code"** 按钮 + 只读候选源码查看器。
+
+#### 元模型目标可否物化
+
+| 元模型目标 | 可否物化 | 说明 |
+|-----------|---------|------|
+| `action` | ✅ 是 | `handler` 是函数体逻辑，AI 物化候选源码 |
+| `entity` | 声明式序列化 | 字段 / 配置可确定性序列化 |
+| `rule` | 声明式序列化 | `defineRule()` 条件 + 效果可序列化 |
+| `view` | 声明式序列化 | `defineView()` 配置可序列化 |
+| `state` | 声明式序列化 | 状态机定义可序列化 |
+| `event` | 声明式序列化 | EventDefinition = name + payload，无逻辑 |
+| `overlay` | 声明式序列化 | 运行时覆写可序列化 |
+| `flow` | 暂无 | `defineFlow` API 尚不存在，目标落地后再纳入 |
+
+#### 安全边界
+
+与 §7.6 及全局原则"AI 绝不直接改生产"一致：
+
+- **仅 draft 可物化**：非 draft 的 Proposal → 422，不产生任何副作用。
+- **CommandLayer 权限槽永远先跑、绝不跳过**：在任何 provider 构建之前执行；命令层或 AI provider 未配置 → 503 优雅降级（而不是去调一个会抛"未配置"的 provider）。
+- **仅产出候选源码**，挂在 draft 上；绝不 submit / approve / commit / graduate / 写文件 / 运行生成代码。
+- **候选仍须经验证（Phase 2 构建门）+ 双重人审**（draft 审查 + 毕业 PR）才可能落地。
+- **仅按需触发（on-demand）**，无调度器 / cron——自动节奏（cadence）是被搁置的产品决策。
+
+### 7.8 反馈回路
 
 用户对 Proposal 的接受/拒绝/效果，反馈回 Memory 层：
 

--- a/docs/specs/55_evolution_system.md
+++ b/docs/specs/55_evolution_system.md
@@ -555,7 +555,7 @@ Proposal 验证通过 + successMetric 达标
 
 AI 只为**不可声明化的代码部分**生成候选 TypeScript 源码。当前唯一可物化的目标是 `action`——Event 是声明式的 name + payload，`defineFlow` API 尚不存在。三段流水线：
 
-```
+```text
 CodeGenerationProvider（生成）→ materializeProposalChanges（编排+质量门）→ Phase 2 构建门（语法校验）
                                           ↓
                           候选源码挂到 ProposalChange.generatedSource
@@ -563,9 +563,10 @@ CodeGenerationProvider（生成）→ materializeProposalChanges（编排+质量
                           毕业时 ProposalFileWriter 原样写入（优先于脚手架）
 ```
 
-- **CodeGenerationProvider** — `@linchkit/cap-ai-provider` 的 `createCodeGenerationProvider`，跑在配置的 AI provider 上（本仓库为 GLM）。
+- **CodeGenerationProvider** — `@linchkit/cap-ai-provider` 的 `createCodeGenerationProvider`，跑在由 `linchkit.config` 的 `ai` 配置决定的 AI provider 上。
 - **物化器 `materializeProposalChanges`** — `@linchkit/core`。每个可物化 change：生成 → 去 markdown 代码围栏（`stripCodeFence`，容忍裸源码 / 围栏 / 围栏外夹带散文三种形态）→ 质量门校验 → 失败时把错误反馈喂回下一次重试（默认 `maxRetries` 3 次）。把候选源码挂到 `ProposalChange.generatedSource`，**返回输入的 COPY**，绝不写文件 / 运行代码 / 提交 / 审批 / 毕业。
 - **构建门（Phase 2）`checkSourceSyntax` / `validatePhase2`** — 用 Bun 的转译器做**语法级**校验，不做项目级类型解析（避免对项目内符号引用产生误报；完整类型检查留给毕业 PR 的 CI）。默认 warn-only；`features.strictGeneratedBuild` 为真时升级为阻断（findings → errors）。空白 / 纯空格源码本身就是一条 finding。
+- **契约门（Phase 4）`validatePhase4`** — 执行无关的静态校验：确认生成源码确实定义了 change 声称的目标 / 名字（正确的 `define*()` 调用、其 options `name:` 与声明名一致、从 `@linchkit/core` 导入对应 helper）。默认 warn-only；`strictGeneratedContract` 升级为阻断。**绝不执行 AI 生成代码**——真正的执行式 dry-run（沙箱跑 handler）刻意留空。
 - **毕业消费** — `ProposalFileWriter` 在 change 携带非空 `generatedSource` 时**原样写入**（优先于确定性脚手架）；空白源码视为缺失，回退脚手架生成，绝不写空文件。
 
 #### 实时入口（live）
@@ -593,7 +594,7 @@ CodeGenerationProvider（生成）→ materializeProposalChanges（编排+质量
 - **仅 draft 可物化**：非 draft 的 Proposal → 422，不产生任何副作用。
 - **CommandLayer 权限槽永远先跑、绝不跳过**：在任何 provider 构建之前执行；命令层或 AI provider 未配置 → 503 优雅降级（而不是去调一个会抛"未配置"的 provider）。
 - **仅产出候选源码**，挂在 draft 上；绝不 submit / approve / commit / graduate / 写文件 / 运行生成代码。
-- **候选仍须经验证（Phase 2 构建门）+ 双重人审**（draft 审查 + 毕业 PR）才可能落地。
+- **候选仍须经验证（Phase 2 构建门 + Phase 4 契约门）+ 双重人审**（draft 审查 + 毕业 PR）才可能落地。
 - **仅按需触发（on-demand）**，无调度器 / cron——自动节奏（cadence）是被搁置的产品决策。
 
 ### 7.8 反馈回路

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -38,7 +38,7 @@ Five-layer evolution model (Sense → Memory → Awareness → Insight → Propo
 
 | # | Title | Summary | Milestone | Status |
 |---|-------|---------|-----------|--------|
-| [55](./55_evolution_system.md) | Evolution System | Living software: sensors, baselines, importance graph, evidence-chain insights, gradual Proposals | M3–M6+ | Partial |
+| [55](./55_evolution_system.md) | Evolution System | Living software: sensors, baselines, importance graph, evidence-chain insights, gradual Proposals. §7.7 G5 code materialization implemented (CodeGenerationProvider + materializeProposalChanges + Phase-2 build gate + Phase-4 contract check + live `POST /api/proposals/:id/materialize`); sensing/cadence still gated | M3–M6+ | Partial |
 
 ## Runtime Engines
 
@@ -211,6 +211,7 @@ Capability definition, extension, composition, and distribution.
 
 | Date | Change |
 |------|--------|
+| 2026-06-07 | Spec 55 §7.7 代码物化 added — G5 materialization (provider #494, materializer+build-gate #495, live endpoint+UI #496) documented; old §7.7 反馈回路 renumbered to §7.8. |
 | 2026-06-01 | Spec 45 progress: `schedule` trigger implemented (croner, PR #439) + `_linchkit.watcher_state` debounce persistence (`WatcherStateStore` InMemory default + Drizzle PG backend) — restart-safe `once_until_reset`. Status stays Partial: the watcher admin UI `EntityDefinition` (§7.1) is still deferred. |
 | 2026-06-01 | Spec 63 Phase 2 shipped: GraphQL field-lock introspection (PR #437) + auto-form field-lock UI reusing core's `matchesLockCondition` (PR #441). Status stays Partial — Phase 3 `cap-lock` needs a returning-value hook/slot extension mechanism (design decision) before it can be built. |
 | 2026-06-01 | Spec 56 Step 2c complete: removed the dead 0-byte `automation-engine`/`automation-registry` stubs from core (PR #436); the Detector/Watcher implementations already live in cap-ai-provider. |


### PR DESCRIPTION
## What

**Consolidation of the shipped G5 capability** (the user-chosen "巩固收尾" step).

### Spec 55 — `§7.7 代码物化（Materialization）`
Documents the now-shipped G5 pipeline: the gap (an action `handler` body can't be
serialized declaratively), the 3 stages (`createCodeGenerationProvider` →
`materializeProposalChanges` → Phase-2 build gate; graduation consumes
`generatedSource`), the live `POST /api/proposals/:id/materialize` endpoint +
`/admin/proposals` review UI, a meta-model materializability table, and the safety
boundary (draft-only / CommandLayer / candidate-only / double human review /
no scheduler). Old `§7.7 反馈回路` renumbered to `§7.8` (no numbering gap). INDEX
row + change-log updated.

### Real-GLM smoke test (gated)
`materialize-e2e.test.ts` exercises the live path end-to-end against the REAL
provider: `createAIService → createCodeGenerationProvider →
materializeProposalChanges → syntax gate`. Gated `describe.skipIf(!VOLCENGINE_API_KEY)`
with a subscription/auth-error skip, so CI (no key) skips it — it proves the
configured provider returns usable source, beyond unit fakes.

## Review

Codex review (`origin/main..HEAD`): clean. (`origin/main` was merged into the
branch to refresh its base after #497 landed — the doc/code now agree that Phase 4
is implemented.)

## Verification
- `bun run check` / `bun run typecheck` — clean
- `bun run test` — PASS (smoke test SKIPS without the key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end smoke test for code materialization with live provider integration.

* **Documentation**
  * Documented code materialization feature with new `POST /api/proposals/:id/materialize` endpoint for on-demand conversion of proposals into executable TypeScript.
  * Defined three-stage validation pipeline with syntax quality gates and safety boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->