### PR TITLE
feat(adapter-ui): scheduler status panel on the Evolution page (Spec 55 §7)

### DIFF
--- a/.changeset/scheduler-status-ui-panel.md
+++ b/.changeset/scheduler-status-ui-panel.md
@@ -1,0 +1,20 @@
+---
+"@linchkit/cap-adapter-ui": minor
+---
+
+Add a read-only **scheduler status panel** to the Evolution admin page (Spec 55
+§7) so an operator can see the autonomous cadence loop's heartbeat at a glance.
+
+The panel polls `GET /api/evolution/scheduler-status` (the sibling backend PR) and
+renders a status pill — Running / Idle / Disabled / Unauthorized / Unavailable —
+plus the clamped interval (humanized), ticks completed/started, the last tick time
+and duration, and an amber error-streak row (`lastError` + consecutive count) when
+the cadence is stuck failing. It auto-polls on a configurable interval with an
+`AbortController` that cancels the in-flight request on unmount, and offers a
+manual refresh. It is strictly read-only — it never triggers a mutation.
+
+The client (`lib/evolution-api.ts`) mirrors the wire contract locally (the UI never
+imports the server/core runtime) and returns a discriminated result so each
+outcome (configured / unconfigured / denied / error) is rendered distinctly
+instead of thrown. Pure data-shaping helpers (ms humanizer, response→view
+reducer, timestamp formatter) are unit-tested without a DOM.

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/scheduler-status-api.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/scheduler-status-api.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the `fetchSchedulerStatus` client.
+ *
+ * Maps the server's JSON envelope (200 configured/unconfigured + 401/403 + 503
+ * + other non-2xx + transport error / invalid JSON) onto a discriminated result
+ * the UI renders. We inject a stub `fetch` via `fetchImpl` so the assertions
+ * never rely on a GLOBAL fetch mock (which would leak across the batched suite).
+ * Mirrors `proposal-graduate-api.test.ts`.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+// Minimal localStorage shim — the client calls getAuthHeaders() which reads
+// localStorage. The bun test runner has no DOM; mirror proposal-graduate-api.test.ts.
+const store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+      key: (index: number) => [...store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import { fetchSchedulerStatus } from "../src/lib/evolution-api";
+
+/** Build a JSON Response with a given status + body. */
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** A `fetch` stub that always returns the given response and records the call. */
+function stubFetch(response: Response | (() => Response | Promise<Response>)): {
+  fetchImpl: typeof fetch;
+  calls: Array<{ url: string; init?: RequestInit }>;
+} {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return typeof response === "function" ? await response() : response;
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("fetchSchedulerStatus client", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("GETs the scheduler-status endpoint", async () => {
+    const { fetchImpl, calls } = stubFetch(
+      jsonResponse(200, { success: true, data: { configured: false } }),
+    );
+    await fetchSchedulerStatus({ fetchImpl });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe("/api/evolution/scheduler-status");
+    // No explicit method → defaults to GET (read-only).
+    expect(calls[0]?.init?.method).toBeUndefined();
+  });
+
+  test("maps 200 unconfigured to ok / configured:false", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, { success: true, data: { configured: false } }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.status.configured).toBe(false);
+  });
+
+  test("maps 200 configured to ok with all fields", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, {
+        success: true,
+        data: {
+          configured: true,
+          running: true,
+          intervalMs: 300000,
+          ticksStarted: 5,
+          ticksCompleted: 4,
+          lastTickStartedAt: "2026-06-08T10:00:00.000Z",
+          lastTickCompletedAt: "2026-06-08T10:00:01.000Z",
+          lastTickDurationMs: 1000,
+          lastError: null,
+          consecutiveErrors: 0,
+        },
+      }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok" || !result.status.configured) return;
+    expect(result.status.running).toBe(true);
+    expect(result.status.intervalMs).toBe(300000);
+    expect(result.status.ticksStarted).toBe(5);
+    expect(result.status.ticksCompleted).toBe(4);
+    expect(result.status.lastTickCompletedAt).toBe("2026-06-08T10:00:01.000Z");
+    expect(result.status.lastTickDurationMs).toBe(1000);
+    expect(result.status.consecutiveErrors).toBe(0);
+  });
+
+  test("defaults missing fields on a configured:true body", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(200, { success: true, data: { configured: true } }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok" || !result.status.configured) return;
+    expect(result.status.running).toBe(false);
+    expect(result.status.intervalMs).toBe(0);
+    expect(result.status.ticksStarted).toBe(0);
+    expect(result.status.ticksCompleted).toBe(0);
+    expect(result.status.lastTickStartedAt).toBeNull();
+    expect(result.status.lastTickCompletedAt).toBeNull();
+    expect(result.status.lastTickDurationMs).toBeNull();
+    expect(result.status.lastError).toBeNull();
+    expect(result.status.consecutiveErrors).toBe(0);
+  });
+
+  test("treats a missing data block as unconfigured", async () => {
+    const { fetchImpl } = stubFetch(jsonResponse(200, { success: true }));
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.status.configured).toBe(false);
+  });
+
+  test("maps 401 to denied", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(401, { success: false, error: { code: "AUTHZ_DENIED", message: "denied" } }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("denied");
+  });
+
+  test("maps 403 to denied", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(403, { success: false, error: { code: "AUTHZ_DENIED", message: "denied" } }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("denied");
+  });
+
+  test("maps 503 (command layer not configured) to error with the message", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(503, {
+        success: false,
+        error: { code: "SERVICE.UNAVAILABLE", message: "Command layer not configured." },
+      }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("Command layer not configured.");
+  });
+
+  test("maps another non-2xx to error with the message", async () => {
+    const { fetchImpl } = stubFetch(
+      jsonResponse(500, { success: false, error: { message: "boom" } }),
+    );
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("boom");
+  });
+
+  test("maps a transport throw to error", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.message).toBe("network down");
+  });
+
+  test("maps invalid JSON on a 200 to error", async () => {
+    const { fetchImpl } = stubFetch(new Response("not json", { status: 200 }));
+    const result = await fetchSchedulerStatus({ fetchImpl });
+    expect(result.kind).toBe("error");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/scheduler-status-panel-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/scheduler-status-panel-helpers.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the pure helpers behind SchedulerStatusPanel: the ms humanizer, the
+ * response → view-state reducer, the error-streak predicate, and the timestamp
+ * formatter. No DOM / render — logic only, mirroring the repo's UI test style.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  formatTimestamp,
+  hasErrorStreak,
+  humanizeMs,
+  toSchedulerStatusView,
+} from "../src/components/scheduler-status-panel-helpers";
+import type { SchedulerStatusResult } from "../src/lib/evolution-api";
+
+// ── humanizeMs ─────────────────────────────────────────────
+
+describe("humanizeMs", () => {
+  test("returns a dash for null / undefined / negative / non-finite", () => {
+    expect(humanizeMs(null)).toBe("—");
+    expect(humanizeMs(undefined)).toBe("—");
+    expect(humanizeMs(-1)).toBe("—");
+    expect(humanizeMs(Number.NaN)).toBe("—");
+    expect(humanizeMs(Number.POSITIVE_INFINITY)).toBe("—");
+  });
+
+  test("formats sub-second as ms", () => {
+    expect(humanizeMs(0)).toBe("0ms");
+    expect(humanizeMs(250)).toBe("250ms");
+    expect(humanizeMs(999)).toBe("999ms");
+  });
+
+  test("formats sub-minute as seconds, dropping a trailing .0", () => {
+    expect(humanizeMs(1000)).toBe("1s");
+    expect(humanizeMs(1500)).toBe("1.5s");
+    expect(humanizeMs(59000)).toBe("59s");
+  });
+
+  test("formats minutes, with optional remaining seconds", () => {
+    expect(humanizeMs(60000)).toBe("1m");
+    expect(humanizeMs(300000)).toBe("5m");
+    expect(humanizeMs(90000)).toBe("1m 30s");
+  });
+
+  test("formats hours, with optional remaining minutes", () => {
+    expect(humanizeMs(3600000)).toBe("1h");
+    expect(humanizeMs(5400000)).toBe("1h 30m");
+  });
+});
+
+// ── toSchedulerStatusView ──────────────────────────────────
+
+describe("toSchedulerStatusView", () => {
+  test("disabled tone for ok + configured:false", () => {
+    const result: SchedulerStatusResult = { kind: "ok", status: { configured: false } };
+    const view = toSchedulerStatusView(result);
+    expect(view.tone).toBe("disabled");
+    expect(view.labelDefault).toBe("Disabled");
+    expect(view.detail).toBeUndefined();
+  });
+
+  test("running tone for ok + configured:true + running:true", () => {
+    const result: SchedulerStatusResult = {
+      kind: "ok",
+      status: {
+        configured: true,
+        running: true,
+        intervalMs: 300000,
+        ticksStarted: 3,
+        ticksCompleted: 3,
+        lastTickStartedAt: "2026-06-08T10:00:00.000Z",
+        lastTickCompletedAt: "2026-06-08T10:00:01.000Z",
+        lastTickDurationMs: 1000,
+        lastError: null,
+        consecutiveErrors: 0,
+      },
+    };
+    const view = toSchedulerStatusView(result);
+    expect(view.tone).toBe("running");
+    expect(view.labelDefault).toBe("Running");
+    expect(view.detail?.intervalMs).toBe(300000);
+    expect(view.detail?.ticksCompleted).toBe(3);
+  });
+
+  test("idle tone for ok + configured:true + running:false", () => {
+    const result: SchedulerStatusResult = {
+      kind: "ok",
+      status: {
+        configured: true,
+        running: false,
+        intervalMs: 300000,
+        ticksStarted: 0,
+        ticksCompleted: 0,
+        lastTickStartedAt: null,
+        lastTickCompletedAt: null,
+        lastTickDurationMs: null,
+        lastError: null,
+        consecutiveErrors: 0,
+      },
+    };
+    const view = toSchedulerStatusView(result);
+    expect(view.tone).toBe("idle");
+    expect(view.labelDefault).toBe("Idle");
+    expect(view.detail?.running).toBe(false);
+  });
+
+  test("denied tone for a denied result", () => {
+    const view = toSchedulerStatusView({ kind: "denied" });
+    expect(view.tone).toBe("denied");
+    expect(view.labelDefault).toBe("Unauthorized");
+    expect(view.detail).toBeUndefined();
+  });
+
+  test("error tone carries the message", () => {
+    const view = toSchedulerStatusView({ kind: "error", message: "Command layer not configured." });
+    expect(view.tone).toBe("error");
+    expect(view.labelDefault).toBe("Unavailable");
+    expect(view.message).toBe("Command layer not configured.");
+  });
+});
+
+// ── hasErrorStreak ─────────────────────────────────────────
+
+describe("hasErrorStreak", () => {
+  const base = {
+    running: false,
+    intervalMs: 0,
+    ticksStarted: 0,
+    ticksCompleted: 0,
+    lastTickStartedAt: null,
+    lastTickCompletedAt: null,
+    lastTickDurationMs: null,
+    lastError: null,
+  };
+
+  test("false for undefined detail", () => {
+    expect(hasErrorStreak(undefined)).toBe(false);
+  });
+
+  test("false when consecutiveErrors is 0", () => {
+    expect(hasErrorStreak({ ...base, consecutiveErrors: 0 })).toBe(false);
+  });
+
+  test("true when consecutiveErrors > 0", () => {
+    expect(hasErrorStreak({ ...base, consecutiveErrors: 2, lastError: "boom" })).toBe(true);
+  });
+});
+
+// ── formatTimestamp ────────────────────────────────────────
+
+describe("formatTimestamp", () => {
+  test("returns a dash for null / undefined / empty / invalid", () => {
+    expect(formatTimestamp(null)).toBe("—");
+    expect(formatTimestamp(undefined)).toBe("—");
+    expect(formatTimestamp("")).toBe("—");
+    expect(formatTimestamp("not-a-date")).toBe("—");
+  });
+
+  test("returns a non-dash localized string for a valid ISO timestamp", () => {
+    const out = formatTimestamp("2026-06-08T10:00:00.000Z");
+    expect(out).not.toBe("—");
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/scheduler-status-panel-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/scheduler-status-panel-helpers.test.ts
@@ -46,6 +46,15 @@ describe("humanizeMs", () => {
     expect(humanizeMs(3600000)).toBe("1h");
     expect(humanizeMs(5400000)).toBe("1h 30m");
   });
+
+  test("carries rounding at unit boundaries (never '60s' / '59m 60s')", () => {
+    // 59.999s must round up to "1m", not "60s".
+    expect(humanizeMs(59_999)).toBe("1m");
+    // 59m 59.999s must carry all the way to "1h", not "59m 60s".
+    expect(humanizeMs(3_599_999)).toBe("1h");
+    // A sub-second-from-the-minute value still floors cleanly.
+    expect(humanizeMs(119_400)).toBe("1m 59s");
+  });
 });
 
 // ── toSchedulerStatusView ──────────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel-helpers.ts
@@ -1,0 +1,148 @@
+/**
+ * Helpers for SchedulerStatusPanel — the cadence-loop heartbeat panel.
+ *
+ * Kept separate from the JSX component so the data-shaping logic (ms humanizer,
+ * status → tone/label mapping, response → view-state reducer) can be unit-tested
+ * without a DOM. The component file imports from here.
+ *
+ * This module never imports from `@linchkit/core` or the server — the wire type
+ * is mirrored locally (see `SchedulerStatus` in `lib/evolution-api.ts`).
+ */
+
+import type { SchedulerStatusResult } from "@/lib/evolution-api";
+
+// ── View tone ──────────────────────────────────────────────
+
+/** Visual tone for the status pill. */
+export type SchedulerTone = "running" | "idle" | "disabled" | "denied" | "error";
+
+/**
+ * Compact view model the panel renders. Derived from the discriminated
+ * `SchedulerStatusResult` so the JSX stays dumb. Numeric / string fields are
+ * only present in the `running`/`idle` tones (i.e. `configured: true`).
+ */
+export interface SchedulerStatusView {
+  /** Drives the pill colour + label. */
+  tone: SchedulerTone;
+  /** i18n key for the pill label (caller resolves with a fallback default). */
+  labelKey: string;
+  /** Human default for the pill label (paired with `labelKey`). */
+  labelDefault: string;
+  /** Optional one-line message (e.g. error text or denial reason). */
+  message?: string;
+  /** Present only when the scheduler is wired (`configured: true`). */
+  detail?: SchedulerStatusDetail;
+}
+
+/** The numeric / timestamp detail shown when the scheduler is wired. */
+export interface SchedulerStatusDetail {
+  running: boolean;
+  intervalMs: number;
+  ticksStarted: number;
+  ticksCompleted: number;
+  lastTickStartedAt: string | null;
+  lastTickCompletedAt: string | null;
+  lastTickDurationMs: number | null;
+  lastError: string | null;
+  consecutiveErrors: number;
+}
+
+// ── ms humanizer ───────────────────────────────────────────
+
+/**
+ * Humanize a millisecond duration into a compact label (e.g. 300000 → "5m",
+ * 1500 → "1.5s", 90000 → "1m 30s"). Returns "—" for non-finite / negative
+ * input so the UI never shows "NaNms".
+ *
+ * Kept deliberately small: ms → s → m → h. Days are unlikely for a cadence
+ * interval or a tick duration, so they fold into hours.
+ */
+export function humanizeMs(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined || !Number.isFinite(ms) || ms < 0) {
+    return "—";
+  }
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  const totalSeconds = ms / 1000;
+  if (totalSeconds < 60) {
+    // Show one decimal for sub-minute, but drop a trailing ".0".
+    const rounded = Math.round(totalSeconds * 10) / 10;
+    return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}s`;
+  }
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const remSeconds = Math.round(totalSeconds - totalMinutes * 60);
+  if (totalMinutes < 60) {
+    return remSeconds > 0 ? `${totalMinutes}m ${remSeconds}s` : `${totalMinutes}m`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const remMinutes = totalMinutes - hours * 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+}
+
+// ── response → view-state reducer ──────────────────────────
+
+/**
+ * Reduce the discriminated `SchedulerStatusResult` into the flat view model the
+ * panel renders. Pure — no fetching, no side effects. The component calls this
+ * once per fetch result and renders the returned `SchedulerStatusView`.
+ */
+export function toSchedulerStatusView(result: SchedulerStatusResult): SchedulerStatusView {
+  switch (result.kind) {
+    case "ok": {
+      const s = result.status;
+      if (!s.configured) {
+        return {
+          tone: "disabled",
+          labelKey: "evolution.scheduler.pill.disabled",
+          labelDefault: "Disabled",
+        };
+      }
+      return {
+        tone: s.running ? "running" : "idle",
+        labelKey: s.running ? "evolution.scheduler.pill.running" : "evolution.scheduler.pill.idle",
+        labelDefault: s.running ? "Running" : "Idle",
+        detail: {
+          running: s.running,
+          intervalMs: s.intervalMs,
+          ticksStarted: s.ticksStarted,
+          ticksCompleted: s.ticksCompleted,
+          lastTickStartedAt: s.lastTickStartedAt,
+          lastTickCompletedAt: s.lastTickCompletedAt,
+          lastTickDurationMs: s.lastTickDurationMs,
+          lastError: s.lastError,
+          consecutiveErrors: s.consecutiveErrors,
+        },
+      };
+    }
+    case "denied":
+      return {
+        tone: "denied",
+        labelKey: "evolution.scheduler.pill.denied",
+        labelDefault: "Unauthorized",
+      };
+    case "error":
+      return {
+        tone: "error",
+        labelKey: "evolution.scheduler.pill.error",
+        labelDefault: "Unavailable",
+        message: result.message,
+      };
+  }
+}
+
+/** True when the detail block carries an active error streak worth surfacing. */
+export function hasErrorStreak(detail: SchedulerStatusDetail | undefined): boolean {
+  return !!detail && detail.consecutiveErrors > 0;
+}
+
+/**
+ * Localize an ISO timestamp for display, returning "—" for null/empty/invalid
+ * input so the UI never shows "Invalid Date".
+ */
+export function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel-helpers.ts
@@ -68,10 +68,17 @@ export function humanizeMs(ms: number | null | undefined): string {
   if (totalSeconds < 60) {
     // Show one decimal for sub-minute, but drop a trailing ".0".
     const rounded = Math.round(totalSeconds * 10) / 10;
-    return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}s`;
+    if (rounded < 60) {
+      return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}s`;
+    }
+    // rounded up to exactly 60.0s → fall through so it renders as "1m", not "60s".
   }
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const remSeconds = Math.round(totalSeconds - totalMinutes * 60);
+  // Round to whole seconds FIRST, then decompose — flooring minutes before
+  // rounding the remainder can carry to 60 and render impossible labels like
+  // "59m 60s" (e.g. 3_599_999ms) or "60s" (e.g. 59_999ms).
+  const roundedSeconds = Math.round(totalSeconds);
+  const totalMinutes = Math.floor(roundedSeconds / 60);
+  const remSeconds = roundedSeconds - totalMinutes * 60;
   if (totalMinutes < 60) {
     return remSeconds > 0 ? `${totalMinutes}m ${remSeconds}s` : `${totalMinutes}m`;
   }

--- a/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel.tsx
@@ -107,9 +107,13 @@ export function SchedulerStatusPanel({
   // older response could overwrite a newer heartbeat. Only the most recently
   // STARTED request is allowed to commit its result.
   const requestIdRef = useRef(0);
+  // True while a request is outstanding — lets the poll skip a tick instead of
+  // piling up overlapping requests (see the interval below).
+  const inFlightRef = useRef(false);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     const requestId = ++requestIdRef.current;
+    inFlightRef.current = true;
     setLoading(true);
     try {
       const next = await fetchSchedulerStatus({ fetchImpl: fetchImplRef.current, signal });
@@ -118,7 +122,12 @@ export function SchedulerStatusPanel({
       if (signal?.aborted || requestId !== requestIdRef.current) return;
       setResult(next);
     } finally {
-      if (!signal?.aborted && requestId === requestIdRef.current) setLoading(false);
+      // Only the latest request clears the shared flags — an older, superseded
+      // request finishing late must not flip them while the newer one is pending.
+      if (requestId === requestIdRef.current) {
+        inFlightRef.current = false;
+        if (!signal?.aborted) setLoading(false);
+      }
     }
   }, []);
 
@@ -130,7 +139,13 @@ export function SchedulerStatusPanel({
 
     let timer: ReturnType<typeof setInterval> | undefined;
     if (pollIntervalMs > 0) {
-      timer = setInterval(() => void load(controller.signal), pollIntervalMs);
+      timer = setInterval(() => {
+        // Skip this tick if a request is still outstanding. Otherwise, when the
+        // endpoint is slower than the interval, every poll would supersede the
+        // previous one and the panel could never commit a fresh status.
+        if (inFlightRef.current) return;
+        void load(controller.signal);
+      }, pollIntervalMs);
     }
 
     return () => {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel.tsx
@@ -102,13 +102,23 @@ export function SchedulerStatusPanel({
   const fetchImplRef = useRef(fetchImpl);
   fetchImplRef.current = fetchImpl;
 
+  // Monotonic request id. A poll and a manual refresh (or two slow polls) can be
+  // in flight at once; without this guard they commit in COMPLETION order, so an
+  // older response could overwrite a newer heartbeat. Only the most recently
+  // STARTED request is allowed to commit its result.
+  const requestIdRef = useRef(0);
+
   const load = useCallback(async (signal?: AbortSignal) => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     try {
       const next = await fetchSchedulerStatus({ fetchImpl: fetchImplRef.current, signal });
-      if (!signal?.aborted) setResult(next);
+      // Drop a stale response: aborted (unmount/interval change) or superseded by
+      // a newer load() that started after this one.
+      if (signal?.aborted || requestId !== requestIdRef.current) return;
+      setResult(next);
     } finally {
-      if (!signal?.aborted) setLoading(false);
+      if (!signal?.aborted && requestId === requestIdRef.current) setLoading(false);
     }
   }, []);
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/scheduler-status-panel.tsx
@@ -1,0 +1,262 @@
+/**
+ * SchedulerStatusPanel — read-only heartbeat for the autonomous-evolution
+ * cadence loop.
+ *
+ * Polls `GET /api/evolution/scheduler-status` and visualizes whether the
+ * cadence scheduler is alive: a status pill (Running / Idle / Disabled /
+ * Unauthorized / Unavailable), the tick interval, ticks completed/started, the
+ * last tick time + duration, and — on an error streak — a warning row with the
+ * last error and consecutive-error count.
+ *
+ * Purely presentational + a fetch hook. It NEVER mutates anything: the only
+ * network call is the read-only status GET, triggered on mount, on an optional
+ * poll interval, and by a manual refresh button.
+ */
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@linchkit/ui-kit/components";
+import {
+  ActivityIcon,
+  AlertTriangleIcon,
+  CheckCircle2,
+  Loader2Icon,
+  PauseCircleIcon,
+  PowerOffIcon,
+  RefreshCwIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { fetchSchedulerStatus, type SchedulerStatusResult } from "@/lib/evolution-api";
+import {
+  formatTimestamp,
+  hasErrorStreak,
+  humanizeMs,
+  type SchedulerTone,
+  toSchedulerStatusView,
+} from "./scheduler-status-panel-helpers";
+
+// ── Pill tone → classes + icon ─────────────────────────────
+
+const TONE_PILL_CLASS: Record<SchedulerTone, string> = {
+  running: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  idle: "border-border bg-muted text-muted-foreground",
+  disabled: "border-border bg-muted text-muted-foreground",
+  denied: "border-destructive/30 bg-destructive/10 text-destructive",
+  error: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400",
+};
+
+const TONE_ICON: Record<SchedulerTone, typeof ActivityIcon> = {
+  running: ActivityIcon,
+  idle: PauseCircleIcon,
+  disabled: PowerOffIcon,
+  denied: XCircleIcon,
+  error: AlertTriangleIcon,
+};
+
+// ── Props ──────────────────────────────────────────────────
+
+export interface SchedulerStatusPanelProps {
+  /**
+   * Auto-poll interval in ms. When > 0, the panel refetches on a timer and
+   * cleans the timer up on unmount. Defaults to 0 (no auto-poll — manual only).
+   */
+  pollIntervalMs?: number;
+  /** Optional fetch override (tests inject a stub; never used in production). */
+  fetchImpl?: typeof fetch;
+  /** Optional className for the outer Card. */
+  className?: string;
+}
+
+// ── A single detail row ────────────────────────────────────
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────
+
+export function SchedulerStatusPanel({
+  pollIntervalMs = 0,
+  fetchImpl,
+  className,
+}: SchedulerStatusPanelProps) {
+  const { t } = useTranslation();
+  const [result, setResult] = useState<SchedulerStatusResult | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Keep the latest fetchImpl in a ref so the polling effect never re-subscribes
+  // when a parent passes a fresh function identity each render.
+  const fetchImplRef = useRef(fetchImpl);
+  fetchImplRef.current = fetchImpl;
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    try {
+      const next = await fetchSchedulerStatus({ fetchImpl: fetchImplRef.current, signal });
+      if (!signal?.aborted) setResult(next);
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  // Initial load + optional poll. One AbortController per effect run cancels any
+  // in-flight request on unmount / interval change.
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+
+    let timer: ReturnType<typeof setInterval> | undefined;
+    if (pollIntervalMs > 0) {
+      timer = setInterval(() => void load(controller.signal), pollIntervalMs);
+    }
+
+    return () => {
+      controller.abort();
+      if (timer) clearInterval(timer);
+    };
+  }, [load, pollIntervalMs]);
+
+  const view = result ? toSchedulerStatusView(result) : null;
+  const tone: SchedulerTone = view?.tone ?? "idle";
+  const PillIcon = TONE_ICON[tone];
+  const detail = view?.detail;
+
+  return (
+    <Card className={className} data-testid="scheduler-status-panel">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              <ActivityIcon className="h-4 w-4 text-muted-foreground" />
+              {t("evolution.scheduler.title", "Cadence Scheduler")}
+            </CardTitle>
+            <CardDescription className="mt-1">
+              {t(
+                "evolution.scheduler.description",
+                "Read-only heartbeat of the autonomous evolution loop.",
+              )}
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {view && (
+              <Badge
+                variant="outline"
+                className={`gap-1 text-[11px] ${TONE_PILL_CLASS[tone]}`}
+                data-testid="scheduler-status-pill"
+                data-tone={tone}
+              >
+                <PillIcon className="h-3 w-3" />
+                {t(view.labelKey, view.labelDefault)}
+              </Badge>
+            )}
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={() => void load()}
+              disabled={loading}
+              aria-label={t("common.refresh", "Refresh")}
+              data-testid="scheduler-status-refresh"
+            >
+              {loading ? (
+                <Loader2Icon className="h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCwIcon className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {/* Error / denial message (non-configured states). */}
+        {view?.tone === "error" && view.message && (
+          <div className="flex items-center gap-2 rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+            <AlertTriangleIcon className="size-4 shrink-0" />
+            <span>{view.message}</span>
+          </div>
+        )}
+        {view?.tone === "denied" && (
+          <div className="flex items-center gap-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <XCircleIcon className="size-4 shrink-0" />
+            <span>
+              {t("evolution.scheduler.deniedHint", "Not authorized to view scheduler status.")}
+            </span>
+          </div>
+        )}
+        {view?.tone === "disabled" && (
+          <div className="flex items-center gap-2 rounded-md border border-dashed bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+            <PowerOffIcon className="size-4 shrink-0" />
+            <span>
+              {t(
+                "evolution.scheduler.disabledHint",
+                "Cadence loop is not wired in this environment.",
+              )}
+            </span>
+          </div>
+        )}
+
+        {/* Wired-scheduler detail block. */}
+        {detail && (
+          <div className="space-y-2">
+            <DetailRow
+              label={t("evolution.scheduler.interval", "Interval")}
+              value={humanizeMs(detail.intervalMs)}
+            />
+            <DetailRow
+              label={t("evolution.scheduler.ticks", "Ticks (completed / started)")}
+              value={`${detail.ticksCompleted} / ${detail.ticksStarted}`}
+            />
+            <DetailRow
+              label={t("evolution.scheduler.lastTick", "Last tick")}
+              value={formatTimestamp(detail.lastTickCompletedAt ?? detail.lastTickStartedAt)}
+            />
+            <DetailRow
+              label={t("evolution.scheduler.lastDuration", "Last duration")}
+              value={humanizeMs(detail.lastTickDurationMs)}
+            />
+
+            {/* Error-streak warning row. */}
+            {hasErrorStreak(detail) ? (
+              <div
+                className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400"
+                data-testid="scheduler-error-streak"
+              >
+                <AlertTriangleIcon className="size-4 shrink-0 mt-0.5" />
+                <div className="min-w-0">
+                  <p className="font-medium">
+                    {t("evolution.scheduler.errorStreak", "Consecutive errors: {{count}}", {
+                      count: detail.consecutiveErrors,
+                    })}
+                  </p>
+                  {detail.lastError && (
+                    <p className="mt-0.5 break-words font-mono text-[12px] opacity-90">
+                      {detail.lastError}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <CheckCircle2 className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+                {t("evolution.scheduler.healthy", "No recent errors")}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/evolution-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/evolution-api.ts
@@ -1,0 +1,172 @@
+/**
+ * API client for the autonomous-evolution cadence loop's read-only surfaces.
+ *
+ * Today this is the scheduler-status heartbeat (`GET /api/evolution/scheduler-status`).
+ * The wire types are mirrored locally — the UI never imports the server/core
+ * runtime — and every call returns a discriminated result so the caller renders
+ * each outcome (configured/unconfigured/denied/error) distinctly instead of
+ * catching thrown errors. Mirrors the conventions in `lib/proposal-api.ts`.
+ */
+
+// ── Auth header helper (reuse from api.ts / proposal-api.ts pattern) ──────
+
+function getAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem("linchkit:token");
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return {};
+}
+
+// ── Wire type ──────────────────────────────────────────────
+
+/**
+ * Self-contained wire shape of `GET /api/evolution/scheduler-status`'s `data`,
+ * mirroring the backend contract (a sibling PR owns the endpoint). Discriminated
+ * on `configured`:
+ *
+ *  - `{ configured: false }` — cadence disabled (no scheduler wired).
+ *  - `{ configured: true, ... }` — scheduler wired; `running` reflects whether
+ *    the cadence loop is currently ticking. `Date` fields arrive as ISO strings
+ *    (serialized server-side) so consumers never call `Date` methods blindly.
+ *
+ * NOT imported from `@linchkit/core` on purpose — the UI keeps its own mirror.
+ */
+export type SchedulerStatus =
+  | { configured: false }
+  | {
+      configured: true;
+      running: boolean;
+      intervalMs: number;
+      ticksStarted: number;
+      ticksCompleted: number;
+      lastTickStartedAt: string | null;
+      lastTickCompletedAt: string | null;
+      lastTickDurationMs: number | null;
+      lastError: string | null;
+      consecutiveErrors: number;
+    };
+
+/**
+ * Discriminated result of `fetchSchedulerStatus`.
+ *
+ *  - `{ kind: "ok" }` — 200; `status` is the discriminated `SchedulerStatus`
+ *    (which itself distinguishes configured vs. unconfigured).
+ *  - `{ kind: "denied" }` — 401 / 403 (AUTHZ_DENIED).
+ *  - `{ kind: "error" }` — 503 (command layer not configured) / other non-2xx /
+ *    transport error / invalid JSON. `message` carries a user-friendly reason.
+ */
+export type SchedulerStatusResult =
+  | { kind: "ok"; status: SchedulerStatus }
+  | { kind: "denied" }
+  | { kind: "error"; message: string };
+
+/** Shape of the `scheduler-status` JSON envelope. Local mirror of the wire contract. */
+interface SchedulerStatusWireResponse {
+  success?: boolean;
+  data?: Partial<{
+    configured: boolean;
+    running: boolean;
+    intervalMs: number;
+    ticksStarted: number;
+    ticksCompleted: number;
+    lastTickStartedAt: string | null;
+    lastTickCompletedAt: string | null;
+    lastTickDurationMs: number | null;
+    lastError: string | null;
+    consecutiveErrors: number;
+  }>;
+  error?: { code?: string; message?: string };
+}
+
+/** Best-effort extraction of the structured error message from a JSON body. */
+async function readErrorMessage(res: Response): Promise<string | undefined> {
+  try {
+    const json = (await res.json()) as { error?: { message?: string }; message?: string };
+    return json.error?.message ?? json.message;
+  } catch {
+    // Body was empty / non-JSON — caller falls back to its own message.
+    return undefined;
+  }
+}
+
+/** Normalize a possibly-partial wire `data` block into a typed `SchedulerStatus`. */
+function toSchedulerStatus(data: SchedulerStatusWireResponse["data"]): SchedulerStatus {
+  if (data?.configured !== true) {
+    return { configured: false };
+  }
+  return {
+    configured: true,
+    running: data.running ?? false,
+    intervalMs: data.intervalMs ?? 0,
+    ticksStarted: data.ticksStarted ?? 0,
+    ticksCompleted: data.ticksCompleted ?? 0,
+    lastTickStartedAt: data.lastTickStartedAt ?? null,
+    lastTickCompletedAt: data.lastTickCompletedAt ?? null,
+    lastTickDurationMs: data.lastTickDurationMs ?? null,
+    lastError: data.lastError ?? null,
+    consecutiveErrors: data.consecutiveErrors ?? 0,
+  };
+}
+
+// ── API call ───────────────────────────────────────────────
+
+/**
+ * Read the cadence loop's scheduler status (read-only — never mutates).
+ *
+ * Wire contract (GET /api/evolution/scheduler-status):
+ *   200 → { success: true, data: { configured: false } }
+ *       | { success: true, data: { configured: true, running, intervalMs, ... } }
+ *   401/403 → AUTHZ_DENIED (mapped to `denied`)
+ *   503 → command layer not configured (mapped to `error`)
+ *   other non-2xx / transport error / invalid JSON → `error`
+ *
+ * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
+ * global mock across the batched suite; `signal` allows the caller to cancel an
+ * in-flight poll on unmount.
+ */
+export async function fetchSchedulerStatus(
+  opts: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
+): Promise<SchedulerStatusResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  let res: Response;
+  try {
+    res = await doFetch("/api/evolution/scheduler-status", {
+      headers: getAuthHeaders(),
+      signal: opts.signal,
+    });
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : "Failed to load scheduler status",
+    };
+  }
+
+  // 401 / 403 — access denied.
+  if (res.status === 401 || res.status === 403) {
+    return { kind: "denied" };
+  }
+
+  // 503 (command layer not configured) / other non-2xx — surface an error.
+  if (!res.ok) {
+    return {
+      kind: "error",
+      message: (await readErrorMessage(res)) ?? "Failed to load scheduler status",
+    };
+  }
+
+  let json: SchedulerStatusWireResponse;
+  try {
+    json = (await res.json()) as SchedulerStatusWireResponse;
+  } catch {
+    return { kind: "error", message: "Scheduler status returned an invalid response" };
+  }
+
+  // A `null` body is valid JSON but not a usable envelope — guard before reading
+  // `.data` so this can't throw an unhandled TypeError outside the catch above.
+  if (!json || typeof json !== "object") {
+    return { kind: "error", message: "Scheduler status returned an invalid response" };
+  }
+
+  return { kind: "ok", status: toSchedulerStatus(json.data) };
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/evolution-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/evolution-api.ts
@@ -11,6 +11,11 @@
 // ── Auth header helper (reuse from api.ts / proposal-api.ts pattern) ──────
 
 function getAuthHeaders(): Record<string, string> {
+  // Guard `localStorage` access: it is absent in non-browser contexts (SSR,
+  // loaders, some test runners), where touching it throws a ReferenceError.
+  if (typeof localStorage === "undefined") {
+    return {};
+  }
   const token = localStorage.getItem("linchkit:token");
   if (token) {
     return { Authorization: `Bearer ${token}` };

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/evolution.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/evolution.tsx
@@ -36,6 +36,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { NlRuleDrafter } from "@/components/nl-rule-drafter";
+import { SchedulerStatusPanel } from "@/components/scheduler-status-panel";
 import {
   type EvolutionEntry,
   fetchEvolutionHistory,
@@ -305,6 +306,10 @@ export function EvolutionPage() {
 
   return (
     <div className="p-4 space-y-4">
+      {/* Read-only heartbeat of the autonomous evolution cadence loop. Auto-polls
+          so the operator can see at a glance whether the scheduler is alive. */}
+      <SchedulerStatusPanel pollIntervalMs={15000} />
+
       {/* "说→有" — draft a governed rule from natural language. The draft enters
           the human-gated review pipeline; this surface never approves/applies. */}
       <NlRuleDrafter />


### PR DESCRIPTION
## What

Add a read-only **scheduler status panel** to the Evolution admin page (`/admin/evolution`) so an operator can see the autonomous cadence loop's heartbeat at a glance — completing the observability story started by the backend endpoint in #508.

## Panel

Polls `GET /api/evolution/scheduler-status` and renders:
- a status pill: **Running** / **Idle** / **Disabled** / **Unauthorized** / **Unavailable**
- humanized interval, ticks completed/started, last tick time + duration
- an amber **error-streak** row (`lastError` + consecutive count) when the cadence is stuck failing — the exact "stuck on a repeating error" signal #508 added to the backend

It auto-polls on a configurable interval and offers a manual refresh. Strictly read-only — it never triggers a mutation.

## Client

`lib/evolution-api.ts` — `fetchSchedulerStatus()` + a self-contained `SchedulerStatus` wire type (the UI never imports the server/core runtime). Returns a discriminated result (`ok` / `denied` / `error`) so each outcome renders distinctly instead of throwing. `fetchImpl` injection keeps tests free of global fetch mocks.

## Robustness (codex iterative review)

- **Out-of-order responses** — a monotonic request-id guard: only the most recently *started* request commits, so a slow poll can't overwrite a newer heartbeat.
- **Latency > poll interval** — the poll *skips a tick while a request is in flight* (`inFlightRef`), so sustained latency can't make overlapping polls supersede each other forever and leave the panel stale.
- **Duration formatting** — `humanizeMs` rounds to whole seconds before decomposing, so boundary values never render impossible labels like `59m 60s` / `60s` (regression-tested).

## Tests

Pure helpers (ms humanizer incl. boundary carries, response→view reducer, timestamp formatter) and the client (200 configured/unconfigured, field defaults, 401/403→denied, 503/non-2xx/transport/invalid-JSON→error) are unit-tested with `bun:test` (no DOM — this repo's UI tests are logic-only). Full `bun run test` green; typecheck + biome clean; codex clean after the hardening rounds.

Depends on #508 (the endpoint), already merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
