### PR TITLE
feat(adapter-ui): per-change re-generate button on failed materializations

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-review-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-review-helpers.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildMaterializeScope,
   canGraduate,
   changeTypeBadgeClass,
   isPending,
@@ -147,5 +148,25 @@ describe("selectFailedMaterializationChanges", () => {
         { name: "b" },
       ]),
     ).toEqual([]);
+  });
+});
+
+describe("buildMaterializeScope", () => {
+  test("scopes the materialize request to exactly the given change name", () => {
+    expect(buildMaterializeScope("submit_request")).toEqual({
+      changeNames: ["submit_request"],
+    });
+  });
+
+  test("never widens the scope — always a single-element list", () => {
+    const scope = buildMaterializeScope("approve_order");
+    expect(scope.changeNames).toHaveLength(1);
+    expect(scope.changeNames[0]).toBe("approve_order");
+  });
+
+  test("preserves the raw change name (no trimming / normalization)", () => {
+    expect(buildMaterializeScope("  weird name ")).toEqual({
+      changeNames: ["  weird name "],
+    });
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
@@ -12,7 +12,8 @@
  * policy. Purely presentational — it never triggers a mutation.
  */
 
-import { AlertTriangleIcon } from "lucide-react";
+import { Button } from "@linchkit/ui-kit/components";
+import { AlertTriangleIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
 import type { useTranslation } from "react-i18next";
 import type { ProposalChange } from "@/lib/proposal-api";
 
@@ -21,9 +22,30 @@ type TFn = ReturnType<typeof useTranslation>["t"];
 export function FailedMaterializationChanges({
   changes,
   t,
+  onRetryChange,
+  retryingChange,
+  disabled,
 }: {
   changes: readonly ProposalChange[];
   t: TFn;
+  /**
+   * Optional callback raised when the reviewer clicks "re-generate" on a failed
+   * change. Receives the change's `name`; the parent scopes a materialize to just
+   * that change. When absent, NO retry button renders (back-compat / read-only).
+   */
+  onRetryChange?: (changeName: string) => void;
+  /**
+   * The change name whose re-generate is currently in flight, if any — used to
+   * show a spinner on that change's button while it materializes.
+   */
+  retryingChange?: string | null;
+  /**
+   * When true, ALL retry buttons are disabled — a card-level action (approve /
+   * reject / graduate / materialize, or another retry) is in flight. Prevents
+   * concurrent mutations / overlapping materialize calls. The spinner still
+   * shows only on the change named by `retryingChange`.
+   */
+  disabled?: boolean;
 }) {
   if (changes.length === 0) return null;
 
@@ -48,9 +70,33 @@ export function FailedMaterializationChanges({
             <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-destructive">
               {t("proposals.materializeFailedBadge", "failed")}
             </span>
-            <span className="truncate">
+            <span className="min-w-0 flex-1 truncate">
               {c.target}/{c.name}
             </span>
+            {/* Per-change retry — scopes a materialize to JUST this change so the
+                reviewer can re-generate one failed change without regenerating the
+                already-good ones. Purely raises the callback; the parent calls the
+                API. Absent callback → no button (back-compat / read-only). */}
+            {onRetryChange && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 shrink-0 px-2 text-[11px]"
+                onClick={() => onRetryChange(c.name)}
+                // Disable every retry button while ANY card action or retry is in
+                // flight (`disabled` covers approve/reject/graduate/materialize via
+                // `busy`; `retryingChange` covers a sibling retry). Spinner below
+                // still shows only on the change actually re-generating.
+                disabled={disabled || retryingChange !== null}
+              >
+                {retryingChange === c.name ? (
+                  <Loader2Icon className="mr-1 size-3 animate-spin" />
+                ) : (
+                  <RefreshCwIcon className="mr-1 size-3" />
+                )}
+                {t("proposals.materializeRetryChange", "Re-generate")}
+              </Button>
+            )}
           </div>
           {c.materializationErrors && c.materializationErrors.length > 0 && (
             // A <div> (not <pre>) so the JSX indentation between the mapped <code>

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-failed-changes.tsx
@@ -85,9 +85,11 @@ export function FailedMaterializationChanges({
                 onClick={() => onRetryChange(c.name)}
                 // Disable every retry button while ANY card action or retry is in
                 // flight (`disabled` covers approve/reject/graduate/materialize via
-                // `busy`; `retryingChange` covers a sibling retry). Spinner below
-                // still shows only on the change actually re-generating.
-                disabled={disabled || retryingChange !== null}
+                // `busy`; `retryingChange` covers a sibling retry). `!!retryingChange`
+                // (not `!== null`) so an omitted optional prop (undefined) does NOT
+                // disable the button. Spinner below still shows only on the change
+                // actually re-generating.
+                disabled={disabled || !!retryingChange}
               >
                 {retryingChange === c.name ? (
                   <Loader2Icon className="mr-1 size-3 animate-spin" />

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -506,20 +506,31 @@ interface MaterializeWireResponse {
  *   401/403 → AUTHZ_DENIED (mapped to `denied`)
  *   500 → `error`
  *
+ * Pass `opts.changeNames` (non-empty) to scope materialization to JUST those
+ * change names — used by the per-failed-change "re-generate" retry so a reviewer
+ * can retry one failed change without regenerating the already-good ones. Omit it
+ * (or pass an empty array) to materialize every materializable change (default).
+ *
  * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
  * global mock across the batched suite.
  */
 export async function materializeProposal(
   id: string,
-  opts: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
+  opts: { fetchImpl?: typeof fetch; signal?: AbortSignal; changeNames?: string[] } = {},
 ): Promise<MaterializeProposalResult> {
   const doFetch = opts.fetchImpl ?? fetch;
+  // Scope the request to specific change names only when a non-empty list is
+  // given; otherwise send no body so the server materializes all changes (the
+  // pre-existing default behavior).
+  const scopedNames =
+    Array.isArray(opts.changeNames) && opts.changeNames.length > 0 ? opts.changeNames : undefined;
   let res: Response;
   try {
     res = await doFetch(`/api/proposals/${encodeURIComponent(id)}/materialize`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...getAuthHeaders() },
       signal: opts.signal,
+      ...(scopedNames ? { body: JSON.stringify({ changeNames: scopedNames }) } : {}),
     });
   } catch (err) {
     return {

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-helpers.ts
@@ -86,3 +86,18 @@ export function selectFailedMaterializationChanges<
 >(changes: readonly T[]): T[] {
   return changes.filter((c) => c.materializationStatus === "failed");
 }
+
+/**
+ * Shape the materialize-request scope for a single change-name retry. Returns the
+ * `{ changeNames }` option object that scopes `materializeProposal` to JUST this
+ * change, so re-generating one failed change never regenerates the good ones.
+ * Pure so the request shaping is unit-testable without the React render.
+ */
+export function buildMaterializeScope(changeName: string): { changeNames: string[] } {
+  return { changeNames: [changeName] };
+}
+
+/** Narrow a caught unknown to its message, falling back to a default string. */
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -3,11 +3,12 @@
  *
  * The real human-gated proposal review surface for the evolution governance
  * loop. Lists governed Proposals, lets a human approve / reject pending ones,
- * and graduate an approved one (write files + open a GitHub PR for review).
+ * graduate an approved one (write files + open a GitHub PR for review), and
+ * materialize / re-generate a draft's AI code candidates.
  *
  * Hard rule ("AI Never Modifies Production Directly"): every mutation here is an
- * EXPLICIT user click. Graduation only ever opens a PR — it NEVER merges. The
- * UI never auto-approves or auto-graduates anything.
+ * EXPLICIT user click. Graduation only ever opens a PR — it NEVER merges. The UI
+ * never auto-approves or auto-graduates anything.
  */
 
 import {
@@ -48,8 +49,10 @@ import {
   rejectProposal,
 } from "@/lib/proposal-api";
 import {
+  buildMaterializeScope,
   canGraduate,
   changeTypeBadgeClass,
+  errorMessage,
   isPending,
   PROPOSAL_STATUS_FILTERS,
   type ProposalStatusFilter,
@@ -74,6 +77,8 @@ function ProposalCard({
   const [reason, setReason] = useState("");
   const [grad, setGrad] = useState<GraduateProposalResult | null>(null);
   const [mat, setMat] = useState<MaterializeProposalResult | null>(null);
+  // Failed change name whose per-change "re-generate" is in flight, if any.
+  const [retryingChange, setRetryingChange] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const handleApprove = useCallback(async () => {
@@ -83,9 +88,7 @@ function ProposalCard({
       await approveProposal(proposal.id);
       onChanged();
     } catch (err) {
-      setActionError(
-        err instanceof Error ? err.message : t("proposals.approveFailed", "Approve failed"),
-      );
+      setActionError(errorMessage(err, t("proposals.approveFailed", "Approve failed")));
     } finally {
       setBusy(false);
     }
@@ -102,9 +105,7 @@ function ProposalCard({
       setReason("");
       onChanged();
     } catch (err) {
-      setActionError(
-        err instanceof Error ? err.message : t("proposals.rejectFailed", "Reject failed"),
-      );
+      setActionError(errorMessage(err, t("proposals.rejectFailed", "Reject failed")));
     } finally {
       setBusy(false);
     }
@@ -115,17 +116,14 @@ function ProposalCard({
     setActionError(null);
     setGrad(null);
     try {
-      // graduateProposal is designed to never throw (it maps every failure to a
-      // discriminated result), but wrap it defensively so an unexpected throw
-      // still surfaces as an error outcome and never leaves the button stuck
-      // disabled. Mirrors handleRunCycle on the Evolution page.
-      const result = await graduateProposal(proposal.id);
-      setGrad(result);
+      // graduateProposal maps every failure to a discriminated result; wrap
+      // defensively so an unexpected throw still surfaces as an error outcome.
+      // Mirrors handleRunCycle on the Evolution page.
+      setGrad(await graduateProposal(proposal.id));
     } catch (err) {
       setGrad({
         kind: "error",
-        message:
-          err instanceof Error ? err.message : t("proposals.graduateFailed", "Graduation failed"),
+        message: errorMessage(err, t("proposals.graduateFailed", "Graduation failed")),
       });
     } finally {
       setBusy(false);
@@ -143,18 +141,13 @@ function ProposalCard({
     setActionError(null);
     setMat(null);
     try {
-      // materializeProposal maps every failure to a discriminated result, but
-      // wrap defensively so an unexpected throw still surfaces and never leaves
-      // the button stuck disabled. Mirrors handleGraduate.
-      const result = await materializeProposal(proposal.id);
-      setMat(result);
+      // materializeProposal maps every failure to a discriminated result; wrap
+      // defensively so an unexpected throw still surfaces. Mirrors handleGraduate.
+      setMat(await materializeProposal(proposal.id));
     } catch (err) {
       setMat({
         kind: "error",
-        message:
-          err instanceof Error
-            ? err.message
-            : t("proposals.materializeFailed", "Materialization failed"),
+        message: errorMessage(err, t("proposals.materializeFailed", "Materialization failed")),
       });
     } finally {
       setBusy(false);
@@ -164,6 +157,28 @@ function ProposalCard({
     // server-side (the candidate source is persisted on it); a manual refresh
     // re-loads it via `proposal.changes`.
   }, [proposal.id, t]);
+
+  // Re-generate ONE failed change (scope materialize to it); reuse handleMaterialize's
+  // result path. `busy` blocks other actions/retries; `retryingChange` spins this button.
+  const handleRetryChange = useCallback(
+    async (changeName: string) => {
+      setBusy(true);
+      setRetryingChange(changeName);
+      setActionError(null);
+      try {
+        setMat(await materializeProposal(proposal.id, buildMaterializeScope(changeName)));
+      } catch (err) {
+        setMat({
+          kind: "error",
+          message: errorMessage(err, t("proposals.materializeFailed", "Materialization failed")),
+        });
+      } finally {
+        setRetryingChange(null);
+        setBusy(false);
+      }
+    },
+    [proposal.id, t],
+  );
 
   const pending = isPending(proposal.status);
   const graduatable = canGraduate(proposal.status);
@@ -359,11 +374,16 @@ function ProposalCard({
           </div>
         )}
 
-        {/* Failed materialization (durable signal). Renders changes that FAILED
-            the build gate — no generatedSource, but a `failed` status + the gate
-            errors — so the reviewer sees WHICH changes failed code generation and
-            WHY. Read-only: it never triggers any mutation. */}
-        <FailedMaterializationChanges changes={failedChanges} t={t} />
+        {/* Durable failure signal: changes that FAILED the build gate, each with a scoped retry. */}
+        <FailedMaterializationChanges
+          changes={failedChanges}
+          t={t}
+          // Retry calls materialize (DRAFT-ONLY) — only offer it on a draft; disable
+          // all retry buttons while any card action is in flight (`busy`).
+          onRetryChange={isDraft ? handleRetryChange : undefined}
+          retryingChange={retryingChange}
+          disabled={busy}
+        />
 
         {/* Approved: graduate → open PR (never merges). Once a PR is opened the
             button + hint are hidden so the success outcome (with the PR link)


### PR DESCRIPTION
## What

A per-failed-change **"Re-generate"** button on the proposal review page (`/admin/proposals`), completing the materialization-failure loop's last step (**fix**): a reviewer can retry ONE build-gate-failed change without regenerating the already-good ones.

> ⚠️ **Merge after** the backend PR (`feat/materialize-scope` — scoped `changeNames`). Until that lands, the scoped request degrades to "materialize all" (back-compat, not broken).

## Change

- **proposal-api.ts** — `materializeProposal(id, opts?)` gains optional `changeNames?: string[]`; non-empty → POSTs `{ changeNames }` (scoped), else no body (unchanged default).
- **proposal-failed-changes.tsx** — optional `onRetryChange` + `retryingChange` props render a small "Re-generate" button per failed change (only that button spins). Absent `onRetryChange` → no button (back-compat, still purely presentational).
- **proposal-review.tsx** — `handleRetryChange` mirrors the materialize handler, scopes via `buildMaterializeScope`, and reuses the result path so the change flips failed → materialized (or refreshes errors) in place — no reload. The button is gated on `isDraft` (materialize is draft-only; never expose a retry the endpoint would 422).
- **proposal-review-helpers.ts** — pure `buildMaterializeScope(name)` + `errorMessage(err, fallback)` (dedups approve/reject/retry catch handlers).

## Tests

3 new helper cases for `buildMaterializeScope` (20 total). No approval/graduate logic touched.

## Review

codex flagged (1) the backend-scoping dependency → addressed by merge ordering, and (2) exposing retry in non-draft statuses → fixed by gating the button on `isDraft`. `bun run check`/`typecheck`/full `bun run test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now retry individual failed materializations in proposal reviews without retrying all changes.
  * Failed change blocks now display retry buttons with visual loading indicators showing when a retry is in progress.

* **Tests**
  * Added comprehensive test coverage for materialization scope validation during retry operations.

* **Refactor**
  * Consolidated error handling across proposal action flows for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->