### PR TITLE
feat(adapter-ui): render the durable materialization-failure signal in proposal review

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-review-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-review-helpers.test.ts
@@ -12,6 +12,8 @@ import {
   changeTypeBadgeClass,
   isPending,
   PROPOSAL_STATUS_FILTERS,
+  selectFailedMaterializationChanges,
+  selectSourcedChanges,
   statusBadgeClass,
 } from "../src/pages/proposal-review-helpers";
 
@@ -93,5 +95,57 @@ describe("PROPOSAL_STATUS_FILTERS", () => {
       "rejected",
       "committed",
     ]);
+  });
+});
+
+describe("selectSourcedChanges", () => {
+  test("keeps changes whose generatedSource is a non-empty string", () => {
+    const a = { name: "a", generatedSource: "export const x = 1;" };
+    const b = { name: "b", generatedSource: "  " }; // whitespace only → dropped
+    const c = { name: "c", generatedSource: "" }; // empty → dropped
+    const d = { name: "d" }; // undefined → dropped
+    const result = selectSourcedChanges([a, b, c, d]);
+    expect(result).toEqual([a]);
+  });
+
+  test("returns an empty array when nothing is sourced", () => {
+    expect(selectSourcedChanges([{ name: "x" }, { name: "y", generatedSource: "\t\n" }])).toEqual(
+      [],
+    );
+  });
+
+  test("returns an empty array for an empty input", () => {
+    expect(selectSourcedChanges([])).toEqual([]);
+  });
+});
+
+describe("selectFailedMaterializationChanges", () => {
+  test("keeps only changes whose materializationStatus is 'failed'", () => {
+    const failed = {
+      name: "failed_action",
+      materializationStatus: "failed",
+      materializationErrors: ["TS1005: ';' expected", "Build gate rejected output"],
+    };
+    const ok = { name: "ok_action", materializationStatus: "materialized" };
+    const none = { name: "declarative" }; // never materialized → dropped
+    const result = selectFailedMaterializationChanges([failed, ok, none]);
+    expect(result).toEqual([failed]);
+  });
+
+  test("the returned failed change carries its materializationErrors", () => {
+    const errors = ["error one", "error two"];
+    const [only] = selectFailedMaterializationChanges([
+      { name: "f", materializationStatus: "failed", materializationErrors: errors },
+    ]);
+    expect(only?.materializationErrors).toEqual(errors);
+  });
+
+  test("returns an empty array when nothing failed", () => {
+    expect(
+      selectFailedMaterializationChanges([
+        { name: "a", materializationStatus: "materialized" },
+        { name: "b" },
+      ]),
+    ).toEqual([]);
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
@@ -1,0 +1,70 @@
+/**
+ * FailedMaterializationChanges — renders the DURABLE materialization-failure
+ * signal on the proposal review page.
+ *
+ * When an AI-materialized change FAILS the build/syntax gate it has no
+ * `generatedSource`; instead it carries `materializationStatus:"failed"` plus the
+ * gate errors in `materializationErrors`. The review page otherwise only renders
+ * changes that SUCCEEDED, so a reviewer would never see WHICH changes failed code
+ * generation or WHY. This presentational component surfaces that durably.
+ *
+ * Extracted from `proposal-review.tsx` to keep that page under the file-size
+ * policy. Purely presentational — it never triggers a mutation.
+ */
+
+import { AlertTriangleIcon } from "lucide-react";
+import type { useTranslation } from "react-i18next";
+import type { ProposalChange } from "@/lib/proposal-api";
+
+type TFn = ReturnType<typeof useTranslation>["t"];
+
+export function FailedMaterializationChanges({
+  changes,
+  t,
+}: {
+  changes: readonly ProposalChange[];
+  t: TFn;
+}) {
+  if (changes.length === 0) return null;
+
+  return (
+    <div className="space-y-2" data-testid="materialize-failed-changes">
+      <h5 className="flex items-center gap-1.5 text-xs font-medium text-destructive">
+        <AlertTriangleIcon className="size-3.5" />
+        {t("proposals.materializeFailedChanges", "Generation failed (build gate)")}
+      </h5>
+      <p className="text-[11px] text-muted-foreground">
+        {t(
+          "proposals.materializeFailedHint",
+          "These changes' AI-generated code did not pass the build gate. Review the errors; no candidate source was attached.",
+        )}
+      </p>
+      {changes.map((c) => (
+        <div
+          key={`${c.target}:${c.operation}:${c.name}`}
+          className="rounded-md border border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/30"
+        >
+          <div className="flex items-center gap-2 px-3 py-2 text-xs font-medium">
+            <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-destructive">
+              {t("proposals.materializeFailedBadge", "failed")}
+            </span>
+            <span className="truncate">
+              {c.target}/{c.name}
+            </span>
+          </div>
+          {c.materializationErrors && c.materializationErrors.length > 0 && (
+            <pre className="overflow-x-auto border-t border-red-200 px-3 py-2 text-[11px] leading-relaxed dark:border-red-900">
+              {c.materializationErrors.map((err, i) => (
+                // Errors have no stable id; index keys are fine for this static list.
+                // biome-ignore lint/suspicious/noArrayIndexKey: gate errors are a static, append-only list with no id
+                <code key={i} className="block">
+                  {err}
+                </code>
+              ))}
+            </pre>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
@@ -53,15 +53,19 @@ export function FailedMaterializationChanges({
             </span>
           </div>
           {c.materializationErrors && c.materializationErrors.length > 0 && (
-            <pre className="overflow-x-auto border-t border-red-200 px-3 py-2 text-[11px] leading-relaxed dark:border-red-900">
+            // A <div> (not <pre>) so the JSX indentation between the mapped <code>
+            // elements is not preserved as literal whitespace in the DOM. `font-mono`
+            // keeps the monospace look; `whitespace-pre-wrap` on each line preserves
+            // the error text's own spacing while still wrapping long lines.
+            <div className="overflow-x-auto border-t border-red-200 px-3 py-2 font-mono text-[11px] leading-relaxed dark:border-red-900">
               {c.materializationErrors.map((err, i) => (
                 // Errors have no stable id; index keys are fine for this static list.
                 // biome-ignore lint/suspicious/noArrayIndexKey: gate errors are a static, append-only list with no id
-                <code key={i} className="block">
+                <code key={i} className="block whitespace-pre-wrap">
                   {err}
                 </code>
               ))}
-            </pre>
+            </div>
           )}
         </div>
       ))}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -29,6 +29,15 @@ export interface ProposalChange {
    * after materialization on a draft; still gated by validation + human review.
    */
   generatedSource?: string;
+  /**
+   * Durable status of the last materialization attempt for this change (UI mirror
+   * of the server wire field). "failed" means the AI-generated source did not pass
+   * the build/syntax gate — the reason is in `materializationErrors` and there is
+   * no `generatedSource`. Undefined for changes never materialized or declarative.
+   */
+  materializationStatus?: "materialized" | "failed";
+  /** Build/syntax-gate errors from the final failed attempt (only when status==="failed"). */
+  materializationErrors?: string[];
 }
 
 export interface ProposalImpact {

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-helpers.ts
@@ -61,3 +61,28 @@ export function changeTypeBadgeClass(changeType: string): string {
   };
   return map[changeType] ?? "";
 }
+
+/**
+ * Changes that carry candidate source (materialized successfully). Mirrors the
+ * inline filter the review page used to do, lifted out so it is unit-testable.
+ * Generic + structural so it never imports the page's wire type.
+ */
+export function selectSourcedChanges<T extends { generatedSource?: string }>(
+  changes: readonly T[],
+): T[] {
+  return changes.filter(
+    (c) => typeof c.generatedSource === "string" && c.generatedSource.trim().length > 0,
+  );
+}
+
+/**
+ * Changes whose materialization FAILED the build gate. This is the durable
+ * signal: such a change has no `generatedSource` but carries
+ * `materializationStatus:"failed"` plus the reason in `materializationErrors`.
+ * Surfacing these tells the reviewer WHICH changes failed code generation and WHY.
+ */
+export function selectFailedMaterializationChanges<
+  T extends { materializationStatus?: string; materializationErrors?: string[] },
+>(changes: readonly T[]): T[] {
+  return changes.filter((c) => c.materializationStatus === "failed");
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -33,6 +33,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FailedMaterializationChanges } from "@/components/proposal-failed-changes";
 import { ProposalImpactPreview } from "@/components/proposal-impact-preview";
 import { GraduateOutcome, MaterializeOutcome } from "@/components/proposal-review-outcomes";
 import {
@@ -52,6 +53,8 @@ import {
   isPending,
   PROPOSAL_STATUS_FILTERS,
   type ProposalStatusFilter,
+  selectFailedMaterializationChanges,
+  selectSourcedChanges,
   statusBadgeClass,
 } from "./proposal-review-helpers";
 
@@ -166,10 +169,12 @@ function ProposalCard({
   const graduatable = canGraduate(proposal.status);
   const isDraft = proposal.status === "draft";
   // Prefer the freshly-materialized proposal's changes (if any) over the prop so
-  // generated source shows immediately after a click without a manual refresh.
-  const sourcedChanges: ProposalChange[] = (
-    (mat?.kind === "ok" && mat.proposal ? mat.proposal.changes : proposal.changes) ?? []
-  ).filter((c) => typeof c.generatedSource === "string" && c.generatedSource.trim().length > 0);
+  // generated source / failure signals show immediately after a click without a
+  // manual refresh.
+  const renderedChanges: ProposalChange[] =
+    (mat?.kind === "ok" && mat.proposal ? mat.proposal.changes : proposal.changes) ?? [];
+  const sourcedChanges = selectSourcedChanges(renderedChanges);
+  const failedChanges = selectFailedMaterializationChanges(renderedChanges);
 
   return (
     <Card data-testid="proposal-card">
@@ -353,6 +358,12 @@ function ProposalCard({
             ))}
           </div>
         )}
+
+        {/* Failed materialization (durable signal). Renders changes that FAILED
+            the build gate — no generatedSource, but a `failed` status + the gate
+            errors — so the reviewer sees WHICH changes failed code generation and
+            WHY. Read-only: it never triggers any mutation. */}
+        <FailedMaterializationChanges changes={failedChanges} t={t} />
 
         {/* Approved: graduate → open PR (never merges). Once a PR is opened the
             button + hint are hidden so the success outcome (with the PR link)


### PR DESCRIPTION
## What

Render the **durable materialization-failure signal** (from #513) in the proposal review page (`/admin/proposals`), so a human reviewer sees WHICH AI-materialized changes failed code generation and WHY — directly in the review UI.

## Why

#513 made `materializationStatus:"failed"` + `materializationErrors` durable on a change whose AI-generated code failed the build gate (it has no `generatedSource`). But the review page only rendered changes that SUCCEEDED (those with `generatedSource`), so a reviewer never saw the failures. This surfaces them.

## Change

- **proposal-api.ts** — mirror the two wire fields on the UI `ProposalChange`.
- **proposal-review-helpers.ts** — extract two pure, tested helpers: `selectSourcedChanges` (replaces the inline filter) and `selectFailedMaterializationChanges`.
- **proposal-failed-changes.tsx** (NEW) — presentational component (`data-testid="materialize-failed-changes"`) rendering each failed change's name/target with a destructive badge and its build-gate errors in `<code>`.
- **proposal-review.tsx** — render the failed section after the generated-source block, reading from the freshly-materialized proposal (or the prop).

Purely **read-only** rendering of an already-fetched proposal — no approval / graduate / materialize logic touched. Page stays under the 500-line policy (479) via the extracted component.

## Tests

6 new helper cases (17 total): empty/whitespace/undefined drops, failed-only selection, error-payload preservation. (This project unit-tests pure helpers; no DOM/RTL harness.)

## Verification

- helper test → 17 pass; `bun run check`, `bun run typecheck`, full `bun run test` → green
- codex review → clean ("cleanly adds durable failed-materialization display without breaking existing sourced-change rendering")

## Loop

Completes the durable-signal loop with #513 (persist) and the Phase 4 validation PR (block in prod): generation fails → recorded → **shown to the reviewer here** → blocked at the validation gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
