### PR TITLE
feat(core,adapter-server): gate Phase 4 generated-source contract via environment (Spec 55 §7)

### DIFF
--- a/.changeset/strict-generated-contract-gating.md
+++ b/.changeset/strict-generated-contract-gating.md
@@ -1,0 +1,19 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": patch
+---
+
+Wire the Phase 4 generated-source contract gate to the environment (Spec 55 §7,
+Spec 09). The validator (`validatePhase4`) and its `strictGeneratedContract`
+gating already existed in core, but the flag was never reachable from the
+deployment environment — so production could never actually block a
+contract-violating AI-generated `generatedSource`, it only ever warned.
+
+`EnvironmentFeatureFlags` gains `strictGeneratedContract`, derived from
+`isProduction` (the same expression as `strictCompatibility`, so the two Phase 3
+and Phase 4 gates move in lock-step — production and staging block, development
+stays warn-only). The adapter-server now threads
+`environment.features.strictGeneratedContract` through `mountProposalAPI` into the
+`ValidationContext`, so proposal validation flips Phase 4 findings from
+non-blocking warnings to blocking errors in production-like environments. No
+behavior change in development.

--- a/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
@@ -182,6 +182,12 @@ export interface MountProposalAPIOptions {
    * from `detectEnvironment().features.strictCompatibility` (true in prod/staging).
    */
   strictCompatibility?: boolean;
+  /**
+   * Escalate Phase 4 generated-source CONTRACT findings (G5) from WARN to BLOCK.
+   * Sourced from `detectEnvironment().features.strictGeneratedContract` (true in
+   * prod/staging). Lock-step sibling of `strictCompatibility`.
+   */
+  strictGeneratedContract?: boolean;
 }
 
 /**
@@ -206,11 +212,14 @@ export function mountProposalAPI(
     : (options ?? {});
   const executionLogger = opts.executionLogger;
 
-  // ValidationContext threaded into both submit sites so Phase 3 can run.
-  // Built once; when ontology is absent Phase 3 returns "skipped" (unchanged).
+  // ValidationContext threaded into both submit sites so Phase 3 (compatibility)
+  // and Phase 4 (generated-source contract) can run. Built once; when ontology is
+  // absent Phase 3 returns "skipped" and when no change carries generated source
+  // Phase 4 returns "skipped" (both unchanged for existing callers).
   const validationContext: ValidationContext = {
     ontology: opts.ontology,
     strictCompatibility: opts.strictCompatibility,
+    strictGeneratedContract: opts.strictGeneratedContract,
   };
 
   // Run initial pattern scan in background if execution logger is available

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -452,13 +452,16 @@ export function createServer(
   mountDeployRoutes(app, opts.deployWebhookHandler);
 
   // ── Proposal / Evolution / AI Insights endpoints ──────────────
-  // Thread the ontology + the env compatibility policy so proposal validation
-  // Phase 3 (Spec 09 §4.5) can detect breaking references. strictCompatibility
-  // blocks breaking proposals in prod/staging; dev/test stay warn-only.
+  // Thread the ontology + the env validation policies so proposal validation
+  // Phase 3 (Spec 09 §4.5) can detect breaking references and Phase 4 (G5) can
+  // gate generated-source contract findings. strictCompatibility /
+  // strictGeneratedContract block such proposals in prod/staging; dev/test stay
+  // warn-only.
   mountProposalAPI(app, {
     executionLogger,
     ontology: opts.ontologyRegistry,
     strictCompatibility: environment.features.strictCompatibility,
+    strictGeneratedContract: environment.features.strictGeneratedContract,
   });
   // Manual, admin-triggered graduation: POST /api/proposals/:id/graduate writes
   // an approved proposal to disk and opens a PR (Spec 55 §7.6/§7.7). It NEVER

--- a/packages/core/__tests__/deployment.strict-generated-contract.test.ts
+++ b/packages/core/__tests__/deployment.strict-generated-contract.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Environment gating for the Phase 4 generated-source contract check.
+ *
+ * `strictGeneratedContract` controls whether the heuristic generated-source
+ * contract validation (validation-phase4) reports findings as blocking ERRORS
+ * (production-like) or non-blocking WARNINGS (development). It moves in
+ * lock-step with `strictCompatibility` (Phase 3): both derive from
+ * `isProduction`, which includes staging.
+ *
+ * Kept in a focused module so the broad `deployment.test.ts` stays under the
+ * file-size policy.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { detectEnvironment } from "../src/deployment";
+
+describe("detectEnvironment — strictGeneratedContract", () => {
+  it("blocks generated-source contract findings in production", () => {
+    const config = detectEnvironment("production");
+    expect(config.features.strictGeneratedContract).toBe(true);
+    // Lock-step with the Phase 3 compatibility gate.
+    expect(config.features.strictGeneratedContract).toBe(config.features.strictCompatibility);
+  });
+
+  it("blocks in staging (production-like)", () => {
+    const config = detectEnvironment("staging");
+    expect(config.isProduction).toBe(true);
+    expect(config.features.strictGeneratedContract).toBe(true);
+    expect(config.features.strictGeneratedContract).toBe(config.features.strictCompatibility);
+  });
+
+  it("stays warn-only in development", () => {
+    const config = detectEnvironment("development");
+    expect(config.features.strictGeneratedContract).toBe(false);
+    expect(config.features.strictGeneratedContract).toBe(config.features.strictCompatibility);
+  });
+});

--- a/packages/core/__tests__/validation-engine.test.ts
+++ b/packages/core/__tests__/validation-engine.test.ts
@@ -457,4 +457,44 @@ describe("validateProposal", () => {
     expect(result.passed).toBe(false);
     expect(result.impactSummary).toContain("change");
   });
+
+  // Phase 4 (generated-source contract) env→pipeline gating: the server threads
+  // detectEnvironment().features.strictGeneratedContract via ValidationContext into
+  // THIS call, so these tests prove the context flag flips Phase 4 warning→error
+  // end-to-end. The fixture's generatedSource defines "other", not "make_thing".
+  const contractViolatingProposal = {
+    id: "p-gen",
+    title: "Generated Action",
+    status: "draft",
+    changes: [
+      {
+        ...makeActionChange("make_thing"),
+        generatedSource: `import { defineAction } from "@linchkit/core";\nexport const other = defineAction({ name: "other", handler: async () => ({}) });`,
+      },
+    ],
+    author: { type: "human", id: "u1", name: "Alice" },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("warn-only by default: contract-violating generatedSource does NOT block (passed)", () => {
+    const result = validateProposal({ proposal: contractViolatingProposal as never });
+    const phase4 = result.phases[3];
+    expect(phase4.phase).toBe(4);
+    expect(phase4.status).toBe("passed");
+    expect(phase4.warnings.length).toBeGreaterThan(0);
+    expect(phase4.errors).toEqual([]);
+  });
+
+  it("strictGeneratedContract via ValidationContext blocks: Phase 4 errors → passed=false", () => {
+    const result = validateProposal({
+      proposal: contractViolatingProposal as never,
+      context: { strictGeneratedContract: true },
+    });
+    const phase4 = result.phases[3];
+    expect(phase4.status).toBe("failed");
+    expect(phase4.warnings).toEqual([]);
+    expect(phase4.errors[0]?.code).toBe("GENERATED_SOURCE_CONTRACT");
+    expect(result.passed).toBe(false);
+  });
 });

--- a/packages/core/src/deployment/environment.ts
+++ b/packages/core/src/deployment/environment.ts
@@ -21,6 +21,15 @@ export interface EnvironmentFeatureFlags {
    * proposals that break existing references.
    */
   strictCompatibility: boolean;
+  /**
+   * Escalate proposal-validation Phase 4 generated-source CONTRACT findings (G5)
+   * from WARN to BLOCK (default: true in prod/staging). Lock-step sibling of
+   * `strictCompatibility`: the checks are heuristic static verifications that an
+   * AI-materialized `generatedSource` actually defines the declared target/name,
+   * so dev/test stay warn-only while production refuses contract-violating
+   * candidate code.
+   */
+  strictGeneratedContract: boolean;
   /** Enable detailed error messages in responses (default: true in dev/test) */
   detailedErrors: boolean;
   /** Enable hot-reload / watch mode (default: true in dev) */
@@ -98,6 +107,7 @@ function buildConfig(name: EnvironmentName): EnvironmentConfig {
       verboseLogging: isDevelopment || isTest,
       strictValidation: isProduction,
       strictCompatibility: isProduction,
+      strictGeneratedContract: isProduction,
       detailedErrors: isDevelopment || isTest,
       hotReload: isDevelopment,
       requestLogging: isDevelopment,


### PR DESCRIPTION
## What

Wire the **Phase 4 generated-source contract gate** to the deployment environment so production can actually **block** a contract-violating AI-generated handler, not merely warn.

The validator (`validatePhase4`) and its `strictGeneratedContract` gating already shipped in core (PRs #494–#496). The gap was the upstream half: the flag did not exist on the environment-features object and was never threaded server → pipeline, so the gate was effectively dead in production.

## Changes

- **`packages/core/src/deployment/environment.ts`** — add `strictGeneratedContract` to `EnvironmentFeatureFlags`, derived from `isProduction` (the *identical* expression to `strictCompatibility`, so the Phase 3 and Phase 4 gates move in lock-step: **production + staging block, development stays warn-only**).
- **`addons/.../server.ts`** — thread `environment.features.strictGeneratedContract` into `mountProposalAPI`.
- **`addons/.../proposal-api.ts`** — forward it into the `ValidationContext` so proposal validation flips Phase 4 findings warnings → errors in production-like environments.

## Live wiring (not a dormant flag)

`environment.ts:110` → `server.ts:464` → `proposal-api.ts:222` → `validation-engine.ts:700` → `validation-phase4.ts:281` (where findings escalate to errors).

## Tests

- `validation-engine.test.ts` — env→pipeline gating proof: with `context.strictGeneratedContract:true` a contract-violating `generatedSource` produces a blocking Phase-4 ERROR (`passed:false`); default is a non-blocking WARNING (`passed:true`).
- `deployment.strict-generated-contract.test.ts` (new, focused module) — asserts the flag is `true` in production + staging, `false` in development, always in lock-step with `strictCompatibility`. Kept separate so `deployment.test.ts` stays under the file-size policy.

Full `bun run test` green. typecheck + biome clean. codex review: no introduced bug.

Safety: no production behavior change in development; the gate only ever **rejects** a proposal earlier in the existing human-gated pipeline — it never auto-approves, commits, or writes anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
