### PR TITLE
feat(core): Phase 4 validation flags failed-materialization changes (G5)

### DIFF
--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -387,6 +387,42 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(msg).not.toContain(longError);
   });
 
+  test("empty / whitespace error entries are filtered out before joining (no malformed detail)", () => {
+    // A malformed errors array (empty + whitespace-only entries) must not produce
+    // "a; ; b" or a trailing "; ". (Regression for the gemini review on the Phase 4 PR.)
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: ["", "  ", "missing handler", ""],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    const msg = result.warnings[0]?.message ?? "";
+    expect(msg).toContain("Build-gate errors: missing handler");
+    // No empty fragments around the real error.
+    expect(msg).not.toContain("; ;");
+    expect(msg).not.toContain(": ;");
+    expect(msg).not.toMatch(/;\s*$/);
+  });
+
+  test("an all-empty error array produces a finding with NO 'Build-gate errors:' detail", () => {
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: ["", "   "],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.warnings[0]?.code).toBe("GENERATED_SOURCE_FAILED");
+    expect(result.warnings[0]?.message).not.toContain("Build-gate errors");
+  });
+
   test("declarative-only changes (no source, no failed status) still skip (unchanged)", () => {
     const result = validatePhase4({
       changes: [change({}), change({ target: "rule", name: "r1" })],

--- a/packages/core/src/__tests__/engine/validation-phase4.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase4.test.ts
@@ -319,4 +319,158 @@ describe("validatePhase4 — generated-source contract", () => {
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]?.code).toBe("GENERATED_SOURCE_CONTRACT");
   });
+
+  test("a FAILED materialization (no source) is flagged warn-only by default, NOT skipped", () => {
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: ["syntax error: unexpected token at line 3"],
+          // no generatedSource — cleared on failure
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed"); // warn-only, NOT "skipped"
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.code).toBe("GENERATED_SOURCE_FAILED");
+    expect(result.warnings[0]?.message).toContain("deduct_inventory");
+    expect(result.warnings[0]?.message).toContain("syntax error: unexpected token at line 3");
+    expect(result.warnings[0]?.target).toBe("deduct_inventory");
+  });
+
+  test("a FAILED materialization under strictGeneratedContract becomes a blocking error", () => {
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: ["syntax error: unexpected token at line 3"],
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]?.code).toBe("GENERATED_SOURCE_FAILED");
+    expect(result.errors[0]?.message).toContain("deduct_inventory");
+  });
+
+  test("a FAILED materialization with no error detail still flags (no crash)", () => {
+    const result = validatePhase4({
+      changes: [change({ name: "deduct_inventory", materializationStatus: "failed" })],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.code).toBe("GENERATED_SOURCE_FAILED");
+    // no "Build-gate errors:" detail when there are no errors
+    expect(result.warnings[0]?.message).not.toContain("Build-gate errors");
+  });
+
+  test("a very long error list is capped to a reasonable length with an ellipsis", () => {
+    const longError = "x".repeat(500);
+    const result = validatePhase4({
+      changes: [
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: [longError],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    const msg = result.warnings[0]?.message ?? "";
+    expect(msg).toContain("...");
+    // the capped detail must not contain the full 500-char error verbatim
+    expect(msg).not.toContain(longError);
+  });
+
+  test("declarative-only changes (no source, no failed status) still skip (unchanged)", () => {
+    const result = validatePhase4({
+      changes: [change({}), change({ target: "rule", name: "r1" })],
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a NON-materializable change carrying a stale 'failed' status is NOT flagged (aligned with isMaterializable)", () => {
+    // The change was an action that failed generation (so it carries
+    // materializationStatus:"failed"), then was edited to a declarative target
+    // without re-materializing. It is no longer materializable, so Phase 4 must
+    // not treat it as a failed code generation — reporting it (and blocking
+    // under strict) would be wrong. The failed-filter is guarded by
+    // isMaterializable, so this degrades to "skipped". (Regression for codex on
+    // the Phase 4 PR.)
+    const result = validatePhase4({
+      changes: [
+        change({
+          target: "entity",
+          name: "invoice",
+          materializationStatus: "failed",
+          materializationErrors: ["stale build-gate error"],
+        }),
+      ],
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("a NON-materializable change with a stale 'failed' status does NOT block under strict", () => {
+    const result = validatePhase4({
+      changes: [
+        change({
+          target: "entity",
+          name: "invoice",
+          materializationStatus: "failed",
+          materializationErrors: ["stale build-gate error"],
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    // No materializable failure → nothing to escalate → not blocking.
+    expect(result.status).toBe("skipped");
+    expect(result.errors).toEqual([]);
+  });
+
+  test("mix: one good source + one failed change → non-strict passes with exactly one FAILED warning", () => {
+    const result = validatePhase4({
+      changes: [
+        change({ name: "do_thing", generatedSource: GOOD }),
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: ["build gate rejected: missing handler"],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    const failedWarnings = result.warnings.filter((w) => w.code === "GENERATED_SOURCE_FAILED");
+    expect(failedWarnings.length).toBe(1);
+    expect(failedWarnings[0]?.target).toBe("deduct_inventory");
+    // the good source produces no contract finding
+    expect(result.warnings.filter((w) => w.code === "GENERATED_SOURCE_CONTRACT")).toEqual([]);
+  });
+
+  test("mix: one good source + one failed change → strict fails on the failed change", () => {
+    const result = validatePhase4({
+      changes: [
+        change({ name: "do_thing", generatedSource: GOOD }),
+        change({
+          name: "deduct_inventory",
+          materializationStatus: "failed",
+          materializationErrors: ["build gate rejected: missing handler"],
+        }),
+      ],
+      strictGeneratedContract: true,
+    });
+    expect(result.status).toBe("failed");
+    const failedErrors = result.errors.filter((e) => e.code === "GENERATED_SOURCE_FAILED");
+    expect(failedErrors.length).toBe(1);
+    expect(failedErrors[0]?.target).toBe("deduct_inventory");
+  });
 });

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -9,6 +9,14 @@
  * gate yet are wrong (e.g. an empty scaffold, the wrong target, or a mismatched
  * name) before a human reviews the candidate.
  *
+ * Phase 4 ALSO reports materializable changes whose code generation FAILED the
+ * build/syntax gate (`materializationStatus: "failed"`, no `generatedSource` — the
+ * materializer cleared it). Such a change has no working candidate code, so it
+ * must not pass silently: a finding is emitted (distinct `GENERATED_SOURCE_FAILED`
+ * code) so a reviewer cannot approve + graduate a proposal carrying a change with
+ * no valid code. These findings inherit the SAME warn/error gating as the
+ * contract checks below.
+ *
  * SAFETY — EXECUTION-FREE BY DESIGN ("AI never modifies production directly"):
  * this NEVER `eval`s, `import`s, transpiles-and-runs, or otherwise executes the
  * generated source. It only does static string/structural heuristics. A true
@@ -33,6 +41,7 @@ import type {
   ValidationError,
   ValidationWarning,
 } from "../types/proposal";
+import { isMaterializable } from "./proposal-materializer";
 
 // ── Options ──────────────────────────────────────────────
 
@@ -164,7 +173,8 @@ function escapeRegExp(s: string): string {
  * Run Phase 4 (generated-source contract) validation on a proposal's changes.
  *
  * Returns a PhaseResult:
- *  - no change carries a non-empty `generatedSource` → status "skipped"
+ *  - nothing to report (no non-empty `generatedSource` AND no failed
+ *    materialization) → status "skipped"
  *  - findings + strictGeneratedContract=false → status "passed" with `warnings`
  *  - findings + strictGeneratedContract=true  → status "failed" with `errors`
  */
@@ -179,11 +189,43 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
     (c) => typeof c.generatedSource === "string" && c.generatedSource.trim().length > 0,
   );
 
-  if (withSource.length === 0) {
+  // Materializable changes whose code generation FAILED the build gate. They
+  // carry no `generatedSource` (cleared on failure) so the contract loop never
+  // sees them — but they must be reported, not skipped: a failed change has no
+  // working candidate code and must block graduation under strict gating.
+  //
+  // Guard with `isMaterializable` (the SAME predicate the materializer uses) so a
+  // change carrying a STALE "failed" status from when it WAS materializable but
+  // since edited to a non-materializable target/operation (e.g. action→entity,
+  // create→delete) is NOT flagged as a failed code generation — it no longer
+  // needs code at all, so reporting it (and blocking under strict) would be wrong.
+  const failed = changes.filter((c) => c.materializationStatus === "failed" && isMaterializable(c));
+
+  // Skip ONLY when there is genuinely nothing to report — neither a contract to
+  // check nor a failed materialization to flag.
+  if (withSource.length === 0 && failed.length === 0) {
     return { phase: 4, status: "skipped", errors: [], warnings: [], duration: Date.now() - start };
   }
 
   const findings: Array<{ code: string; message: string; target?: string }> = [];
+
+  // Failed-materialization findings. A failed change has no `generatedSource`, so
+  // it is never in `withSource` — the two loops do not double-count.
+  for (const change of failed) {
+    let detail = "";
+    if (change.materializationErrors && change.materializationErrors.length > 0) {
+      const joined = change.materializationErrors.join("; ");
+      // Cap the joined errors so a single finding message stays reasonable.
+      const capped = joined.length > 300 ? `${joined.slice(0, 297)}...` : joined;
+      detail = ` Build-gate errors: ${capped}`;
+    }
+    findings.push({
+      code: "GENERATED_SOURCE_FAILED",
+      message: `Materializable ${change.target} "${change.name}" failed code generation — no candidate source passed the build gate; it cannot be safely graduated.${detail}`,
+      target: change.name,
+    });
+  }
+
   for (const change of withSource) {
     const source = change.generatedSource as string;
     // Code with comments+strings removed → a `define*()` call here is a REAL call,

--- a/packages/core/src/engine/validation-phase4.ts
+++ b/packages/core/src/engine/validation-phase4.ts
@@ -213,8 +213,17 @@ export function validatePhase4(options: ValidatePhase4Options): PhaseResult {
   // it is never in `withSource` — the two loops do not double-count.
   for (const change of failed) {
     let detail = "";
-    if (change.materializationErrors && change.materializationErrors.length > 0) {
-      const joined = change.materializationErrors.join("; ");
+    // Defensively keep only non-empty STRING entries before joining. The field is
+    // typed `string[]`, but it can be rehydrated from persisted JSON, so guard
+    // against a malformed array (empty strings → "a; ; b" / trailing "; ", or a
+    // non-string slipping past the type) producing a malformed finding message.
+    const cleanErrors = Array.isArray(change.materializationErrors)
+      ? change.materializationErrors.filter(
+          (e): e is string => typeof e === "string" && e.trim().length > 0,
+        )
+      : [];
+    if (cleanErrors.length > 0) {
+      const joined = cleanErrors.join("; ");
       // Cap the joined errors so a single finding message stays reasonable.
       const capped = joined.length > 300 ? `${joined.slice(0, 297)}...` : joined;
       detail = ` Build-gate errors: ${capped}`;


### PR DESCRIPTION
## What

Phase 4 validation now **flags changes whose AI code-generation FAILED the build gate**, closing the loop on the durable materialization signal (#513): a failed generation now actively BLOCKS graduation in production-like envs instead of passing validation invisibly.

## Why (the gap)

Phase 4 (generated-source contract) previously inspected ONLY changes with a non-empty `generatedSource`. A change whose materialization FAILED has NO `generatedSource` (the materializer clears it) but carries `materializationStatus:"failed"` — so Phase 4 **skipped it entirely**. Net effect: a proposal where a materializable change failed code generation (no valid candidate code) silently passed Phase 4, and a human could approve + graduate a change with no working code.

## Change (additive)

- Collect `materializationStatus:"failed"` changes (guarded by `isMaterializable` — the SAME predicate the materializer uses, so a change carrying a STALE "failed" status after being edited to a non-materializable target/op is not mis-flagged).
- Emit one `GENERATED_SOURCE_FAILED` finding per failed change (distinct from the `GENERATED_SOURCE_CONTRACT` mismatch code), with the change name + capped (~300-char) build-gate error detail.
- Skip condition now requires BOTH no sourced changes AND no failed changes.
- Findings flow into the existing `findings` array → inherit the existing gating: **warn-only by default, blocking (status `failed` → `passed:false`) when `strictGeneratedContract` is true** (prod/staging via `isProduction`).
- The contract-check logic, regexes, comment/string stripping, and import checks are **untouched**. `validation-engine.ts` already passes all changes + the strict flag, so this **auto-wires** (no engine change).

## Safety

Still execution-free static validation — never runs the generated code. A true execution-based dry-run remains intentionally out of scope (sandbox-gated). Reinforces "AI Never Modifies Production Directly": a failed code generation cannot slip through to graduation in production.

## Tests

9 new `validation-phase4` cases (25 total): failed→warn (non-strict), failed→error (strict), no-error-detail (no crash), long-error capping, declarative-only still skips, good+failed mix (strict + non-strict), and — for the codex review — a non-materializable change carrying a stale "failed" status is NOT flagged (warn or strict).

## Verification

- `bun test …/validation-phase4.test.ts` → 25 pass; `bun run check`, `bun run typecheck`, full `bun run test` → green
- codex review R1 (flagged: align the failed-filter with `isMaterializable`) → fixed + regression tests → R2 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation reporting for failed build-gate scenarios with better error handling
  * Fixed error message formatting with intelligent truncation for large outputs
  * Enhanced strictness control for build failures

* **Tests**
  * Added comprehensive test coverage for materialization failure validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->