### PR TITLE
feat(core,adapter-server): observable evolution scheduler status + real-boot smoke (Spec 55 §7)

### DIFF
--- a/.changeset/scheduler-status-observability.md
+++ b/.changeset/scheduler-status-observability.md
@@ -1,0 +1,29 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+---
+
+Make the autonomous evolution cadence loop observable (Spec 55 §7). An operator
+could start the cadence scheduler but had no way to see whether it was actually
+alive — ticking, idle, or stuck on a repeating error.
+
+`EvolutionScheduler` gains a read-only `getStatus(): EvolutionSchedulerStatus`
+liveness snapshot (running, clamped intervalMs, ticksStarted/ticksCompleted,
+last-tick timestamps + duration, lastError, consecutiveErrors). The counters are
+tracked inside the non-overlapping tick runner; the snapshot clones its `Date`s
+so callers cannot mutate scheduler state. A successful tick clears the error
+streak; a thrown tick still "completes" and increments `consecutiveErrors`.
+
+The adapter-server exposes it at `GET /api/evolution/scheduler-status`, dispatched
+through the **same CommandLayer permission path** as `/api/evolution/run-cycle`
+(synthetic `evolution.scheduler_status` command, `skipActionSlots`): 503 when no
+CommandLayer is configured, 401/403 canonical `AUTHZ_DENIED` on denial, `200
+{ configured: false }` when cadence is disabled, and `200 { configured: true,
+...status }` (Date fields as ISO strings) when a scheduler is wired. Permission
+runs before anything is reported, so an unauthorized caller cannot even learn
+whether cadence is configured.
+
+A real-`createServer` smoke test drives the endpoint through the canonical server
+factory (the same assembly `http-transport` boots), advances the scheduler with
+`runOnce()`, reads the live state back over HTTP, and asserts the read fails
+closed (`PERMISSION.MIDDLEWARE_MISSING`) when no permission middleware is present.

--- a/addons/adapter-server/cap-adapter-server/__tests__/evolution-scheduler-wiring.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/evolution-scheduler-wiring.test.ts
@@ -184,6 +184,39 @@ describe("createEvolutionCadence", () => {
     expect(seenTenants).toEqual(["tenant-a", "tenant-b"]);
   });
 
+  test("repeated cadence failures surface in liveness status; a clean tick clears the streak", async () => {
+    // Regression: the per-tenant catch must not SWALLOW failures so completely
+    // that the scheduler reports healthy. After attempting every scope, a tick
+    // with any failure re-throws an aggregate, so getStatus() (→ GET
+    // /api/evolution/scheduler-status) reflects a cadence stuck on errors.
+    let failing = true;
+    const fakeRuntime = {
+      evolutionCycle: {
+        runCycle: async () => {
+          if (failing) throw new Error("sensor exploded");
+          return { proposals: [] };
+        },
+      },
+    } as unknown as EvolutionRuntime;
+    const scheduler = createEvolutionCadence({
+      evolutionRuntime: fakeRuntime,
+      intervalMs: 1000,
+      engine: createProposalEngine(),
+      logger: SILENT,
+    });
+
+    await scheduler?.runOnce();
+    await scheduler?.runOnce();
+    expect(scheduler?.getStatus().consecutiveErrors).toBe(2);
+    expect(scheduler?.getStatus().lastError).toContain("sensor exploded");
+
+    // A subsequent all-green tick clears the streak — the loop recovered.
+    failing = false;
+    await scheduler?.runOnce();
+    expect(scheduler?.getStatus().consecutiveErrors).toBe(0);
+    expect(scheduler?.getStatus().lastError).toBeNull();
+  });
+
   test("re-running the cadence tick is idempotent (deduped, not duplicated)", async () => {
     const fakeRuntime = {
       evolutionCycle: { runCycle: async () => ({ proposals: [cycleProposal()] }) },

--- a/addons/adapter-server/cap-adapter-server/__tests__/evolution-status-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/evolution-status-api.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Evolution scheduler status endpoint tests — GET /api/evolution/scheduler-status.
+ *
+ * Pins the read-only liveness surface: the CommandLayer permission gate
+ * (503 no-layer / 401-403 denied), the `{ configured: false }` answer when no
+ * scheduler is wired (cadence disabled), and the full status shape (with Date
+ * fields serialized as ISO strings) when one is.
+ *
+ * Endpoint dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ * `app.listen(PORT)` is intentionally avoided — a bound socket per suite
+ * SEGFAULTS the batched addons run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CommandLayer } from "@linchkit/core";
+import { createEvolutionScheduler, type EvolutionScheduler } from "@linchkit/core/server";
+import { Elysia } from "elysia";
+import { mountEvolutionStatusRoutes } from "../src/routes/evolution-status-api";
+import type { ServerOptions } from "../src/server";
+
+const BASE = "http://local.test";
+const SILENT = { debug() {}, info() {}, warn() {}, error() {} } as const;
+
+interface StatusJson {
+  success: boolean;
+  data?: {
+    configured?: boolean;
+    running?: boolean;
+    intervalMs?: number;
+    ticksStarted?: number;
+    ticksCompleted?: number;
+    lastTickStartedAt?: string | null;
+    lastTickCompletedAt?: string | null;
+    lastTickDurationMs?: number | null;
+    lastError?: string | null;
+    consecutiveErrors?: number;
+  };
+  error?: { code?: string; message?: string };
+}
+
+/** Permissive command layer; `data` carries the synthetic tenant slot result. */
+function passLayer(data: Record<string, unknown> = {}): CommandLayer {
+  return { execute: async () => ({ success: true, data }) } as unknown as CommandLayer;
+}
+
+function mountApp(opts: { commandLayer?: CommandLayer; scheduler?: EvolutionScheduler }): Elysia {
+  const app = new Elysia();
+  mountEvolutionStatusRoutes(app, {
+    commandLayer: opts.commandLayer,
+    evolutionScheduler: opts.scheduler,
+  } as unknown as ServerOptions);
+  return app;
+}
+
+async function getStatus(app: Elysia): Promise<{ status: number; json: StatusJson }> {
+  const res = await app.handle(
+    new Request(`${BASE}/api/evolution/scheduler-status`, { method: "GET" }),
+  );
+  return { status: res.status, json: (await res.json()) as StatusJson };
+}
+
+describe("GET /api/evolution/scheduler-status", () => {
+  test("no scheduler wired → 200 { configured: false }", async () => {
+    const app = mountApp({ commandLayer: passLayer(), scheduler: undefined });
+    const { status, json } = await getStatus(app);
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.configured).toBe(false);
+    // No status fields leak when there is no scheduler.
+    expect(json.data?.running).toBeUndefined();
+  });
+
+  test("scheduler wired → 200 with the full status shape (fresh scheduler)", async () => {
+    const scheduler = createEvolutionScheduler({
+      tick: () => {},
+      intervalMs: 60_000,
+      logger: SILENT,
+    });
+    const app = mountApp({ commandLayer: passLayer(), scheduler });
+
+    const { status, json } = await getStatus(app);
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.configured).toBe(true);
+    expect(json.data?.running).toBe(false);
+    expect(json.data?.intervalMs).toBe(60_000);
+    expect(json.data?.ticksStarted).toBe(0);
+    expect(json.data?.ticksCompleted).toBe(0);
+    expect(json.data?.lastTickStartedAt).toBeNull();
+    expect(json.data?.lastTickCompletedAt).toBeNull();
+    expect(json.data?.lastTickDurationMs).toBeNull();
+    expect(json.data?.lastError).toBeNull();
+    expect(json.data?.consecutiveErrors).toBe(0);
+  });
+
+  test("Date fields are serialized as ISO strings after a tick", async () => {
+    const scheduler = createEvolutionScheduler({
+      tick: () => {},
+      intervalMs: 1000,
+      logger: SILENT,
+    });
+    await scheduler.runOnce();
+    const app = mountApp({ commandLayer: passLayer(), scheduler });
+
+    const { json } = await getStatus(app);
+    expect(json.data?.configured).toBe(true);
+    expect(json.data?.ticksStarted).toBe(1);
+    expect(json.data?.ticksCompleted).toBe(1);
+    // ISO-8601 string, round-trips through Date without becoming Invalid Date.
+    const startedAt = json.data?.lastTickStartedAt;
+    expect(typeof startedAt).toBe("string");
+    expect(Number.isNaN(new Date(startedAt as string).getTime())).toBe(false);
+  });
+
+  test("reflects a throwing tick's lastError + consecutiveErrors", async () => {
+    const scheduler = createEvolutionScheduler({
+      tick: () => {
+        throw new Error("cycle boom");
+      },
+      intervalMs: 1000,
+      logger: SILENT,
+      onError: () => {},
+    });
+    await scheduler.runOnce();
+    const app = mountApp({ commandLayer: passLayer(), scheduler });
+
+    const { json } = await getStatus(app);
+    expect(json.data?.lastError).toBe("cycle boom");
+    expect(json.data?.consecutiveErrors).toBe(1);
+  });
+
+  test("command layer absent → 503 (cannot authorize, fail closed)", async () => {
+    const scheduler = createEvolutionScheduler({
+      tick: () => {},
+      intervalMs: 1000,
+      logger: SILENT,
+    });
+    const app = mountApp({ commandLayer: undefined, scheduler });
+    const { status, json } = await getStatus(app);
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+  });
+
+  test("unauthorized caller → 403 canonical AUTHZ_DENIED; status not leaked", async () => {
+    const scheduler = createEvolutionScheduler({
+      tick: () => {},
+      intervalMs: 1000,
+      logger: SILENT,
+    });
+    const denying = {
+      execute: async () => ({ success: false, data: { error: "not allowed" } }),
+    } as unknown as CommandLayer;
+    const app = mountApp({ commandLayer: denying, scheduler });
+
+    const { status, json } = await getStatus(app);
+    expect(status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+    // Denied callers learn nothing about the scheduler.
+    expect(json.data).toBeUndefined();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/evolution-status-smoke.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/evolution-status-smoke.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Evolution scheduler status — REAL server-assembly smoke test.
+ *
+ * The sibling `evolution-status-api.test.ts` pins the route in isolation
+ * (a hand-built Elysia app with only the status routes mounted). This smoke
+ * test instead drives the route through the canonical `createServer(...)`
+ * factory — the SAME assembly path `http-transport.ts` boots in production —
+ * to prove the endpoint is actually wired into the real server (not merely
+ * mountable on its own), and that it reflects the scheduler's LIVE runtime
+ * state.
+ *
+ * It exercises real components end-to-end: a real `createEvolutionScheduler`,
+ * a real `createCommandLayer`, a real GraphQL schema, and the real REST
+ * surface — then advances the scheduler with `runOnce()` and reads the change
+ * back out over HTTP. No mock seams, so a broken wiring can't pass.
+ *
+ * Dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ * `app.listen(PORT)` is intentionally avoided — a bound socket per suite
+ * SEGFAULTS the batched addons run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CommandLayer, EntityDefinition } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  createEvolutionScheduler,
+  type EvolutionScheduler,
+  InMemoryExecutionLogger,
+  InMemoryStore,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+const BASE = "http://local.test";
+const SILENT = { debug() {}, info() {}, warn() {}, error() {} } as const;
+
+const taskSchema: EntityDefinition = {
+  name: "task",
+  label: "Task",
+  fields: { title: { type: "string", required: true, label: "Title" } },
+};
+
+/**
+ * Register an allow-all permission middleware. The status read dispatches with
+ * `skipActionSlots: true`, which is fail-closed: the CommandLayer rejects it
+ * unless a permission middleware is present (the executor's default-allow does
+ * NOT apply to non-action dispatches). In a real deployment cap-permission
+ * provides this slot; here a minimal pass-through stands in for "the read is
+ * authorized" so we can observe the rest of the wiring.
+ */
+function grantReadPermission(commandLayer: CommandLayer): void {
+  commandLayer.use({
+    name: "smoke_allow_read",
+    slot: "permission",
+    handler: async (_ctx, next) => {
+      await next();
+    },
+  });
+}
+
+interface StatusResponse {
+  success: boolean;
+  data?: {
+    configured?: boolean;
+    running?: boolean;
+    intervalMs?: number;
+    ticksStarted?: number;
+    ticksCompleted?: number;
+    lastTickStartedAt?: string | null;
+    lastTickCompletedAt?: string | null;
+    lastTickDurationMs?: number | null;
+    lastError?: string | null;
+    consecutiveErrors?: number;
+  };
+  error?: { code?: string; message?: string };
+}
+
+/** Build the real server via the canonical factory, optionally with a scheduler. */
+function buildApp(
+  evolutionScheduler?: EvolutionScheduler,
+  opts: { withPermission?: boolean } = {},
+): { handle: (req: Request) => Promise<Response> } {
+  const { withPermission = true } = opts;
+  const store = new InMemoryStore();
+  const executor = createActionExecutor({
+    dataProvider: store,
+    executionLogger: new InMemoryExecutionLogger(),
+  });
+  const commandLayer = createCommandLayer({ executor });
+  if (withPermission) {
+    grantReadPermission(commandLayer);
+  }
+  const graphqlSchema = buildGraphQLSchema([taskSchema], {
+    executor,
+    commandLayer,
+    dataProvider: store,
+  });
+  return createServer(graphqlSchema, { executor, commandLayer, evolutionScheduler });
+}
+
+async function getStatus(app: {
+  handle: (req: Request) => Promise<Response>;
+}): Promise<{ status: number; body: StatusResponse }> {
+  const res = await app.handle(new Request(`${BASE}/api/evolution/scheduler-status`));
+  const body = (await res.json()) as StatusResponse;
+  return { status: res.status, body };
+}
+
+describe("evolution scheduler-status — real createServer smoke", () => {
+  test("reports configured:false when no scheduler is wired into the real server", async () => {
+    const app = buildApp(undefined);
+    const { status, body } = await getStatus(app);
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data?.configured).toBe(false);
+  });
+
+  test("surfaces a wired scheduler's LIVE state after a real tick", async () => {
+    let ticks = 0;
+    const scheduler = createEvolutionScheduler({
+      tick: () => {
+        ticks += 1;
+      },
+      intervalMs: 60_000,
+      logger: SILENT,
+    });
+    const app = buildApp(scheduler);
+
+    // Before any tick: configured + idle counters, surfaced through the real route.
+    const before = await getStatus(app);
+    expect(before.status).toBe(200);
+    expect(before.body.data?.configured).toBe(true);
+    expect(before.body.data?.running).toBe(false);
+    expect(before.body.data?.intervalMs).toBe(60_000);
+    expect(before.body.data?.ticksStarted).toBe(0);
+    expect(before.body.data?.lastTickStartedAt).toBeNull();
+
+    // Advance the scheduler deterministically (no timers) and read it back over HTTP.
+    const ran = await scheduler.runOnce();
+    expect(ran).toBe(true);
+    expect(ticks).toBe(1);
+
+    const after = await getStatus(app);
+    expect(after.body.data?.ticksStarted).toBe(1);
+    expect(after.body.data?.ticksCompleted).toBe(1);
+    expect(after.body.data?.lastError).toBeNull();
+    expect(after.body.data?.consecutiveErrors).toBe(0);
+    // Timestamp serialized as an ISO string over the wire (not a raw Date).
+    expect(typeof after.body.data?.lastTickStartedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(after.body.data?.lastTickStartedAt ?? ""))).toBe(false);
+    expect(after.body.data?.lastTickDurationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("permission slot is never skipped: real server fails closed without a permission middleware", async () => {
+    // No permission middleware → the skipActionSlots status read must be rejected
+    // (PERMISSION.MIDDLEWARE_MISSING), proving the real assembly enforces the
+    // permission slot end-to-end rather than leaking liveness to an unauthorized
+    // caller. A scheduler IS wired, so a leak would expose real state.
+    const scheduler = createEvolutionScheduler({
+      tick: () => {},
+      intervalMs: 60_000,
+      logger: SILENT,
+    });
+    const app = buildApp(scheduler, { withPermission: false });
+    const res = await app.handle(new Request(`${BASE}/api/evolution/scheduler-status`));
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as StatusResponse;
+    expect(body.success).toBe(false);
+    expect(body.error?.code).toBe("PERMISSION.MIDDLEWARE_MISSING");
+    // Liveness must NOT leak to an unauthorized caller.
+    expect(body.data).toBeUndefined();
+  });
+
+  test("a failing tick's error streak is observable through the real route", async () => {
+    const scheduler = createEvolutionScheduler({
+      tick: () => {
+        throw new Error("smoke boom");
+      },
+      intervalMs: 60_000,
+      logger: SILENT,
+      onError: () => {},
+    });
+    const app = buildApp(scheduler);
+
+    await scheduler.runOnce();
+    const { body } = await getStatus(app);
+    expect(body.data?.configured).toBe(true);
+    expect(body.data?.ticksCompleted).toBe(1);
+    expect(body.data?.lastError).toBe("smoke boom");
+    expect(body.data?.consecutiveErrors).toBe(1);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/evolution-scheduler-wiring.ts
+++ b/addons/adapter-server/cap-adapter-server/src/evolution-scheduler-wiring.ts
@@ -120,6 +120,7 @@ export function createEvolutionCadence(
       // path (tracked in #500), not something this cadence wiring can force.
       // Scopes are processed serially within the (non-overlapping) tick, and each
       // is isolated: one tenant's failing cycle must not starve the rest.
+      const failures: string[] = [];
       for (const tenantId of tenantScopes) {
         try {
           const result = await cycle.runCycle({ timestamp: new Date(), tenantId });
@@ -135,11 +136,23 @@ export function createEvolutionCadence(
               `${summary.deduped} deduped (DRAFT-only; approval and graduation stay human-gated).`,
           );
         } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          failures.push(`${tenantId ?? "(default)"}: ${message}`);
           logger.warn(
             `[EvolutionCadence] tenant=${tenantId ?? "(default)"} cycle failed: ` +
-              `${err instanceof Error ? err.message : String(err)} — continuing with remaining tenants.`,
+              `${message} — continuing with remaining tenants.`,
           );
         }
+      }
+      // Every scope was still attempted (isolation preserved), but if ANY failed
+      // we re-throw an aggregate so the scheduler's liveness counters record it.
+      // Otherwise GET /api/evolution/scheduler-status would report lastError:null
+      // / consecutiveErrors:0 even while every scheduled cycle is failing — exactly
+      // the "stuck on a repeating error" case the status surface exists to catch.
+      if (failures.length > 0) {
+        throw new Error(
+          `Evolution cadence: ${failures.length}/${tenantScopes.length} tenant cycle(s) failed — ${failures.join("; ")}`,
+        );
       }
     },
   });

--- a/addons/adapter-server/cap-adapter-server/src/http-transport.ts
+++ b/addons/adapter-server/cap-adapter-server/src/http-transport.ts
@@ -135,6 +135,28 @@ export async function createHttpTransport(ctx: TransportContext): Promise<Transp
   // Collect rule definitions from all capabilities for /api/rules endpoint
   const allRules = (ctx.capabilities ?? []).flatMap((c) => c.rules ?? []);
 
+  // Spec 55 §7 — OPT-IN autonomous cadence. OFF unless EVOLUTION_CADENCE_INTERVAL_MS
+  // is set to a positive integer (ms). The tick runs one cycle and persists its
+  // proposals as DRAFTS only — approval and graduation stay human-gated. Built
+  // here (un-started) BEFORE the server so its read-only status can be wired into
+  // `GET /api/evolution/scheduler-status`; started/stopped with the lifecycle below.
+  const cadenceIntervalMs = resolveCadenceIntervalMs();
+  const evolutionScheduler =
+    cadenceIntervalMs !== null
+      ? createEvolutionCadence({
+          evolutionRuntime: ctx.evolutionRuntime,
+          intervalMs: cadenceIntervalMs,
+          tenantIds: resolveCadenceTenantIds(),
+        })
+      : null;
+  // The operator opted into cadence but no evolution runtime is wired, so
+  // createEvolutionCadence returned null — warn instead of silently doing nothing.
+  if (cadenceIntervalMs !== null && !evolutionScheduler) {
+    consoleLogger.warn(
+      "[cap-adapter-server] EVOLUTION_CADENCE_INTERVAL_MS is set but no evolution runtime is wired — autonomous cadence will NOT start.",
+    );
+  }
+
   const app = createServer(graphqlSchema, {
     port,
     executor: ctx.executor,
@@ -173,28 +195,11 @@ export async function createHttpTransport(ctx: TransportContext): Promise<Transp
     // Spec 55 §7 — enable `POST /api/evolution/run-cycle` so an operator can run
     // one on-demand evolution cycle and land its proposals as governance drafts.
     evolutionRuntime: ctx.evolutionRuntime,
+    // Spec 55 §7 — expose the opt-in cadence scheduler's read-only status via
+    // `GET /api/evolution/scheduler-status` (null when cadence is disabled →
+    // that endpoint reports `{ configured: false }`).
+    evolutionScheduler: evolutionScheduler ?? undefined,
   });
-
-  // Spec 55 §7 — OPT-IN autonomous cadence. OFF unless EVOLUTION_CADENCE_INTERVAL_MS
-  // is set to a positive integer (ms). The tick runs one cycle and persists its
-  // proposals as DRAFTS only — approval and graduation stay human-gated. Built
-  // here (un-started); started/stopped with the server lifecycle below.
-  const cadenceIntervalMs = resolveCadenceIntervalMs();
-  const evolutionScheduler =
-    cadenceIntervalMs !== null
-      ? createEvolutionCadence({
-          evolutionRuntime: ctx.evolutionRuntime,
-          intervalMs: cadenceIntervalMs,
-          tenantIds: resolveCadenceTenantIds(),
-        })
-      : null;
-  // The operator opted into cadence but no evolution runtime is wired, so
-  // createEvolutionCadence returned null — warn instead of silently doing nothing.
-  if (cadenceIntervalMs !== null && !evolutionScheduler) {
-    consoleLogger.warn(
-      "[cap-adapter-server] EVOLUTION_CADENCE_INTERVAL_MS is set but no evolution runtime is wired — autonomous cadence will NOT start.",
-    );
-  }
 
   return {
     start: () => {

--- a/addons/adapter-server/cap-adapter-server/src/routes/evolution-status-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/evolution-status-api.ts
@@ -1,0 +1,170 @@
+/**
+ * Evolution scheduler status REST endpoint (Spec 55 §7).
+ *
+ * GET /api/evolution/scheduler-status
+ *
+ * Read-only liveness surface for the OPT-IN autonomous evolution cadence loop:
+ * lets a human operator see whether the timer is alive (running, ticking,
+ * succeeding, or stuck erroring) WITHOUT any side effect. The cadence itself is
+ * built in `evolution-scheduler-wiring.ts` and only produces governance DRAFTS —
+ * this endpoint never mutates anything; it only reports `scheduler.getStatus()`.
+ *
+ * Hard safety boundary (repo principle "AI Never Modifies Production Directly"):
+ *  - This route is strictly READ-ONLY. It never starts/stops the scheduler, runs
+ *    a cycle, or persists anything.
+ *
+ * Pipeline: like `POST /api/evolution/run-cycle`, the request first passes
+ * through CommandLayer with `skipActionSlots = true` so auth / permission /
+ * tenant slots still run (the permission slot is NEVER skipped) while the
+ * action-specific slots are bypassed. The synthetic command name
+ * `"evolution.scheduler_status"` exists only for metrics/tracing labels; the
+ * authoritative permission target is carried in `meta.evolution`.
+ *
+ * Graceful degradation: when no scheduler is wired (cadence disabled via env),
+ * the endpoint returns 200 `{ configured: false }` rather than an error — the
+ * operator's question ("is the loop alive?") has a definitive answer ("there is
+ * no loop"), so this is a successful read, not a failure.
+ */
+
+import type { EvolutionScheduler, EvolutionSchedulerStatus } from "@linchkit/core/server";
+import type { Elysia } from "elysia";
+import type { ServerOptions } from "../server";
+import { resolveActor, resolveStatusCode, serviceUnavailable } from "./shared";
+
+/**
+ * Canonical authorization-denied envelope — every 401/403 path returns the
+ * SAME payload so the response text cannot be used as a side channel.
+ */
+const AUTHZ_DENIED_BODY = {
+  success: false as const,
+  error: {
+    code: "AUTHZ_DENIED",
+    message: "Access denied",
+  },
+} as const;
+
+/** Synthetic command name for the scheduler-status dispatch (metrics/tracing only). */
+export const SCHEDULER_STATUS_COMMAND_NAME = "evolution.scheduler_status";
+
+/** Wire-format scheduler status — Date fields serialized as ISO strings (or null). */
+export interface SchedulerStatusWire {
+  running: boolean;
+  intervalMs: number;
+  ticksStarted: number;
+  ticksCompleted: number;
+  lastTickStartedAt: string | null;
+  lastTickCompletedAt: string | null;
+  lastTickDurationMs: number | null;
+  lastError: string | null;
+  consecutiveErrors: number;
+}
+
+/** Successful response when a scheduler is wired. */
+export interface SchedulerStatusConfiguredResponse {
+  success: true;
+  data: { configured: true } & SchedulerStatusWire;
+}
+
+/** Successful response when cadence is disabled (no scheduler wired). */
+export interface SchedulerStatusUnconfiguredResponse {
+  success: true;
+  data: { configured: false };
+}
+
+/** Convert the core status snapshot to its JSON wire form (ISO date strings). */
+function toWire(status: EvolutionSchedulerStatus): SchedulerStatusWire {
+  return {
+    running: status.running,
+    intervalMs: status.intervalMs,
+    ticksStarted: status.ticksStarted,
+    ticksCompleted: status.ticksCompleted,
+    lastTickStartedAt: status.lastTickStartedAt ? status.lastTickStartedAt.toISOString() : null,
+    lastTickCompletedAt: status.lastTickCompletedAt
+      ? status.lastTickCompletedAt.toISOString()
+      : null,
+    lastTickDurationMs: status.lastTickDurationMs,
+    lastError: status.lastError,
+    consecutiveErrors: status.consecutiveErrors,
+  };
+}
+
+/**
+ * Mount `GET /api/evolution/scheduler-status` onto the given Elysia app.
+ *
+ * Behavior summary:
+ *   503 — command layer not configured (cannot run the permission slot).
+ *   401/403 — caller failed the CommandLayer permission slot (canonical envelope).
+ *   200 `{ configured: false }` — no scheduler wired (cadence disabled).
+ *   200 `{ configured: true, ...status }` — scheduler wired; read-only snapshot.
+ */
+export function mountEvolutionStatusRoutes(app: Elysia, options: ServerOptions): void {
+  const { commandLayer } = options;
+  const scheduler: EvolutionScheduler | undefined = options.evolutionScheduler;
+
+  app.get("/api/evolution/scheduler-status", async ({ set, request }) => {
+    if (!commandLayer) {
+      // The permission slot lives in CommandLayer; without it we cannot
+      // authorize the read, so fail closed rather than skipping the slot.
+      return serviceUnavailable(
+        set,
+        "Command layer is not configured — cannot authorize the evolution scheduler status read.",
+      );
+    }
+
+    // ── Permission slot (CommandLayer, skipActionSlots) ────────────────
+    // Run auth / permission / tenant BEFORE reporting anything — an unauthorized
+    // caller must not learn whether cadence is even configured.
+    const actor = await resolveActor(request, options.resolveRequestActor);
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+    const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
+
+    const commandResult = await commandLayer.execute({
+      command: SCHEDULER_STATUS_COMMAND_NAME,
+      input: {},
+      actor,
+      channel: "http",
+      headers,
+      traceId: incomingTraceId,
+      meta: {
+        // Permission middleware gates on this target rather than an action named
+        // "scheduler_status". Mirrors the run-cycle route's `meta.evolution`.
+        evolution: { operation: "scheduler_status" },
+      },
+      skipActionSlots: true,
+    });
+
+    if (!commandResult.success) {
+      const status = resolveStatusCode(commandResult);
+      set.status = status;
+      if (status === 401 || status === 403) {
+        return AUTHZ_DENIED_BODY;
+      }
+      const errData = commandResult.data as Record<string, unknown> | undefined;
+      const middlewareMessage =
+        (errData?.error as string) ?? "Evolution scheduler status read blocked";
+      const middlewareCode = (errData?.code as string) ?? "EVOLUTION.SCHEDULER_STATUS.BLOCKED";
+      return { success: false, error: { code: middlewareCode, message: middlewareMessage } };
+    }
+
+    // ── Report (read-only) ─────────────────────────────────────────────
+    // No scheduler wired → cadence is disabled in this deployment. That's a
+    // definitive answer to "is the loop alive?" ("there is no loop"), so it's a
+    // successful 200 read rather than an error.
+    if (!scheduler) {
+      const response: SchedulerStatusUnconfiguredResponse = {
+        success: true,
+        data: { configured: false },
+      };
+      return response;
+    }
+
+    const response: SchedulerStatusConfiguredResponse = {
+      success: true,
+      data: { configured: true, ...toWire(scheduler.getStatus()) },
+    };
+    return response;
+  });
+}

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -66,6 +66,7 @@ import { mountConfigStoreRoutes } from "./routes/config-store-api";
 import { mountDeployRoutes } from "./routes/deploy-api";
 import { mountEntityRoutes } from "./routes/entity-api";
 import { mountEvolutionCycleRoutes } from "./routes/evolution-cycle-api";
+import { mountEvolutionStatusRoutes } from "./routes/evolution-status-api";
 import { mountHealthRoutes } from "./routes/health";
 import { mountImportRoutes } from "./routes/import-api";
 import { mountOnchangeRoutes } from "./routes/onchange-api";
@@ -223,9 +224,13 @@ export interface ServerOptions {
    * Evolution runtime (Spec 55) — when provided, enables
    * `POST /api/evolution/run-cycle` to run one on-demand evolution cycle and
    * persist its proposals as governance `draft`s. No-op (501) when absent.
-   * Running the cycle is strictly on-demand: there is NO scheduler.
    */
   evolutionRuntime?: import("@linchkit/core/server").EvolutionRuntime;
+  /**
+   * Opt-in evolution cadence scheduler (Spec 55 §7) — exposes read-only status
+   * via `GET /api/evolution/scheduler-status` (`{ configured: false }` when absent).
+   */
+  evolutionScheduler?: import("@linchkit/core/server").EvolutionScheduler;
 }
 
 // Re-export parseAcceptLanguage for external consumers
@@ -482,10 +487,9 @@ export function createServer(
     ontology: opts.ontologyRegistry,
   });
 
-  // ── Evolution cycle trigger (Spec 55 §7) ─────────────────────
-  // On-demand: runs one cycle and lands its proposals as governance drafts.
-  // No-op (501) when no evolution runtime is wired. There is NO scheduler.
+  // ── Evolution (Spec 55 §7) — on-demand cycle→drafts + read-only scheduler status.
   mountEvolutionCycleRoutes(app, opts);
+  mountEvolutionStatusRoutes(app, opts);
 
   // ── SSE Subscription endpoint (/api/subscribe) ────────────────
   mountSubscriptionRoutes(app, opts);

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -457,11 +457,10 @@ export function createServer(
   mountDeployRoutes(app, opts.deployWebhookHandler);
 
   // ── Proposal / Evolution / AI Insights endpoints ──────────────
-  // Thread the ontology + the env validation policies so proposal validation
-  // Phase 3 (Spec 09 §4.5) can detect breaking references and Phase 4 (G5) can
-  // gate generated-source contract findings. strictCompatibility /
-  // strictGeneratedContract block such proposals in prod/staging; dev/test stay
-  // warn-only.
+  // Thread the ontology + env validation policies so proposal validation can
+  // detect breaking references (Phase 3, Spec 09 §4.5) and gate generated-source
+  // contract findings (Phase 4, G5). strictCompatibility / strictGeneratedContract
+  // block such proposals in prod/staging; dev/test stay warn-only.
   mountProposalAPI(app, {
     executionLogger,
     ontology: opts.ontologyRegistry,

--- a/packages/core/src/__tests__/engine/evolution-scheduler.test.ts
+++ b/packages/core/src/__tests__/engine/evolution-scheduler.test.ts
@@ -154,3 +154,107 @@ describe("createEvolutionScheduler", () => {
     s.stop();
   });
 });
+
+describe("EvolutionScheduler.getStatus", () => {
+  test("a fresh scheduler reports an inert, never-ticked snapshot", () => {
+    const s = createEvolutionScheduler({ tick: () => {}, intervalMs: 60_000, logger: SILENT });
+    const status = s.getStatus();
+    expect(status.running).toBe(false);
+    expect(status.intervalMs).toBe(60_000); // the clamped interval actually in use
+    expect(status.ticksStarted).toBe(0);
+    expect(status.ticksCompleted).toBe(0);
+    expect(status.lastTickStartedAt).toBeNull();
+    expect(status.lastTickCompletedAt).toBeNull();
+    expect(status.lastTickDurationMs).toBeNull();
+    expect(status.lastError).toBeNull();
+    expect(status.consecutiveErrors).toBe(0);
+  });
+
+  test("reports the CLAMPED interval, not the requested one", () => {
+    // Below MIN floors up; above MAX clamps down. getStatus must reflect the
+    // interval actually in use, not the raw requested value.
+    expect(
+      createEvolutionScheduler({ tick: () => {}, intervalMs: 1, logger: SILENT }).getStatus()
+        .intervalMs,
+    ).toBe(MIN_INTERVAL_MS);
+    expect(
+      createEvolutionScheduler({
+        tick: () => {},
+        intervalMs: Number.MAX_SAFE_INTEGER,
+        logger: SILENT,
+      }).getStatus().intervalMs,
+    ).toBe(MAX_INTERVAL_MS);
+  });
+
+  test("after a tick fires, counters increment and timestamps populate", async () => {
+    const s = createEvolutionScheduler({
+      tick: async () => {
+        // A tiny await so the completion timestamp can differ from the start one.
+        await Promise.resolve();
+      },
+      intervalMs: 1000,
+      logger: SILENT,
+    });
+    await s.runOnce();
+
+    const status = s.getStatus();
+    expect(status.ticksStarted).toBe(1);
+    expect(status.ticksCompleted).toBe(1);
+    expect(status.lastTickStartedAt).toBeInstanceOf(Date);
+    expect(status.lastTickCompletedAt).toBeInstanceOf(Date);
+    expect(status.lastTickDurationMs).not.toBeNull();
+    expect(status.lastTickDurationMs).toBeGreaterThanOrEqual(0);
+    expect(status.lastError).toBeNull();
+    expect(status.consecutiveErrors).toBe(0);
+  });
+
+  test("a throwing tick sets lastError + increments consecutiveErrors; a later OK tick resets it", async () => {
+    let shouldThrow = true;
+    const s = createEvolutionScheduler({
+      tick: () => {
+        if (shouldThrow) throw new Error("cycle boom");
+      },
+      intervalMs: 1000,
+      logger: SILENT,
+      onError: () => {}, // swallow — we assert via getStatus
+    });
+
+    // Two consecutive failures.
+    await s.runOnce();
+    await s.runOnce();
+    let status = s.getStatus();
+    expect(status.ticksStarted).toBe(2);
+    expect(status.ticksCompleted).toBe(2); // a thrown tick still "completes"
+    expect(status.lastError).toBe("cycle boom");
+    expect(status.consecutiveErrors).toBe(2);
+
+    // A subsequent OK tick clears the error streak.
+    shouldThrow = false;
+    await s.runOnce();
+    status = s.getStatus();
+    expect(status.lastError).toBeNull();
+    expect(status.consecutiveErrors).toBe(0);
+    expect(status.ticksCompleted).toBe(3);
+  });
+
+  test("getStatus is read-only — mutating the snapshot cannot corrupt internal state", async () => {
+    const s = createEvolutionScheduler({ tick: () => {}, intervalMs: 1000, logger: SILENT });
+    await s.runOnce();
+    const snap = s.getStatus();
+    // Mutate the returned Date and counter.
+    snap.lastTickStartedAt?.setFullYear(1970);
+    snap.ticksStarted = 999;
+    const fresh = s.getStatus();
+    expect(fresh.ticksStarted).toBe(1);
+    expect(fresh.lastTickStartedAt?.getFullYear()).not.toBe(1970);
+  });
+
+  test("running flips true on start() and false on stop()", () => {
+    const s = createEvolutionScheduler({ tick: () => {}, intervalMs: 1000, logger: SILENT });
+    expect(s.getStatus().running).toBe(false);
+    s.start();
+    expect(s.getStatus().running).toBe(true);
+    s.stop();
+    expect(s.getStatus().running).toBe(false);
+  });
+});

--- a/packages/core/src/engine/evolution-scheduler.ts
+++ b/packages/core/src/engine/evolution-scheduler.ts
@@ -55,6 +55,33 @@ export interface EvolutionSchedulerOptions {
   onError?: (err: unknown) => void;
 }
 
+/**
+ * Read-only liveness snapshot of the scheduler (Spec 55 §7) — lets a human
+ * operator see whether the autonomous cadence loop is actually alive (ticking,
+ * succeeding, or stuck erroring) without any side effect. Surfaced over HTTP by
+ * the adapter-server.
+ */
+export interface EvolutionSchedulerStatus {
+  /** True between start() and stop(). */
+  running: boolean;
+  /** The clamped interval actually in use (ms) — after MIN/MAX clamping. */
+  intervalMs: number;
+  /** Count of ticks begun (incremented before each tick body runs). */
+  ticksStarted: number;
+  /** Count of ticks that finished — whether they completed OK or threw. */
+  ticksCompleted: number;
+  /** When the most recent tick started, or null if none has started yet. */
+  lastTickStartedAt: Date | null;
+  /** When the most recent tick finished, or null if none has finished yet. */
+  lastTickCompletedAt: Date | null;
+  /** Duration of the most recent finished tick (ms), or null if none finished. */
+  lastTickDurationMs: number | null;
+  /** Message of the most recent tick error, or null if the last tick was OK. */
+  lastError: string | null;
+  /** Errors in a row; resets to 0 on a successful tick. */
+  consecutiveErrors: number;
+}
+
 export interface EvolutionScheduler {
   /** Begin ticking on the interval. Idempotent — a second call is a no-op. */
   start(): void;
@@ -70,6 +97,12 @@ export interface EvolutionScheduler {
    * (even if the tick threw — the throw is caught and reported).
    */
   runOnce(): Promise<boolean>;
+  /**
+   * Read-only liveness snapshot (counters + timing + last error). Pure — calling
+   * it has no side effect and does not advance the schedule. Returns a fresh
+   * object on each call (timestamps are cloned) so callers can't mutate state.
+   */
+  getStatus(): EvolutionSchedulerStatus;
 }
 
 /**
@@ -96,21 +129,42 @@ export function createEvolutionScheduler(options: EvolutionSchedulerOptions): Ev
   let started = false;
   let ticking = false;
 
+  // ── Liveness counters (read-only via getStatus) ──────────────────────
+  // Mutated only inside runOnce. setInterval is real runtime time here (not a
+  // deterministic workflow), so new Date() is appropriate for the timestamps.
+  let ticksStarted = 0;
+  let ticksCompleted = 0;
+  let lastTickStartedAt: Date | null = null;
+  let lastTickCompletedAt: Date | null = null;
+  let lastTickDurationMs: number | null = null;
+  let lastError: string | null = null;
+  let consecutiveErrors = 0;
+
   async function runOnce(): Promise<boolean> {
     // Non-overlapping: never start a tick while one is already running.
     if (ticking) return false;
     ticking = true;
+    ticksStarted += 1;
+    const startedAt = new Date();
+    lastTickStartedAt = startedAt;
     try {
       await tick();
+      // Success path: clear the error streak so a recovered loop reads "healthy".
+      lastError = null;
+      consecutiveErrors = 0;
     } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+      consecutiveErrors += 1;
       if (onError) {
         onError(err);
       } else {
-        logger.warn(
-          `[EvolutionScheduler] tick failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        logger.warn(`[EvolutionScheduler] tick failed: ${lastError}`);
       }
     } finally {
+      const completedAt = new Date();
+      lastTickCompletedAt = completedAt;
+      lastTickDurationMs = completedAt.getTime() - startedAt.getTime();
+      ticksCompleted += 1;
       ticking = false;
     }
     return true;
@@ -145,5 +199,20 @@ export function createEvolutionScheduler(options: EvolutionSchedulerOptions): Ev
       return ticking;
     },
     runOnce,
+    getStatus(): EvolutionSchedulerStatus {
+      // Clone the Date fields so a caller can't mutate the scheduler's internal
+      // timestamps through the returned snapshot.
+      return {
+        running: started,
+        intervalMs,
+        ticksStarted,
+        ticksCompleted,
+        lastTickStartedAt: lastTickStartedAt ? new Date(lastTickStartedAt) : null,
+        lastTickCompletedAt: lastTickCompletedAt ? new Date(lastTickCompletedAt) : null,
+        lastTickDurationMs,
+        lastError,
+        consecutiveErrors,
+      };
+    },
   };
 }

--- a/packages/core/src/engine/evolution-scheduler.ts
+++ b/packages/core/src/engine/evolution-scheduler.ts
@@ -147,6 +147,10 @@ export function createEvolutionScheduler(options: EvolutionSchedulerOptions): Ev
     ticksStarted += 1;
     const startedAt = new Date();
     lastTickStartedAt = startedAt;
+    // Measure elapsed time with the MONOTONIC clock — `new Date()` deltas can go
+    // backwards (or spike) on NTP syncs / manual clock changes, yielding bogus or
+    // negative durations. `new Date()` is kept only for the wall-clock timestamps.
+    const monotonicStartMs = performance.now();
     try {
       await tick();
       // Success path: clear the error streak so a recovered loop reads "healthy".
@@ -161,9 +165,8 @@ export function createEvolutionScheduler(options: EvolutionSchedulerOptions): Ev
         logger.warn(`[EvolutionScheduler] tick failed: ${lastError}`);
       }
     } finally {
-      const completedAt = new Date();
-      lastTickCompletedAt = completedAt;
-      lastTickDurationMs = completedAt.getTime() - startedAt.getTime();
+      lastTickCompletedAt = new Date();
+      lastTickDurationMs = Math.round(performance.now() - monotonicStartMs);
       ticksCompleted += 1;
       ticking = false;
     }

--- a/packages/core/src/exports/server/engines.ts
+++ b/packages/core/src/exports/server/engines.ts
@@ -54,6 +54,7 @@ export {
   createEvolutionScheduler,
   type EvolutionScheduler,
   type EvolutionSchedulerOptions,
+  type EvolutionSchedulerStatus,
   MAX_INTERVAL_MS,
   MIN_INTERVAL_MS,
 } from "../../engine/evolution-scheduler";


### PR DESCRIPTION
## What

Make the autonomous evolution **cadence loop observable**. An operator could `start()` the scheduler (#501) but had no way to see whether the loop was actually alive — ticking, idle, or stuck repeating an error.

## Changes

**core** — `EvolutionScheduler.getStatus(): EvolutionSchedulerStatus`, a read-only liveness snapshot:
`running`, clamped `intervalMs`, `ticksStarted` / `ticksCompleted`, last-tick timestamps + `lastTickDurationMs`, `lastError`, `consecutiveErrors`. Counters are tracked inside the existing non-overlapping tick runner; the snapshot **clones its `Date`s** so a caller can't mutate scheduler state. A successful tick clears the error streak; a thrown tick still "completes" and increments `consecutiveErrors`. Re-exported from `@linchkit/core/server`.

**adapter-server** — `GET /api/evolution/scheduler-status`, dispatched through the **same CommandLayer permission path** as `/api/evolution/run-cycle` (synthetic `evolution.scheduler_status`, `skipActionSlots`):
- `503` — no CommandLayer (cannot authorize → fail closed)
- `401/403` — canonical `AUTHZ_DENIED` (permission runs *before* anything is reported, so an unauthorized caller can't even learn whether cadence is configured)
- `200 { configured: false }` — cadence disabled
- `200 { configured: true, ...status }` — Date fields as ISO strings

`http-transport` constructs the scheduler before `createServer` and passes it in, so the route reflects the live boot-path instance.

## codex P2 fix — failures were being swallowed

codex caught that the production cadence tick (`createEvolutionCadence`) caught each tenant's cycle error and continued **without re-throwing**, so the scheduler saw every tick as a success and `getStatus()` reported `lastError:null` / `consecutiveErrors:0` even while every scheduled cycle was failing — defeating the surface for the exact "stuck on a repeating error" case. The tick now still attempts every tenant scope (isolation preserved), then **re-throws an aggregate** when any failed; a later all-green tick clears the streak.

## Tests (incl. a real-boot smoke)

- Unit: `getStatus` counters/timestamps/read-only snapshot/error-streak reset.
- Route: permission gate (503 / 403 `AUTHZ_DENIED`), `configured:false`, full shape, ISO serialization, error reflection.
- Cadence wiring: repeated failures surface in `getStatus()`; a clean tick clears the streak (the codex P2 regression test).
- **Smoke (`evolution-status-smoke.test.ts`)** — drives the endpoint through the canonical `createServer(...)` factory (the same assembly `http-transport` boots), advances the scheduler with `runOnce()`, reads the live state back over HTTP, and asserts the read **fails closed** (`PERMISSION.MIDDLEWARE_MISSING`) when no permission middleware is present. No mock seams, so a broken wiring can't pass.

Full `bun run test` green. typecheck + biome clean. codex: clean after the P2 fix (R2).

Safety: read-only liveness only — no mutation, the permission slot is never skipped, and it never auto-approves/graduates/commits anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduler observability via a new `getStatus()` method providing read-only snapshots of run state, tick counters, timestamps, durations, and error tracking.
  * Introduced HTTP endpoint `GET /api/evolution/scheduler-status` for monitoring scheduler liveness, with permission-based access control.
  * Enhanced error tracking to include consecutive error counts and last error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->