### PR TITLE
feat(core): durable materialization quality signal on ProposalChange (G5 Phase 4)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-durable-smoke.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-durable-smoke.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Durable materialization quality signal — REAL server-assembly smoke (G5 Phase 4).
+ *
+ * The sibling `proposal-materialize-api.test.ts` pins the route in isolation with
+ * an injected fake provider and a pass-everything gate. This smoke instead drives
+ * `POST /api/proposals/:id/materialize` through the canonical `createServer(...)`
+ * factory — the SAME assembly `http-transport.ts` boots in production — with:
+ *   - a REAL `createCommandLayer({ executor })` + an allow-all permission slot
+ *     (the materialize dispatch uses `skipActionSlots:true` → fails closed without
+ *     one: `PERMISSION.MIDDLEWARE_MISSING`),
+ *   - a REAL `createCodeGenerationProvider` built from an INJECTED fake `AIService`
+ *     (`configured:true`) whose `complete()` returns syntactically-BROKEN source,
+ *   - the REAL Phase-2 syntax gate (`createSyntaxQualityGate`) that the route mounts
+ *     by default — so the gate genuinely FAILS the generated source.
+ *
+ * The core proof: after the (failing) materialize, a SECOND, separate
+ * `GET /api/proposals/:id` request returns a change that DURABLY carries
+ * `materializationStatus:"failed"` + a non-empty `materializationErrors` array,
+ * and NO `generatedSource`. The signal survives past the transient materialize
+ * response. SAFETY: the proposal stays `draft` (never auto-advanced).
+ *
+ * The route persists into the PROCESS-WIDE shared engine
+ * (`getSharedProposalEngine()`), which survives across suites in the batched
+ * runner, so every fixture is GLOBALLY UNIQUE (module counter + time suffix).
+ *
+ * Dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ * `app.listen(PORT)` is intentionally avoided — a bound socket per suite SEGFAULTS
+ * the batched addons run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AICompletionOptions,
+  AICompletionResult,
+  AIService,
+  CommandLayer,
+  EntityDefinition,
+  ProposalChange,
+} from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  InMemoryExecutionLogger,
+  InMemoryStore,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { getSharedProposalEngine } from "../src/proposal-api";
+import { createServer } from "../src/server";
+
+const BASE = "http://local.test";
+
+/** Syntactically-broken source so the REAL syntax gate fails every attempt. */
+const BROKEN_SOURCE = "export const x = (((;";
+
+const taskSchema: EntityDefinition = {
+  name: "task",
+  label: "Task",
+  fields: { title: { type: "string", required: true, label: "Title" } },
+};
+
+/**
+ * Globally-unique suffix so the process-wide shared engine never collides across
+ * suites/tests in the batched runner.
+ */
+let uid = 0;
+function uniqueSuffix(): string {
+  uid += 1;
+  return `${uid}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Allow-all permission middleware. The materialize route dispatches with
+ * `skipActionSlots:true`, which is fail-closed: the CommandLayer rejects it unless
+ * a permission slot is present. In a real deployment cap-permission provides this;
+ * here a pass-through stands in for "the mutation is authorized".
+ */
+function grantMaterializePermission(commandLayer: CommandLayer): void {
+  commandLayer.use({
+    name: "smoke_allow_materialize",
+    slot: "permission",
+    handler: async (_ctx, next) => {
+      await next();
+    },
+  });
+}
+
+/**
+ * Fake AIService (`configured:true`) whose `complete()` returns broken source as
+ * the completion `content`. The real `createCodeGenerationProvider` reads
+ * `result.content`, so the route's provider yields BROKEN source and the real
+ * syntax gate fails it.
+ */
+function makeBrokenAIService(): AIService {
+  return {
+    configured: true,
+    defaultProvider: "fake",
+    providerNames: ["fake"],
+    async complete(_options: AICompletionOptions): Promise<AICompletionResult> {
+      return {
+        content: BROKEN_SOURCE,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        model: "fake",
+        provider: "fake",
+        duration: 0,
+      };
+    },
+  };
+}
+
+/** Build the REAL server via the canonical factory with a broken AI provider. */
+function buildApp(): { handle: (req: Request) => Promise<Response> } {
+  const store = new InMemoryStore();
+  const executor = createActionExecutor({
+    dataProvider: store,
+    executionLogger: new InMemoryExecutionLogger(),
+  });
+  const commandLayer = createCommandLayer({ executor });
+  grantMaterializePermission(commandLayer);
+  const graphqlSchema = buildGraphQLSchema([taskSchema], {
+    executor,
+    commandLayer,
+    dataProvider: store,
+  });
+  return createServer(graphqlSchema, {
+    executor,
+    commandLayer,
+    aiService: makeBrokenAIService(),
+  });
+}
+
+// ── Response helpers ─────────────────────────────────────────
+
+interface MaterializeJson {
+  success: boolean;
+  data?: {
+    allMaterialized?: boolean;
+    outcomes?: Array<{ changeName: string; status: string; errors?: string[] }>;
+  };
+  error?: { code?: string; message?: string };
+}
+
+interface ProposalGetJson {
+  success: boolean;
+  data?: {
+    status?: string;
+    changes?: ProposalChange[];
+  };
+  error?: { message?: string };
+}
+
+/** Read a response body as text first, then JSON-parse with a descriptive throw. */
+async function readJson<T>(res: Response, label: string): Promise<T> {
+  const body = await res.text();
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    throw new Error(`${label} returned non-JSON (status ${res.status}): ${body.slice(0, 300)}`);
+  }
+}
+
+async function postMaterialize(
+  app: { handle: (req: Request) => Promise<Response> },
+  id: string,
+): Promise<{ status: number; json: MaterializeJson }> {
+  const res = await app.handle(
+    new Request(`${BASE}/api/proposals/${id}/materialize`, { method: "POST" }),
+  );
+  return { status: res.status, json: await readJson<MaterializeJson>(res, "materialize") };
+}
+
+async function getProposal(
+  app: { handle: (req: Request) => Promise<Response> },
+  id: string,
+): Promise<{ status: number; json: ProposalGetJson }> {
+  const res = await app.handle(new Request(`${BASE}/api/proposals/${id}`, { method: "GET" }));
+  return { status: res.status, json: await readJson<ProposalGetJson>(res, "proposal GET") };
+}
+
+describe("POST /api/proposals/:id/materialize — durable failure signal (real createServer)", () => {
+  test("failed materialization durably stamps the change; signal survives a separate GET", async () => {
+    const app = buildApp();
+    const sfx = uniqueSuffix();
+
+    // Seed a DRAFT proposal with one materializable action/create change in the
+    // SAME shared engine the route reads from.
+    const draft = getSharedProposalEngine().createProposal({
+      title: `Durable signal smoke ${sfx}`,
+      description: "Materialization fails the syntax gate; the signal must persist.",
+      author: { type: "ai", id: "pattern-detector", name: "Pattern Detector" },
+      capability: `cap-durable-smoke-${sfx}`,
+      changeType: "minor",
+      changes: [{ target: "action", operation: "create", name: `deduct_inventory_${sfx}` }],
+    });
+    expect(draft.status).toBe("draft");
+
+    // ── 1. Materialize → 200, but generation FAILED the real syntax gate.
+    const mat = await postMaterialize(app, draft.id);
+    expect(mat.status).toBe(200);
+    expect(mat.json.success).toBe(true);
+    expect(mat.json.data?.allMaterialized).toBe(false);
+    const outcome = mat.json.data?.outcomes?.[0];
+    expect(outcome?.status).toBe("failed");
+    expect((outcome?.errors ?? []).length).toBeGreaterThan(0);
+
+    // ── 2. A SECOND, separate GET must show the DURABLE signal on the change.
+    const got = await getProposal(app, draft.id);
+    expect(got.status).toBe(200);
+    expect(got.json.success).toBe(true);
+
+    const change = got.json.data?.changes?.find((c) => c.name === `deduct_inventory_${sfx}`);
+    expect(change).toBeDefined();
+    // The core proof: the failure signal is DURABLE, not just in the transient
+    // materialize response.
+    expect(change?.materializationStatus).toBe("failed");
+    expect(Array.isArray(change?.materializationErrors)).toBe(true);
+    expect((change?.materializationErrors ?? []).length).toBeGreaterThan(0);
+    // No candidate source survived the gate.
+    expect(change?.generatedSource).toBeUndefined();
+
+    // ── SAFETY: the proposal was never auto-advanced past draft.
+    expect(got.json.data?.status).toBe("draft");
+  });
+});

--- a/packages/core/__tests__/proposal-materializer.durable-status.test.ts
+++ b/packages/core/__tests__/proposal-materializer.durable-status.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Proposal materializer — DURABLE materialization quality signal (G5 Phase 4).
+ *
+ * The materializer's `outcomes` array is transient (only in the POST /materialize
+ * response). These tests pin the ADDITIVE durable signal it now stamps onto each
+ * MATERIALIZABLE change so a reviewer reading the PERSISTED proposal can tell a
+ * never-materialized change (undefined) apart from one whose generated source
+ * FAILED the build/syntax gate ("failed" + errors) or succeeded ("materialized").
+ *
+ * No real model is called — the `CodeGenerationProvider` is an injected fake; the
+ * quality gate is either the real syntax gate or a fake returning fixed errors.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { CodeGenerationProvider, QualityGateRunner } from "../src/ai/proposal-code-generator";
+import { createSyntaxQualityGate } from "../src/engine/code-quality-gate";
+import { materializeProposalChanges } from "../src/engine/proposal-materializer";
+import type { ProposalChange, ProposalDefinition } from "../src/types/proposal";
+
+const GOOD = "export const deduct_inventory = 1;";
+const BROKEN = "export const x = (((;"; // never parses → fails the syntax gate
+
+function makeProposal(changes: ProposalChange[]): ProposalDefinition {
+  const now = new Date();
+  return {
+    id: "prop-durable-1",
+    title: "Add deduct_inventory action",
+    description: "When an order is approved, deduct inventory",
+    author: { type: "ai", id: "pattern-detector", name: "Pattern Detector" },
+    capability: "cap-demo",
+    changeType: "minor",
+    changes,
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: [],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+  } as ProposalDefinition;
+}
+
+/** Fake provider that always returns the given source. */
+function makeProvider(source: string): CodeGenerationProvider {
+  return {
+    async generateCode(): Promise<string> {
+      return source;
+    },
+  };
+}
+
+/** Fake quality gate that always reports the given errors (empty = pass). */
+function makeGate(errors: string[]): QualityGateRunner {
+  return { check: async () => errors };
+}
+
+describe("materializeProposalChanges — durable materialization status", () => {
+  test("success → materializationStatus 'materialized', no errors, source set", async () => {
+    const input = makeProposal([
+      { target: "action", operation: "create", name: "deduct_inventory" },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+    });
+
+    const change = result.proposal.changes[0];
+    expect(change?.materializationStatus).toBe("materialized");
+    expect(change?.materializationErrors).toBeUndefined();
+    expect(change?.generatedSource).toBe(GOOD);
+    // Transient outcome shape is unchanged.
+    expect(result.outcomes[0]?.status).toBe("materialized");
+  });
+
+  test("gate failure after retries → status 'failed', errors[], no source", async () => {
+    const input = makeProposal([
+      { target: "action", operation: "create", name: "deduct_inventory" },
+    ]);
+    // Fake gate returns a fixed error so we don't depend on Bun.Transpiler's
+    // exact message — the provider source is also genuinely broken for realism.
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(BROKEN),
+      qualityGate: makeGate(["syntax error: unexpected token"]),
+      maxRetries: 2,
+    });
+
+    const change = result.proposal.changes[0];
+    expect(change?.materializationStatus).toBe("failed");
+    expect(Array.isArray(change?.materializationErrors)).toBe(true);
+    expect((change?.materializationErrors ?? []).length).toBeGreaterThan(0);
+    expect(change?.materializationErrors?.[0]).toContain("syntax error");
+    expect(change?.generatedSource).toBeUndefined();
+    // Transient outcome still reports the same failure (unchanged behavior).
+    expect(result.outcomes[0]?.status).toBe("failed");
+    expect(result.allMaterialized).toBe(false);
+  });
+
+  test("real syntax gate on broken source → 'failed' with non-empty errors", async () => {
+    const input = makeProposal([
+      { target: "action", operation: "create", name: "deduct_inventory" },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(BROKEN),
+      qualityGate: createSyntaxQualityGate(),
+      maxRetries: 2,
+    });
+
+    const change = result.proposal.changes[0];
+    expect(change?.materializationStatus).toBe("failed");
+    expect((change?.materializationErrors ?? []).length).toBeGreaterThan(0);
+    expect(change?.generatedSource).toBeUndefined();
+  });
+
+  test("declarative (entity) change → skipped, both durable fields undefined", async () => {
+    const input = makeProposal([{ target: "entity", operation: "create", name: "invoice" }]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+    });
+
+    const change = result.proposal.changes[0];
+    expect(result.outcomes[0]?.status).toBe("skipped");
+    expect(change?.materializationStatus).toBeUndefined();
+    expect(change?.materializationErrors).toBeUndefined();
+  });
+
+  test("input proposal is NOT mutated — durable signal lands only on the returned copy", async () => {
+    const input = makeProposal([
+      { target: "action", operation: "create", name: "deduct_inventory" },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+    });
+
+    // The returned copy carries the signal…
+    expect(result.proposal.changes[0]?.materializationStatus).toBe("materialized");
+    // …but the original input change was never touched.
+    expect(input.changes[0]?.materializationStatus).toBeUndefined();
+    expect(input.changes[0]?.materializationErrors).toBeUndefined();
+    expect(input.changes[0]?.generatedSource).toBeUndefined();
+  });
+
+  test("re-materialization clears a stale failure signal on success", async () => {
+    // A change carrying a STALE failed signal from a prior attempt.
+    const input = makeProposal([
+      {
+        target: "action",
+        operation: "create",
+        name: "deduct_inventory",
+        materializationStatus: "failed",
+        materializationErrors: ["old error"],
+      },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+    });
+
+    const change = result.proposal.changes[0];
+    expect(change?.materializationStatus).toBe("materialized");
+    expect(change?.materializationErrors).toBeUndefined();
+    expect(change?.generatedSource).toBe(GOOD);
+  });
+});

--- a/packages/core/__tests__/proposal-materializer.durable-status.test.ts
+++ b/packages/core/__tests__/proposal-materializer.durable-status.test.ts
@@ -134,6 +134,37 @@ describe("materializeProposalChanges — durable materialization status", () => 
     expect(change?.materializationErrors).toBeUndefined();
   });
 
+  test("non-materializable change with a STALE signal → skipped, all artifacts cleared", async () => {
+    // A change that was materialized while it was an action (so it carries
+    // generatedSource + a "materialized" status), then edited to a declarative
+    // (non-materializable) target. Re-materialization must CLEAR the stale
+    // source/status/errors even though the change is now skipped — the clear runs
+    // BEFORE the materializable check, so a skipped change never retains stale
+    // materialization artifacts. (Regression for the gemini review on #513.)
+    const input = makeProposal([
+      {
+        target: "entity",
+        operation: "create",
+        name: "invoice",
+        generatedSource: GOOD,
+        materializationStatus: "materialized",
+        materializationErrors: ["stale error"],
+      },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+    });
+
+    const change = result.proposal.changes[0];
+    expect(result.outcomes[0]?.status).toBe("skipped");
+    expect(change?.generatedSource).toBeUndefined();
+    expect(change?.materializationStatus).toBeUndefined();
+    expect(change?.materializationErrors).toBeUndefined();
+  });
+
   test("input proposal is NOT mutated — durable signal lands only on the returned copy", async () => {
     const input = makeProposal([
       { target: "action", operation: "create", name: "deduct_inventory" },

--- a/packages/core/src/engine/proposal-materializer.ts
+++ b/packages/core/src/engine/proposal-materializer.ts
@@ -116,9 +116,12 @@ export async function materializeProposalChanges(
       continue;
     }
 
-    // Clear any pre-existing source up front so a failed (re-)materialization
-    // never leaves STALE code on the change — it is set again only on success.
+    // Clear any pre-existing source AND durable quality signal up front so a
+    // failed (re-)materialization never leaves STALE code or a stale status on
+    // the change — they are set again only as the attempt resolves.
     change.generatedSource = undefined;
+    change.materializationStatus = undefined;
+    change.materializationErrors = undefined;
 
     let lastErrors: string[] = [];
     let materialized = false;
@@ -137,8 +140,18 @@ export async function materializeProposalChanges(
       }
 
       change.generatedSource = source;
+      // Durable success signal: source is attached, errors stay cleared.
+      change.materializationStatus = "materialized";
       materialized = true;
       break;
+    }
+
+    // Durable failure signal: no candidate source survived the gate. Stamp the
+    // status + the final attempt's errors onto the change so a reviewer reading
+    // the PERSISTED proposal sees WHY, independent of the transient outcomes.
+    if (!materialized) {
+      change.materializationStatus = "failed";
+      change.materializationErrors = lastErrors;
     }
 
     outcomes.push(

--- a/packages/core/src/engine/proposal-materializer.ts
+++ b/packages/core/src/engine/proposal-materializer.ts
@@ -106,6 +106,16 @@ export async function materializeProposalChanges(
   const outcomes: MaterializeChangeOutcome[] = [];
 
   for (const change of changes) {
+    // Clear any pre-existing source AND durable quality signal up front — BEFORE
+    // the materializable check — so neither a re-materialization NOR a change
+    // that became non-materializable (its target/operation was edited, e.g.
+    // action→entity or create→delete) ever leaves a STALE source/status/errors
+    // behind. They are set again only as a materializable attempt resolves; a
+    // skipped (declarative) change correctly carries no materialization artifacts.
+    change.generatedSource = undefined;
+    change.materializationStatus = undefined;
+    change.materializationErrors = undefined;
+
     if (!isMaterializable(change)) {
       outcomes.push({
         changeName: change.name,
@@ -115,13 +125,6 @@ export async function materializeProposalChanges(
       });
       continue;
     }
-
-    // Clear any pre-existing source AND durable quality signal up front so a
-    // failed (re-)materialization never leaves STALE code or a stale status on
-    // the change — they are set again only as the attempt resolves.
-    change.generatedSource = undefined;
-    change.materializationStatus = undefined;
-    change.materializationErrors = undefined;
 
     let lastErrors: string[] = [];
     let materialized = false;

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -122,6 +122,26 @@ export interface ProposalChange {
    * PR).
    */
   generatedSource?: string;
+  /**
+   * Durable status of the LAST materialization attempt for this change (G5 Phase 4).
+   *
+   * The materializer stamps this on every MATERIALIZABLE change so a reviewer
+   * reading the PERSISTED proposal (GET /api/proposals/:id) can distinguish a
+   * change that was never materialized (undefined) from one whose generated
+   * source FAILED the build/syntax gate ("failed", reason in
+   * `materializationErrors`) or succeeded ("materialized", source in
+   * `generatedSource`). Unlike the transient POST /materialize `outcomes` array,
+   * this is durable on the change. Declarative / skipped changes leave it
+   * undefined. Candidate signal only — it never auto-advances the proposal.
+   */
+  materializationStatus?: "materialized" | "failed";
+  /**
+   * Build/syntax-gate errors from the final FAILED materialization attempt — set
+   * only when `materializationStatus === "failed"`. Cleared on a successful
+   * (re-)materialization. Lets the human reviewer see WHY a change has no
+   * candidate source without re-running materialization.
+   */
+  materializationErrors?: string[];
 }
 
 // ── Impact analysis ──────────────────────────────────────


### PR DESCRIPTION
## What

Persist a **durable** materialization quality signal on each `ProposalChange`, so the human-gated review loop can see *why* an AI-materialized change has no candidate source — independent of the transient `POST /materialize` response.

## Why (the gap)

When an AI-materialized change failed the build/syntax gate, the failure status + errors lived **only** in the transient `POST /api/proposals/:id/materialize` `outcomes` array. Nothing durable was written onto the change. A reviewer opening the persisted proposal later (`GET /api/proposals/:id`) saw a change with no `generatedSource` and **no way** to distinguish:

- *never materialized* (undefined), from
- *materialized but FAILED the build gate* (and **why**), from
- *succeeded*.

The quality signal "说→有" needs at the human gate was ephemeral. This makes it durable.

## Change (Data Structures First)

Two additive optional fields on `ProposalChange`:

```ts
materializationStatus?: "materialized" | "failed";
materializationErrors?: string[];   // final failed attempt's gate errors
```

The materializer stamps them on every **materializable** change:
- cleared up front (a re-materialization never leaves a stale signal),
- `"materialized"` on success (errors stay cleared),
- `"failed"` + the final attempt's errors on failure.

Declarative / skipped changes leave both undefined. The `outcomes` array behavior is **unchanged**; the input proposal is never mutated (per-change copies). `serializeProposal` already passes `changes` through whole, so `GET /api/proposals/:id` surfaces the signal with **no route change** (verified: the field-picking serializer at proposal-api.ts ~L383 belongs to `/api/evolution/history`, a different route — correctly untouched).

## Safety

Candidate-only signal behind double human review — it never auto-advances, approves, or graduates a proposal. Reinforces "AI Never Modifies Production Directly".

## Tests (feature + its smoke)

- **core unit** (`proposal-materializer.durable-status`): success / gate-failure / **real** syntax gate / declarative-skipped / input-not-mutated / stale-clear (6 cases).
- **real-boot durability smoke**: a fake `AIService` returns syntactically-broken source through the canonical `createServer` assembly → materialize `200` (`allMaterialized:false`), then a **separate** `GET` proves the change durably carries `materializationStatus:"failed"` + non-empty `materializationErrors` and no `generatedSource` — with the SAFETY assertion the proposal stays `draft`.

## Verification

- both test files pass; `bun run check`, `bun run typecheck`, full `bun run test` → green
- codex review → clean (no correctness issue; consistent stamp/clear, outcomes unchanged)

## Follow-up

UI render of the durable badge in the `/admin/proposals` review page (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
