### PR TITLE
feat(adapter-ui): render proposal pre-analysis on the review page (Spec 55 §7.3)

### DIFF
--- a/.changeset/proposal-analysis-review-ui.md
+++ b/.changeset/proposal-analysis-review-ui.md
@@ -1,0 +1,10 @@
+---
+"@linchkit/cap-adapter-ui": patch
+---
+
+Render the per-proposal pre-analysis (Spec 55 §7.3) on the human review page
+(`/admin/proposals`). The governed proposal now carries an optional `analysis`
+field (dedup / conflict / impact / backtest envelopes, surfaced by #504); the
+review card wires the existing `ProposalImpactPreview` component to it, shown as
+decision-support evidence above the approve/reject controls. Absent for manual
+drafts. Read-only — no change to the human-gated approve/graduate flow.

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview.tsx
@@ -54,9 +54,19 @@ import {
 
 // ── Component props ────────────────────────────────────────
 
+/**
+ * View shape of a pre-analysis result. `analyzedAt` may arrive as a `Date`
+ * (in-process / demo data) OR an ISO `string` (serialized over the wire from
+ * `/api/proposals`). The component normalizes it via `new Date(...)`, which
+ * accepts either; otherwise this mirrors the core `ProposalPreAnalysisResult`.
+ */
+export type ProposalPreAnalysisView = Omit<ProposalPreAnalysisResult, "analyzedAt"> & {
+  analyzedAt: string | Date;
+};
+
 export interface ProposalImpactPreviewProps {
   /** Pre-analysis result. Pass null/undefined to render an empty placeholder. */
-  result: ProposalPreAnalysisResult | null | undefined;
+  result: ProposalPreAnalysisView | null | undefined;
   /** Optional className for outer wrapper. */
   className?: string;
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-review-outcomes.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-review-outcomes.tsx
@@ -1,0 +1,211 @@
+/**
+ * Proposal review outcome renderers.
+ *
+ * Presentational components that render the result of the two human-triggered
+ * mutations on the proposal review page: graduating an approved proposal into a
+ * GitHub PR, and materializing AI-generated candidate source onto a draft.
+ *
+ * Extracted from `proposal-review.tsx` to keep that page under the file-size
+ * policy. These are purely presentational — they never trigger a mutation.
+ */
+
+import { AlertTriangleIcon, CheckCircle2Icon, ExternalLinkIcon, XCircleIcon } from "lucide-react";
+import type { useTranslation } from "react-i18next";
+import type { GraduateProposalResult, MaterializeProposalResult } from "@/lib/proposal-api";
+
+type TFn = ReturnType<typeof useTranslation>["t"];
+
+// ── Graduate outcome renderer ─────────────────────────────
+
+export function GraduateOutcome({ result, t }: { result: GraduateProposalResult; t: TFn }) {
+  switch (result.kind) {
+    case "ok":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950/30"
+          data-testid="graduate-ok"
+        >
+          <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-green-500" />
+          <div className="space-y-1">
+            <p className="text-sm text-green-700 dark:text-green-300">
+              {t("proposals.graduatePrOpened", "Pull request opened for review.")}
+            </p>
+            {result.prUrl && (
+              <a
+                href={result.prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <ExternalLinkIcon className="size-3" />
+                {t("proposals.viewPr", "View PR")}
+              </a>
+            )}
+          </div>
+        </div>
+      );
+
+    case "unavailable":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-3"
+          data-testid="graduate-unavailable"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            {result.message ?? t("proposals.graduateNotConfigured", "Graduation not configured.")}
+          </p>
+        </div>
+      );
+
+    case "denied":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="graduate-denied"
+        >
+          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {t("proposals.notAuthorized", "Not authorized.")}
+          </p>
+        </div>
+      );
+
+    case "not_approved":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="graduate-not-approved"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {result.message ?? t("proposals.notApproved", "Proposal is not approved.")}
+          </p>
+        </div>
+      );
+
+    case "not_found":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="graduate-not-found"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {t("proposals.notFound", "Proposal not found.")}
+          </p>
+        </div>
+      );
+
+    case "error":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="graduate-error"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">{result.message}</p>
+        </div>
+      );
+  }
+}
+
+// ── Materialize outcome renderer ──────────────────────────
+
+export function MaterializeOutcome({ result, t }: { result: MaterializeProposalResult; t: TFn }) {
+  switch (result.kind) {
+    case "ok": {
+      const materialized = result.outcomes.filter((o) => o.status === "materialized").length;
+      const skipped = result.outcomes.filter((o) => o.status === "skipped").length;
+      const failed = result.outcomes.filter((o) => o.status === "failed").length;
+      const ok = result.allMaterialized;
+      return (
+        <div
+          className={`flex items-start gap-2 rounded-md border p-3 ${
+            ok
+              ? "border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30"
+              : "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30"
+          }`}
+          data-testid="materialize-ok"
+        >
+          {ok ? (
+            <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-green-500" />
+          ) : (
+            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-amber-500" />
+          )}
+          <p className="text-sm">
+            {t("proposals.materializeSummary", "Generated {{m}}, skipped {{s}}, failed {{f}}.", {
+              m: materialized,
+              s: skipped,
+              f: failed,
+            })}
+          </p>
+        </div>
+      );
+    }
+
+    case "unavailable":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-3"
+          data-testid="materialize-unavailable"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            {result.message ??
+              t("proposals.materializeNotConfigured", "AI code generation is not configured.")}
+          </p>
+        </div>
+      );
+
+    case "denied":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-denied"
+        >
+          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {t("proposals.notAuthorized", "Not authorized.")}
+          </p>
+        </div>
+      );
+
+    case "not_draft":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-not-draft"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {result.message ?? t("proposals.notDraft", "Proposal is not a draft.")}
+          </p>
+        </div>
+      );
+
+    case "not_found":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-not-found"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">
+            {t("proposals.notFound", "Proposal not found.")}
+          </p>
+        </div>
+      );
+
+    case "error":
+      return (
+        <div
+          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
+          data-testid="materialize-error"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <p className="text-sm text-destructive">{result.message}</p>
+        </div>
+      );
+  }
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -70,6 +70,16 @@ export interface ProposalValidationResult {
   impactSummary: string;
 }
 
+/**
+ * Wire shape of the per-proposal pre-analysis (Spec 55 §7.3). Mirrors the core
+ * `ProposalPreAnalysisResult` but with `analyzedAt` as an ISO **string** — the
+ * server serializes the `Date` before sending it — so consumers never call Date
+ * methods on what is actually a string. `ProposalImpactPreview` accepts this.
+ */
+export type ProposalAnalysis = Omit<ProposalPreAnalysisResult, "analyzedAt"> & {
+  analyzedAt: string;
+};
+
 export interface Proposal {
   id: string;
   title: string;
@@ -87,7 +97,7 @@ export interface Proposal {
    * proposals that ran through the pre-analysis pipeline; absent for manual drafts.
    * `analyzedAt` arrives as an ISO string over the wire (serialized server-side).
    */
-  analysis?: ProposalPreAnalysisResult;
+  analysis?: ProposalAnalysis;
   createdAt: string;
   updatedAt: string;
   validatedAt?: string;

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -2,6 +2,10 @@
  * API client for Proposal / Evolution / AI Insights endpoints.
  */
 
+// Type-only import (erased at compile time — no core runtime reaches the UI),
+// mirroring proposal-impact-preview.tsx which renders this same shape.
+import type { ProposalPreAnalysisResult } from "@linchkit/core";
+
 // ── Auth header helper (reuse from api.ts pattern) ──────
 
 function getAuthHeaders(): Record<string, string> {
@@ -77,6 +81,13 @@ export interface Proposal {
   impact: ProposalImpact;
   status: string;
   validationResult?: ProposalValidationResult;
+  /**
+   * Per-proposal pre-analysis (Spec 55 §7.3) — dedup / conflict / impact /
+   * backtest envelopes surfaced to the human reviewer. Present on AI-surfaced
+   * proposals that ran through the pre-analysis pipeline; absent for manual drafts.
+   * `analyzedAt` arrives as an ISO string over the wire (serialized server-side).
+   */
+  analysis?: ProposalPreAnalysisResult;
   createdAt: string;
   updatedAt: string;
   validatedAt?: string;

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -22,21 +22,19 @@ import {
 } from "@linchkit/ui-kit/components";
 import {
   AlertTriangleIcon,
-  CheckCircle2Icon,
   ClipboardListIcon,
   Code2Icon,
-  ExternalLinkIcon,
   GitPullRequestIcon,
   Loader2Icon,
   RefreshCwIcon,
   SparklesIcon,
   ThumbsDownIcon,
   ThumbsUpIcon,
-  XCircleIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ProposalImpactPreview } from "@/components/proposal-impact-preview";
+import { GraduateOutcome, MaterializeOutcome } from "@/components/proposal-review-outcomes";
 import {
   approveProposal,
   fetchProposals,
@@ -385,213 +383,6 @@ function ProposalCard({
       </CardContent>
     </Card>
   );
-}
-
-// ── Graduate outcome renderer ─────────────────────────────
-
-function GraduateOutcome({
-  result,
-  t,
-}: {
-  result: GraduateProposalResult;
-  t: ReturnType<typeof useTranslation>["t"];
-}) {
-  switch (result.kind) {
-    case "ok":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950/30"
-          data-testid="graduate-ok"
-        >
-          <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-green-500" />
-          <div className="space-y-1">
-            <p className="text-sm text-green-700 dark:text-green-300">
-              {t("proposals.graduatePrOpened", "Pull request opened for review.")}
-            </p>
-            {result.prUrl && (
-              <a
-                href={result.prUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
-              >
-                <ExternalLinkIcon className="size-3" />
-                {t("proposals.viewPr", "View PR")}
-              </a>
-            )}
-          </div>
-        </div>
-      );
-
-    case "unavailable":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-3"
-          data-testid="graduate-unavailable"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">
-            {result.message ?? t("proposals.graduateNotConfigured", "Graduation not configured.")}
-          </p>
-        </div>
-      );
-
-    case "denied":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="graduate-denied"
-        >
-          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">
-            {t("proposals.notAuthorized", "Not authorized.")}
-          </p>
-        </div>
-      );
-
-    case "not_approved":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="graduate-not-approved"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">
-            {result.message ?? t("proposals.notApproved", "Proposal is not approved.")}
-          </p>
-        </div>
-      );
-
-    case "not_found":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="graduate-not-found"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">
-            {t("proposals.notFound", "Proposal not found.")}
-          </p>
-        </div>
-      );
-
-    case "error":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="graduate-error"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">{result.message}</p>
-        </div>
-      );
-  }
-}
-
-// ── Materialize outcome renderer ──────────────────────────
-
-function MaterializeOutcome({
-  result,
-  t,
-}: {
-  result: MaterializeProposalResult;
-  t: ReturnType<typeof useTranslation>["t"];
-}) {
-  switch (result.kind) {
-    case "ok": {
-      const materialized = result.outcomes.filter((o) => o.status === "materialized").length;
-      const skipped = result.outcomes.filter((o) => o.status === "skipped").length;
-      const failed = result.outcomes.filter((o) => o.status === "failed").length;
-      const ok = result.allMaterialized;
-      return (
-        <div
-          className={`flex items-start gap-2 rounded-md border p-3 ${
-            ok
-              ? "border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/30"
-              : "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/30"
-          }`}
-          data-testid="materialize-ok"
-        >
-          {ok ? (
-            <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-green-500" />
-          ) : (
-            <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-amber-500" />
-          )}
-          <p className="text-sm">
-            {t("proposals.materializeSummary", "Generated {{m}}, skipped {{s}}, failed {{f}}.", {
-              m: materialized,
-              s: skipped,
-              f: failed,
-            })}
-          </p>
-        </div>
-      );
-    }
-
-    case "unavailable":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-3"
-          data-testid="materialize-unavailable"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">
-            {result.message ??
-              t("proposals.materializeNotConfigured", "AI code generation is not configured.")}
-          </p>
-        </div>
-      );
-
-    case "denied":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="materialize-denied"
-        >
-          <XCircleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">
-            {t("proposals.notAuthorized", "Not authorized.")}
-          </p>
-        </div>
-      );
-
-    case "not_draft":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="materialize-not-draft"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">
-            {result.message ?? t("proposals.notDraft", "Proposal is not a draft.")}
-          </p>
-        </div>
-      );
-
-    case "not_found":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="materialize-not-found"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">
-            {t("proposals.notFound", "Proposal not found.")}
-          </p>
-        </div>
-      );
-
-    case "error":
-      return (
-        <div
-          className="flex items-start gap-2 rounded-md bg-destructive/10 p-3"
-          data-testid="materialize-error"
-        >
-          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="text-sm text-destructive">{result.message}</p>
-        </div>
-      );
-  }
 }
 
 // ── Page ──────────────────────────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ProposalImpactPreview } from "@/components/proposal-impact-preview";
 import {
   approveProposal,
   fetchProposals,
@@ -218,6 +219,15 @@ function ProposalCard({
               {t("proposals.impact", "Impact")}
             </h5>
             <p className="text-sm">{proposal.validationResult.impactSummary}</p>
+          </div>
+        )}
+
+        {/* Pre-analysis evidence (Spec 55 §7.3) — dedup / conflict / impact /
+            backtest the AI ran before surfacing this proposal. Decision-support
+            shown BEFORE the approve/reject controls; absent for manual drafts. */}
+        {proposal.analysis && (
+          <div data-testid="proposal-preanalysis">
+            <ProposalImpactPreview result={proposal.analysis} />
           </div>
         )}
 


### PR DESCRIPTION
## What

Render the per-proposal **pre-analysis** (Spec 55 §7.3) on the human review page `/admin/proposals`, completing the value loop opened by #504 (which made the data available) — the reviewer now SEES the dedup / conflict / impact / backtest evidence the AI ran before surfacing a proposal.

The `ProposalImpactPreview` component already existed but was wired only on the demo page; the real review surface never rendered it.

## How

- **`lib/proposal-api.ts`**: add optional `analysis?: ProposalAnalysis` to the client `Proposal` type. `ProposalAnalysis` is a **wire shape** — `Omit<ProposalPreAnalysisResult, "analyzedAt"> & { analyzedAt: string }` — because the server serializes the `Date` to an ISO string (a typed consumer must not call Date methods on a string).
- **`proposal-impact-preview.tsx`**: widen the prop to `analyzedAt: string | Date` (it already normalizes via `new Date(...)`, which accepts both; the demo's `Date` and the wire's `string` both satisfy it).
- **`proposal-review.tsx`**: render `<ProposalImpactPreview result={proposal.analysis} />` as decision-support evidence above the approve/reject controls, guarded by `{proposal.analysis && …}` so manual drafts (no analysis) render nothing.

## Safety

Read-only — no change to the human-gated approve / graduate flow. The AI-Never-Modifies-Production invariant is untouched.

## Tests

UI test infra is **logic-only (no jsdom)** — components aren't render-tested; the preview's rendering logic is already covered by `proposal-impact-preview-helpers` tests, and `bunx tsc --noEmit` verifies the new wiring/types. Full `bun run test` green; `bun run check` clean. codex review: clean (2 rounds — wire-type correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-analysis evidence display to proposal review cards, surfacing decision-support insights including dedup analysis, conflict detection, impact assessments, and backtest envelopes when available for governed proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->