### PR TITLE
feat(core,adapter): attach proposal pre-analysis to governance drafts (Spec 55 §7.3)

### DIFF
--- a/.changeset/attach-proposal-analysis.md
+++ b/.changeset/attach-proposal-analysis.md
@@ -1,0 +1,31 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": patch
+---
+
+Surface the evolution pipeline's per-proposal pre-analysis to human reviewers
+(Spec 55 §7.3).
+
+The evolution cycle generates a pre-analysis envelope (dedup / conflict / impact
+/ backtest) for every proposal it surfaces (`EvolutionCycleResult.proposalAnalyses`),
+but it was DROPPED when those proposals were persisted as governance drafts — so
+the reviewer never saw the "why" (evidence / estimated impact / backtest delta /
+rationale) behind an AI-surfaced change. This change closes that seam, additively:
+
+- `ProposalDefinition` gains an OPTIONAL `analysis?: ProposalPreAnalysisResult`
+  field carrying the read-only pre-analysis. Reuses the existing
+  `ProposalPreAnalysisResult` type — no parallel shape.
+- `CreateProposalOptions` gains a matching OPTIONAL `analysis` that
+  `ProposalEngine.createProposal` stores verbatim onto the draft.
+- `persistCycleProposalsAsDrafts` accepts the cycle's `proposalAnalyses` and
+  attaches each envelope to its draft, keyed by `proposalId` (the source cycle
+  proposal's id). Omitted when absent or unmatched — never fabricated.
+- The on-demand `POST /api/evolution/run-cycle` route and the evolution cadence
+  wiring forward `proposalAnalyses` so the metadata is attached live.
+- The proposal read endpoints (`GET /api/proposals`, `GET /api/proposals/:id`)
+  serialize the new `analysis` field for the review UI.
+
+Strictly additive and read-only: this metadata never affects dedup, validation,
+approval, or graduation. Drafts still land in `draft` status and the human
+approval gate is unchanged — only strengthened by giving the reviewer the
+evidence behind the proposal.

--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-serialize.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-serialize.test.ts
@@ -64,9 +64,15 @@ describe("serializeProposal", () => {
     const serialized = serializeProposal(makeProposal({ analysis }));
 
     expect(serialized.analysis).toBeDefined();
-    const out = serialized.analysis as ProposalPreAnalysisResult;
+    const out = serialized.analysis as Record<string, unknown>;
     expect(out.proposalId).toBe("prop-1");
-    expect(out.stages.impact?.data?.affectedRecordCount).toBe(42);
+    expect(
+      (out.stages as ProposalPreAnalysisResult["stages"]).impact?.data?.affectedRecordCount,
+    ).toBe(42);
+    // analyzedAt (the only Date field) must be an ISO string, consistent with
+    // the rest of the serialized payload — not a raw Date object.
+    expect(typeof out.analyzedAt).toBe("string");
+    expect(out.analyzedAt).toBe(analysis.analyzedAt.toISOString());
   });
 
   test("omits analysis (undefined) when the proposal has none", () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-serialize.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-serialize.test.ts
@@ -1,0 +1,76 @@
+/**
+ * serializeProposal — JSON serialization for the proposal read endpoints.
+ *
+ * Asserts that the per-proposal pre-analysis (`ProposalDefinition.analysis`,
+ * Spec 55 §7.3) surfaces in the serialized output so the review UI can show the
+ * evidence/impact/backtest rationale behind an AI-surfaced proposal, and that it
+ * is absent (undefined) for proposals created without a pre-analysis.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ProposalDefinition, ProposalPreAnalysisResult } from "@linchkit/core";
+import { serializeProposal } from "../src/proposal-api";
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+function makeProposal(overrides: Partial<ProposalDefinition> = {}): ProposalDefinition {
+  const now = new Date();
+  return {
+    id: "prop-1",
+    title: "Add default for order.currency",
+    description: "Detected USD in 95% of records",
+    author: { type: "ai", id: "insight-translator", name: "Insight Translator" },
+    capability: "order",
+    changeType: "minor",
+    changes: [
+      { target: "rule", operation: "create", name: "order_currency_default", diff: "set USD" },
+    ],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: ["order_currency_default"],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeAnalysis(): ProposalPreAnalysisResult {
+  return {
+    proposalId: "prop-1",
+    analyzedAt: new Date(),
+    stages: {
+      impact: {
+        stage: "impact",
+        status: "ok",
+        data: { affectedRecordCount: 42, sampleRecordIds: ["r1"], probedEntities: ["order"] },
+        durationMs: 2,
+      },
+    },
+    allStagesSucceeded: true,
+    totalDurationMs: 2,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("serializeProposal", () => {
+  test("includes the analysis field when present", () => {
+    const analysis = makeAnalysis();
+    const serialized = serializeProposal(makeProposal({ analysis }));
+
+    expect(serialized.analysis).toBeDefined();
+    const out = serialized.analysis as ProposalPreAnalysisResult;
+    expect(out.proposalId).toBe("prop-1");
+    expect(out.stages.impact?.data?.affectedRecordCount).toBe(42);
+  });
+
+  test("omits analysis (undefined) when the proposal has none", () => {
+    const serialized = serializeProposal(makeProposal());
+    expect(serialized.analysis).toBeUndefined();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/evolution-scheduler-wiring.ts
+++ b/addons/adapter-server/cap-adapter-server/src/evolution-scheduler-wiring.ts
@@ -126,7 +126,10 @@ export function createEvolutionCadence(
           // Defensive: a runtime whose cycle returns null/undefined (or omits
           // `proposals`) yields an empty batch rather than throwing a TypeError.
           const proposals = result?.proposals ?? [];
-          const summary = persistCycleProposalsAsDrafts({ proposals, engine });
+          // Forward the per-proposal pre-analysis so each created draft carries
+          // its evidence/impact/backtest rationale for the human reviewer.
+          const proposalAnalyses = result?.proposalAnalyses ?? [];
+          const summary = persistCycleProposalsAsDrafts({ proposals, proposalAnalyses, engine });
           logger.info(
             `[EvolutionCadence] tenant=${tenantId ?? "(default)"} → ${summary.created} new draft(s), ` +
               `${summary.deduped} deduped (DRAFT-only; approval and graduation stay human-gated).`,

--- a/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
@@ -416,7 +416,10 @@ export function serializeProposal(p: ProposalDefinition): Record<string, unknown
     rejectionReason: p.rejectionReason,
     // Per-proposal pre-analysis (Spec 55 §7.3) — read-only evidence/impact/
     // backtest rationale surfaced to the human reviewer. Undefined for proposals
-    // created without a pre-analysis (e.g. manual drafts).
-    analysis: p.analysis,
+    // created without a pre-analysis (e.g. manual drafts). Serialize its only
+    // Date field (analyzedAt) to ISO for consistency with the rest of the payload.
+    analysis: p.analysis
+      ? { ...p.analysis, analyzedAt: p.analysis.analyzedAt.toISOString() }
+      : undefined,
   };
 }

--- a/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
@@ -414,5 +414,9 @@ export function serializeProposal(p: ProposalDefinition): Record<string, unknown
     deployedAt: p.deployedAt?.toISOString(),
     approvedBy: p.approvedBy,
     rejectionReason: p.rejectionReason,
+    // Per-proposal pre-analysis (Spec 55 §7.3) — read-only evidence/impact/
+    // backtest rationale surfaced to the human reviewer. Undefined for proposals
+    // created without a pre-analysis (e.g. manual drafts).
+    analysis: p.analysis,
   };
 }

--- a/addons/adapter-server/cap-adapter-server/src/routes/evolution-cycle-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/evolution-cycle-api.ts
@@ -150,8 +150,11 @@ export function mountEvolutionCycleRoutes(app: Elysia, options: ServerOptions): 
       // Persist each cycle proposal as a `draft` in the shared governance
       // engine, deduped against the already-pending set. NEVER submitted /
       // approved here — the helper only calls createProposal (draft status).
+      // The per-proposal pre-analysis is forwarded so each draft carries its
+      // evidence/impact/backtest rationale for the human reviewer (read-only).
       const summary = persistCycleProposalsAsDrafts({
         proposals: result.proposals,
+        proposalAnalyses: result.proposalAnalyses,
         engine: getSharedProposalEngine(),
       });
       const response: RunCycleResponse = {

--- a/packages/core/src/__tests__/engine/evolution-cycle-drafts.test.ts
+++ b/packages/core/src/__tests__/engine/evolution-cycle-drafts.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, test } from "bun:test";
 import { persistCycleProposalsAsDrafts } from "../../engine/evolution-cycle-drafts";
 import { createProposalEngine } from "../../engine/proposal-engine";
+import type { ProposalPreAnalysisResult } from "../../life-system/proposal-preanalysis/types";
 import type { ProposalDefinition } from "../../types/proposal";
 
 // ── Fixtures ──────────────────────────────────────────────
@@ -46,6 +47,31 @@ function cycleProposal(overrides?: Partial<ProposalDefinition>): ProposalDefinit
     createdAt: now,
     updatedAt: now,
     ...overrides,
+  };
+}
+
+/**
+ * Build a pre-analysis envelope (`EvolutionCycleResult.proposalAnalyses[i]`)
+ * keyed to a given source proposal id.
+ */
+function preAnalysis(proposalId: string): ProposalPreAnalysisResult {
+  return {
+    proposalId,
+    analyzedAt: new Date(),
+    stages: {
+      impact: {
+        stage: "impact",
+        status: "ok",
+        data: {
+          affectedRecordCount: 42,
+          sampleRecordIds: ["r1", "r2"],
+          probedEntities: ["order"],
+        },
+        durationMs: 3,
+      },
+    },
+    allStagesSucceeded: true,
+    totalDurationMs: 3,
   };
 }
 
@@ -219,5 +245,106 @@ describe("persistCycleProposalsAsDrafts", () => {
     const result = persistCycleProposalsAsDrafts({ proposals: [cycleProposal()], engine });
     expect(result.created).toBe(0);
     expect(result.deduped).toBe(1);
+  });
+
+  test("(i) pre-analysis is attached to the created draft when supplied", () => {
+    const engine = createProposalEngine();
+    const source = cycleProposal({ id: "cycle-prop-1" });
+
+    const result = persistCycleProposalsAsDrafts({
+      proposals: [source],
+      proposalAnalyses: [preAnalysis("cycle-prop-1")],
+      engine,
+    });
+
+    expect(result.created).toBe(1);
+    const draft = engine.getProposal(result.createdIds[0] as string);
+    // The analysis envelope rode through onto the draft for the reviewer.
+    expect(draft.analysis).toBeDefined();
+    expect(draft.analysis?.proposalId).toBe("cycle-prop-1");
+    expect(draft.analysis?.stages.impact?.data?.affectedRecordCount).toBe(42);
+    // Status is unchanged — attaching analysis must not alter the gate.
+    expect(draft.status).toBe("draft");
+  });
+
+  test("(j) analysis is matched by proposalId, not array position", () => {
+    const engine = createProposalEngine();
+    const first = cycleProposal({ id: "prop-A" });
+    const second = cycleProposal({
+      id: "prop-B",
+      capability: "invoice",
+      changes: [
+        { target: "rule", operation: "create", name: "invoice_total_positive", diff: ">0" },
+      ],
+    });
+
+    // Analyses supplied in REVERSE order relative to proposals — keying by id
+    // (not index) must still route each envelope to the right draft.
+    const result = persistCycleProposalsAsDrafts({
+      proposals: [first, second],
+      proposalAnalyses: [preAnalysis("prop-B"), preAnalysis("prop-A")],
+      engine,
+    });
+
+    expect(result.created).toBe(2);
+    const drafts = result.createdIds.map((id) => engine.getProposal(id));
+    const draftA = drafts.find((d) => d.capability === "order");
+    const draftB = drafts.find((d) => d.capability === "invoice");
+    expect(draftA?.analysis?.proposalId).toBe("prop-A");
+    expect(draftB?.analysis?.proposalId).toBe("prop-B");
+  });
+
+  test("(k) draft is created without analysis when none is supplied/matches", () => {
+    const engine = createProposalEngine();
+
+    // No proposalAnalyses at all → omitted.
+    const noneResult = persistCycleProposalsAsDrafts({
+      proposals: [cycleProposal({ id: "prop-1" })],
+      engine,
+    });
+    expect(noneResult.created).toBe(1);
+    expect(engine.getProposal(noneResult.createdIds[0] as string).analysis).toBeUndefined();
+
+    // A non-matching analysis id → still omitted (no fabrication).
+    const engine2 = createProposalEngine();
+    const mismatchResult = persistCycleProposalsAsDrafts({
+      proposals: [cycleProposal({ id: "prop-2" })],
+      proposalAnalyses: [preAnalysis("some-other-id")],
+      engine: engine2,
+    });
+    expect(mismatchResult.created).toBe(1);
+    expect(engine2.getProposal(mismatchResult.createdIds[0] as string).analysis).toBeUndefined();
+  });
+
+  test("(l) ProposalEngine.createProposal round-trips the analysis field", () => {
+    const engine = createProposalEngine();
+    const analysis = preAnalysis("direct-create");
+
+    const draft = engine.createProposal({
+      title: "direct",
+      description: "direct create with analysis",
+      author: { type: "ai", id: "x", name: "x" },
+      capability: "order",
+      changeType: "minor",
+      changes: [{ target: "rule", operation: "create", name: "r", diff: "d" }],
+      analysis,
+    });
+
+    expect(draft.analysis).toBe(analysis);
+    expect(draft.status).toBe("draft");
+
+    // It also survives a read-back via getProposal/listProposals.
+    expect(engine.getProposal(draft.id).analysis?.proposalId).toBe("direct-create");
+
+    // Omitting analysis yields no field (backward-compatible).
+    const plain = engine.createProposal({
+      title: "plain",
+      description: "no analysis",
+      author: { type: "ai", id: "x", name: "x" },
+      capability: "order",
+      changeType: "minor",
+      changes: [{ target: "rule", operation: "create", name: "r2", diff: "d" }],
+    });
+    expect(plain.analysis).toBeUndefined();
   });
 });

--- a/packages/core/src/engine/evolution-cycle-drafts.ts
+++ b/packages/core/src/engine/evolution-cycle-drafts.ts
@@ -19,6 +19,7 @@
  *    concern (this is an on-demand bridge only).
  */
 
+import type { ProposalPreAnalysisResult } from "../life-system/proposal-preanalysis/types";
 import type { ProposalDefinition } from "../types/proposal";
 import type { CreateProposalOptions, ProposalEngine } from "./proposal-engine";
 
@@ -57,6 +58,16 @@ export interface PersistCycleDraftsOptions {
   proposals: ProposalDefinition[];
   /** Shared governance engine the review UI reads from. */
   engine: ProposalEngine;
+  /**
+   * Optional per-proposal pre-analysis envelopes for this cycle
+   * (`EvolutionCycleResult.proposalAnalyses`). Each entry is matched to its
+   * source proposal by `proposalId` (which equals the cycle proposal's `id` at
+   * analysis time) and attached to the created draft as read-only review
+   * metadata. When omitted — or when no entry matches a given proposal — the
+   * draft is created without an `analysis` field. Attaching analysis NEVER
+   * changes dedup, validation, approval, or graduation behavior.
+   */
+  proposalAnalyses?: ProposalPreAnalysisResult[];
 }
 
 /**
@@ -87,15 +98,28 @@ function dedupKey(capability: string, changeNames: string[]): string {
  * and stamps `status: "draft"` — we never copy the source id or status, so a
  * cycle proposal can only ever ENTER the pipeline as a new draft.
  *
- * Note on pre-analysis: `EvolutionCycleResult.proposalAnalyses` is intentionally
- * NOT attached here — neither `CreateProposalOptions` nor `ProposalDefinition`
- * has a slot for it, and wiring new plumbing for it is out of scope. See the
- * route/spec notes.
+ * Pre-analysis: when `options.proposalAnalyses` is supplied
+ * (`EvolutionCycleResult.proposalAnalyses`), each created draft is enriched with
+ * its matching pre-analysis envelope (dedup / conflict / impact / backtest) so a
+ * human reviewer can see the evidence behind an AI-surfaced proposal. The match
+ * is keyed on `proposalId` (which equals the source cycle proposal's `id` at
+ * analysis time). This is read-only review metadata — it never affects the
+ * draft's status, dedup, or any downstream gate.
  */
 export function persistCycleProposalsAsDrafts(
   options: PersistCycleDraftsOptions,
 ): PersistCycleDraftsResult {
-  const { proposals, engine } = options;
+  const { proposals, engine, proposalAnalyses } = options;
+
+  // Index the pre-analysis envelopes by their `proposalId` for O(1) lookup
+  // against each source cycle proposal's `id`. Built once; empty when no
+  // analyses were supplied so the attach step is a no-op.
+  const analysisById = new Map<string, ProposalPreAnalysisResult>();
+  for (const analysis of proposalAnalyses ?? []) {
+    if (analysis?.proposalId) {
+      analysisById.set(analysis.proposalId, analysis);
+    }
+  }
 
   // Snapshot the engine's currently-pending dedup keys ONCE up front. We then
   // augment this set as we create new drafts so duplicates WITHIN a single
@@ -131,6 +155,11 @@ export function persistCycleProposalsAsDrafts(
       continue;
     }
 
+    // Match this cycle proposal to its pre-analysis envelope by id (the
+    // analysis carries the source proposal's id as `proposalId`). Omitted when
+    // no analyses were supplied or none match.
+    const analysis = analysisById.get(proposal.id);
+
     const createOptions: CreateProposalOptions = {
       title: proposal.title,
       description: proposal.description,
@@ -138,6 +167,7 @@ export function persistCycleProposalsAsDrafts(
       capability: proposal.capability,
       changeType: proposal.changeType,
       changes: proposal.changes,
+      ...(analysis ? { analysis } : {}),
     };
     const draft = engine.createProposal(createOptions);
     createdIds.push(draft.id);

--- a/packages/core/src/engine/proposal-engine.ts
+++ b/packages/core/src/engine/proposal-engine.ts
@@ -12,6 +12,7 @@
  * copy-on-read semantics so callers cannot accidentally mutate stored state.
  */
 
+import type { ProposalPreAnalysisResult } from "../life-system/proposal-preanalysis/types";
 import { analyzeImpact } from "../ontology/impact-analysis";
 import type { Logger } from "../types/logger";
 import type {
@@ -41,6 +42,14 @@ export interface CreateProposalOptions {
   changeType: ChangeType;
   changes: ProposalChange[];
   impact?: Partial<ProposalImpact>;
+  /**
+   * Optional pre-analysis envelope to attach to the created draft (Spec 55 §7.3).
+   *
+   * When provided, it is stored verbatim on `ProposalDefinition.analysis` so the
+   * review UI can show the evidence/impact/backtest rationale behind the change.
+   * Read-only metadata — it never affects validation, approval, or graduation.
+   */
+  analysis?: ProposalPreAnalysisResult;
 }
 
 // ── Engine options ───────────────────────────────────────
@@ -160,6 +169,9 @@ export class ProposalEngine {
       status: "draft",
       createdAt: now,
       updatedAt: now,
+      // Attach the optional pre-analysis envelope so the review UI can surface
+      // the "why" behind the proposal. Omitted entirely when not provided.
+      ...(options.analysis ? { analysis: options.analysis } : {}),
     };
 
     this.proposals.set(proposal.id, proposal);

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -6,6 +6,7 @@
  * AI can never directly modify production — every change must be proposed and validated first.
  */
 
+import type { ProposalPreAnalysisResult } from "../life-system/proposal-preanalysis/types";
 import type { ImpactNode } from "../ontology/impact-analysis";
 import type { ActionDefinition } from "./action";
 import type { EntityDefinition } from "./entity";
@@ -268,4 +269,17 @@ export interface ProposalDefinition {
    * change merges to determine whether the outcome was achieved.
    */
   successMetric?: SuccessMetric;
+
+  /**
+   * Optional pre-analysis envelope for this proposal (Spec 55 §7.3).
+   *
+   * Carries the evolution pipeline's per-proposal pre-analysis — dedup /
+   * conflict / impact / backtest stages — so a human reviewer can see the
+   * "why" (evidence, estimated impact, backtest delta, rationale) behind an
+   * AI-surfaced proposal. This is READ-ONLY metadata attached when a cycle
+   * proposal is persisted as a draft; it never drives submission, approval,
+   * or graduation. Absent when the proposal entered the pipeline without a
+   * pre-analysis (e.g. manual drafts).
+   */
+  analysis?: ProposalPreAnalysisResult;
 }


### PR DESCRIPTION
## What

Surface the evolution pipeline's per-proposal **pre-analysis** (`proposalAnalyses`) onto persisted governance drafts, so a human reviewer sees the dedup / conflict / impact / backtest rationale behind an AI-surfaced proposal. Strengthens the approval gate (Spec 55 §7.3). Strictly **additive, read-only**.

Until now `EvolutionCycleResult.proposalAnalyses` was generated each cycle but **dropped** when proposals were persisted — `ProposalDefinition` had no slot for it.

## How

- `ProposalDefinition` gains optional `analysis?: ProposalPreAnalysisResult` (reuses the existing life-system type; type-only import).
- `CreateProposalOptions` + `ProposalEngine.createProposal` thread it through.
- `persistCycleProposalsAsDrafts` maps each cycle proposal to its analysis **by `proposalId`** (O(1) Map; omitted when absent, never fabricated).
- Wired **live** at both call sites: `POST /api/evolution/run-cycle` and the cadence tick forward `result.proposalAnalyses`.
- `proposal-api` `serializeProposal` emits the `analysis` field (field-by-field serializer — would otherwise drop it).

## Safety

Read-only review metadata. No change to submit / approve / graduate / materialize / validation behavior; drafts remain double-human-gated.

## Tests

- `evolution-cycle-drafts`: analysis attached when supplied; matched by id not array position; omitted gracefully when none/mismatch; `createProposal({ analysis })` round-trips.
- `proposal-serialize`: `analysis` appears in serialized output when present, undefined when absent.
- Full `bun run test` green; `bun run check` + `bunx tsc --noEmit` clean. codex review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
