### PR TITLE
feat(core,adapter-server): scope code-materialization to named changes (G5)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-scope-smoke.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-materialize-scope-smoke.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Proposal code-materialization SCOPE — REAL server-assembly smoke test.
+ *
+ * Companion to `proposal-materialize-smoke.test.ts`. That suite proves the
+ * happy/guard paths of `POST /api/proposals/:id/materialize` through the
+ * canonical `createServer(...)` factory. This one pins the ADDITIVE
+ * `{ changeNames?: string[] }` request body: scoping materialization to a subset
+ * of changes so retrying ONE failed change does NOT regenerate — and risk
+ * regressing — the already-good ones.
+ *
+ * It exercises the SAME real components end-to-end (real `createCommandLayer`,
+ * real REST surface, the process-wide shared `ProposalEngine`, the real syntax
+ * quality gate). The ONLY stubbed seam is the AI model: a fake `AIService`
+ * (`configured: true`) whose `complete()` returns a `defineAction(...)` source
+ * that ENCODES which call produced it (a module-level call counter baked into
+ * the generated `name:`), so first-vs-second output is distinguishable while the
+ * source still parses through the real Bun.Transpiler gate.
+ *
+ * Core assertions:
+ *   1. First POST (no body) materializes BOTH changes (back-compat = all).
+ *   2. Second POST `{ changeNames: [A.name] }` regenerates ONLY A (new output),
+ *      reports B with its CARRIED-FORWARD durable status, and leaves B's
+ *      persisted `generatedSource` UNCHANGED — provider call count goes up by
+ *      exactly 1. Status stays draft.
+ *   3. Empty body `{}` again materializes ALL (back-compat).
+ *   4. A garbage/unknown `changeNames` is sanitized → materialize all.
+ *   5. A scoped retry of A does NOT hide a still-failed B: B surfaces as
+ *      `failed` and `allMaterialized` stays false (codex regression).
+ *
+ * Dispatch is `app.handle(new Request(...))` (in-process, port-free) — never
+ * `app.listen(PORT)` (a bound socket per suite SEGFAULTS the batched run). All
+ * fixtures are GLOBALLY UNIQUE (counter + Date.now suffix) because the shared
+ * `ProposalEngine` persists across the batched run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  AICompletionOptions,
+  AICompletionResult,
+  AIService,
+  CommandLayer,
+  EntityDefinition,
+  ProposalDefinition,
+} from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  InMemoryExecutionLogger,
+  InMemoryStore,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { getSharedProposalEngine } from "../src/proposal-api";
+import { createServer } from "../src/server";
+
+const BASE = "http://local.test";
+
+const taskSchema: EntityDefinition = {
+  name: "task",
+  label: "Task",
+  fields: { title: { type: "string", required: true, label: "Title" } },
+};
+
+// ── Globally-unique fixtures (shared-engine dedup safety) ────
+
+let fixtureCounter = 0;
+/** Mint a globally-unique (capability, two action names, title) per test. */
+function uniqueFixture(): {
+  capability: string;
+  actionA: string;
+  actionB: string;
+  title: string;
+} {
+  fixtureCounter += 1;
+  const tag = `${Date.now().toString(36)}_${fixtureCounter}`;
+  return {
+    capability: `cap-materialize-scope-${tag}`,
+    actionA: `materialize_scope_action_a_${tag}`,
+    actionB: `materialize_scope_action_b_${tag}`,
+    title: `Materialize scope proposal ${tag}`,
+  };
+}
+
+/**
+ * Seed a DRAFT proposal carrying TWO materializable (action/create) changes,
+ * A and B, into the process-wide shared `ProposalEngine` — the same engine the
+ * production route reads/writes. Returns the proposal id + both change names.
+ */
+function seedDraftProposalWithTwoChanges(): {
+  id: string;
+  actionA: string;
+  actionB: string;
+} {
+  const { capability, actionA, actionB, title } = uniqueFixture();
+  const proposal = getSharedProposalEngine().createProposal({
+    title,
+    description: "Smoke: scope materialization to a subset of action changes.",
+    author: { type: "ai", id: "smoke-detector", name: "Smoke Detector" },
+    capability,
+    changeType: "minor",
+    changes: [
+      { target: "action", operation: "create", name: actionA },
+      { target: "action", operation: "create", name: actionB },
+    ],
+  });
+  return { id: proposal.id, actionA, actionB };
+}
+
+// ── Fake AIService whose output encodes the call index ───────
+
+/**
+ * Build a `defineAction(...)` source that BAKES IN the call index, so two
+ * successive generations are textually distinguishable while still being valid
+ * TypeScript that passes the real syntax quality gate (Bun.Transpiler). The
+ * index lives in the action `name:` AND the returned payload.
+ */
+function generatedSourceForCall(callIndex: number): string {
+  return [
+    'import { defineAction } from "@linchkit/core";',
+    "",
+    "export const generated = defineAction({",
+    `  name: "deduct_inventory_call_${callIndex}",`,
+    "  handler: async () => {",
+    `    return { ok: true, call: ${callIndex} };`,
+    "  },",
+    "});",
+    "",
+  ].join("\n");
+}
+
+/**
+ * A configured fake `AIService`. Each `complete()` call returns source that
+ * encodes a fresh, monotonically-increasing call index, so a regenerated change
+ * gets DIFFERENT source than its prior materialization — letting the test prove
+ * "A regenerated, B preserved". `calls.count` tracks invocations so the test can
+ * assert the provider ran exactly once on a scoped retry.
+ */
+function makeFakeAIService(): { ai: AIService; calls: { count: number } } {
+  const calls = { count: 0 };
+  const ai: AIService = {
+    configured: true,
+    defaultProvider: "smoke",
+    providerNames: ["smoke"],
+    complete(_options: AICompletionOptions): Promise<AICompletionResult> {
+      calls.count += 1;
+      const result: AICompletionResult = {
+        content: generatedSourceForCall(calls.count),
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        model: "smoke-model",
+        provider: "smoke",
+        duration: 0,
+      };
+      return Promise.resolve(result);
+    },
+  };
+  return { ai, calls };
+}
+
+/**
+ * A configured fake whose `complete()` ALWAYS returns syntactically-broken
+ * source, so every materializable change FAILS the real syntax quality gate.
+ * Used to drive changes into the durable `failed` state through the real
+ * pipeline before a scoped retry of just one of them.
+ */
+function makeBrokenAIService(): AIService {
+  return {
+    configured: true,
+    defaultProvider: "smoke",
+    providerNames: ["smoke"],
+    complete(_options: AICompletionOptions): Promise<AICompletionResult> {
+      return Promise.resolve({
+        content: "export const x = (((;", // never parses → fails the syntax gate
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        model: "smoke-model",
+        provider: "smoke",
+        duration: 0,
+      });
+    },
+  };
+}
+
+/**
+ * Allow-all permission middleware. The materialize dispatch uses
+ * `skipActionSlots: true`, which is fail-closed without a permission slot; this
+ * minimal pass-through stands in for "the caller is authorized".
+ */
+function grantPermission(commandLayer: CommandLayer): void {
+  commandLayer.use({
+    name: "smoke_allow_materialize_scope",
+    slot: "permission",
+    handler: async (_ctx, next) => {
+      await next();
+    },
+  });
+}
+
+/** Build the real server via the canonical factory. */
+function buildApp(opts: { aiService: AIService }): {
+  handle: (req: Request) => Promise<Response>;
+} {
+  const store = new InMemoryStore();
+  const executor = createActionExecutor({
+    dataProvider: store,
+    executionLogger: new InMemoryExecutionLogger(),
+  });
+  const commandLayer = createCommandLayer({ executor });
+  grantPermission(commandLayer);
+  const graphqlSchema = buildGraphQLSchema([taskSchema], {
+    executor,
+    commandLayer,
+    dataProvider: store,
+  });
+  return createServer(graphqlSchema, { executor, commandLayer, aiService: opts.aiService });
+}
+
+interface MaterializeJson {
+  success: boolean;
+  data?: {
+    proposalId?: string;
+    allMaterialized?: boolean;
+    outcomes?: Array<{ changeName: string; target: string; status: string }>;
+    proposal?: {
+      status?: string;
+      changes?: Array<{ name: string; generatedSource?: string }>;
+    };
+  };
+  error?: { message?: string; code?: string };
+}
+
+/**
+ * POST the materialize endpoint with an OPTIONAL body. When `body` is omitted no
+ * payload is sent (the empty-body "materialize all" path); otherwise the value
+ * is JSON-encoded. Reads the response as text first so a non-JSON crash surfaces
+ * its raw body instead of an opaque SyntaxError.
+ */
+async function postMaterialize(
+  app: { handle: (req: Request) => Promise<Response> },
+  id: string,
+  body?: unknown,
+): Promise<{ status: number; json: MaterializeJson }> {
+  const init: RequestInit =
+    body === undefined
+      ? { method: "POST" }
+      : {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        };
+  const res = await app.handle(new Request(`${BASE}/api/proposals/${id}/materialize`, init));
+  const text = await res.text();
+  let json: MaterializeJson;
+  try {
+    json = JSON.parse(text) as MaterializeJson;
+  } catch {
+    throw new Error(`materialize returned non-JSON (status ${res.status}): ${text.slice(0, 300)}`);
+  }
+  return { status: res.status, json };
+}
+
+/** Read a change's persisted `generatedSource` back out of the shared engine. */
+function readPersistedSource(id: string, changeName: string): string | undefined {
+  const proposal: ProposalDefinition = getSharedProposalEngine().getProposal(id);
+  return proposal.changes.find((c) => c.name === changeName)?.generatedSource;
+}
+
+describe("POST /api/proposals/:id/materialize — changeNames scope smoke", () => {
+  test("scoped retry regenerates only the named change; out-of-scope is preserved untouched", async () => {
+    const { ai, calls } = makeFakeAIService();
+    const app = buildApp({ aiService: ai });
+    const { id, actionA, actionB } = seedDraftProposalWithTwoChanges();
+
+    // ── First POST (no body) → BOTH A and B materialized (back-compat = all). ──
+    const first = await postMaterialize(app, id);
+    expect(first.status).toBe(200);
+    expect(first.json.success).toBe(true);
+    expect(first.json.data?.allMaterialized).toBe(true);
+
+    const firstA = first.json.data?.outcomes?.find((o) => o.changeName === actionA);
+    const firstB = first.json.data?.outcomes?.find((o) => o.changeName === actionB);
+    expect(firstA?.status).toBe("materialized");
+    expect(firstB?.status).toBe("materialized");
+    // Two materializable changes → exactly two provider calls.
+    expect(calls.count).toBe(2);
+
+    // Capture the first-pass persisted source for each change.
+    const aSourceAfterFirst = readPersistedSource(id, actionA);
+    const bSourceAfterFirst = readPersistedSource(id, actionB);
+    expect(aSourceAfterFirst).toBeDefined();
+    expect(bSourceAfterFirst).toBeDefined();
+    // The two changes got distinct call-encoded sources.
+    expect(aSourceAfterFirst).not.toBe(bSourceAfterFirst);
+
+    // ── Second POST `{ changeNames: [A] }` → ONLY A regenerated; B untouched. ──
+    const callsBeforeScoped = calls.count;
+    const second = await postMaterialize(app, id, { changeNames: [actionA] });
+    expect(second.status).toBe(200);
+    expect(second.json.success).toBe(true);
+    // Both are materialized (A regenerated, B carried forward), so allMaterialized.
+    expect(second.json.data?.allMaterialized).toBe(true);
+
+    const secondA = second.json.data?.outcomes?.find((o) => o.changeName === actionA);
+    const secondB = second.json.data?.outcomes?.find((o) => o.changeName === actionB);
+    expect(secondA?.status).toBe("materialized");
+    // B is out-of-scope but reports its CARRIED-FORWARD durable status (it
+    // succeeded in pass 1) — NOT a blanket "skipped" that would hide a failure.
+    expect(secondB?.status).toBe("materialized");
+
+    // Provider called exactly ONCE more — only A regenerated.
+    expect(calls.count).toBe(callsBeforeScoped + 1);
+
+    // A's persisted source CHANGED (fresh provider output)…
+    const aSourceAfterScoped = readPersistedSource(id, actionA);
+    expect(aSourceAfterScoped).toBeDefined();
+    expect(aSourceAfterScoped).not.toBe(aSourceAfterFirst);
+    // …while B's persisted source is UNCHANGED (out-of-scope, preserved untouched).
+    const bSourceAfterScoped = readPersistedSource(id, actionB);
+    expect(bSourceAfterScoped).toBe(bSourceAfterFirst);
+
+    // SAFETY: still a draft — never auto-advanced.
+    expect(second.json.data?.proposal?.status).toBe("draft");
+    expect(getSharedProposalEngine().getProposal(id).status).toBe("draft");
+  });
+
+  test("empty body {} still materializes ALL changes (back-compat)", async () => {
+    const { ai, calls } = makeFakeAIService();
+    const app = buildApp({ aiService: ai });
+    const { id, actionA, actionB } = seedDraftProposalWithTwoChanges();
+
+    const res = await postMaterialize(app, id, {});
+    expect(res.status).toBe(200);
+    expect(res.json.success).toBe(true);
+    expect(res.json.data?.allMaterialized).toBe(true);
+
+    const a = res.json.data?.outcomes?.find((o) => o.changeName === actionA);
+    const b = res.json.data?.outcomes?.find((o) => o.changeName === actionB);
+    expect(a?.status).toBe("materialized");
+    expect(b?.status).toBe("materialized");
+    // An empty body is treated as absent → ALL materializable changes generated.
+    expect(calls.count).toBe(2);
+
+    expect(readPersistedSource(id, actionA)).toBeDefined();
+    expect(readPersistedSource(id, actionB)).toBeDefined();
+    expect(getSharedProposalEngine().getProposal(id).status).toBe("draft");
+  });
+
+  test("garbage/all-unknown changeNames is sanitized → materialize all (never trusted)", async () => {
+    const { ai, calls } = makeFakeAIService();
+    const app = buildApp({ aiService: ai });
+    const { id, actionA, actionB } = seedDraftProposalWithTwoChanges();
+
+    // Defensive sanitation, two layers:
+    //   1. Non-string entries (123, null, an object that embeds a real name) are
+    //      DROPPED at the route — a client cannot smuggle a name via a non-string.
+    //   2. The surviving strings ("   " is empty-after-trim → dropped;
+    //      "no_such_change" matches no change on this proposal) are filtered
+    //      against the proposal's ACTUAL change names in the orchestrator.
+    // After both layers NOTHING survives → the scope degrades to "materialize all"
+    // rather than scoping to a phantom set that would silently skip everything.
+    const res = await postMaterialize(app, id, {
+      changeNames: [123, null, { name: actionA }, "   ", "no_such_change"],
+    });
+    expect(res.status).toBe(200);
+    expect(res.json.success).toBe(true);
+    expect(res.json.data?.allMaterialized).toBe(true);
+
+    const a = res.json.data?.outcomes?.find((o) => o.changeName === actionA);
+    const b = res.json.data?.outcomes?.find((o) => o.changeName === actionB);
+    // No usable scope survived → BOTH real changes materialized (back-compat).
+    expect(a?.status).toBe("materialized");
+    expect(b?.status).toBe("materialized");
+    expect(calls.count).toBe(2);
+
+    // Both real changes got candidate source; draft untouched.
+    expect(readPersistedSource(id, actionA)).toBeDefined();
+    expect(readPersistedSource(id, actionB)).toBeDefined();
+    expect(getSharedProposalEngine().getProposal(id).status).toBe("draft");
+  });
+
+  test("scoped retry of A does NOT hide a still-failed B → allMaterialized stays false", async () => {
+    // Regression for the codex review: an out-of-scope change that is still
+    // `failed` must surface as "failed" in the outcomes and keep
+    // `allMaterialized` false — a scoped retry of A must NOT misreport the whole
+    // proposal as fully materialized while B is still broken.
+    const { id, actionA, actionB } = seedDraftProposalWithTwoChanges();
+
+    // Pass 1: a BROKEN-source provider fails BOTH A and B (durable "failed").
+    // The shared, process-wide ProposalEngine persists that state across apps.
+    const brokenApp = buildApp({ aiService: makeBrokenAIService() });
+    const first = await postMaterialize(brokenApp, id);
+    expect(first.status).toBe(200);
+    expect(first.json.data?.allMaterialized).toBe(false);
+    expect(first.json.data?.outcomes?.find((o) => o.changeName === actionA)?.status).toBe("failed");
+    expect(first.json.data?.outcomes?.find((o) => o.changeName === actionB)?.status).toBe("failed");
+
+    // Pass 2: scope a retry to A only, now with a GOOD-source provider. A
+    // succeeds; B is out-of-scope and STILL failed.
+    const goodApp = buildApp({ aiService: makeFakeAIService().ai });
+    const second = await postMaterialize(goodApp, id, { changeNames: [actionA] });
+    expect(second.status).toBe(200);
+
+    const a = second.json.data?.outcomes?.find((o) => o.changeName === actionA);
+    const b = second.json.data?.outcomes?.find((o) => o.changeName === actionB);
+    expect(a?.status).toBe("materialized");
+    // B carries forward its durable "failed" — NOT hidden as "skipped".
+    expect(b?.status).toBe("failed");
+    // The whole-proposal summary is honest: B is still broken.
+    expect(second.json.data?.allMaterialized).toBe(false);
+
+    // A now has source; B still has none (its failed materialization persisted).
+    expect(readPersistedSource(id, actionA)).toBeDefined();
+    expect(readPersistedSource(id, actionB)).toBeUndefined();
+    expect(getSharedProposalEngine().getProposal(id).status).toBe("draft");
+  });
+
+  test("scoping A on a never-materialized proposal leaves B un-generated → allMaterialized false", async () => {
+    // Regression for codex R2: allMaterialized must reflect the WHOLE proposal,
+    // not just the scoped round. With a FIRST-EVER scoped materialization of A,
+    // the out-of-scope B is a materializable change that was NEVER generated (no
+    // source, no status) — the proposal is NOT fully materialized, so
+    // allMaterialized must be false even though nothing "failed" this round.
+    const { ai } = makeFakeAIService();
+    const app = buildApp({ aiService: ai });
+    const { id, actionA, actionB } = seedDraftProposalWithTwoChanges();
+
+    const res = await postMaterialize(app, id, { changeNames: [actionA] });
+    expect(res.status).toBe(200);
+    expect(res.json.data?.outcomes?.find((o) => o.changeName === actionA)?.status).toBe(
+      "materialized",
+    );
+    // B never generated → not materialized → drags allMaterialized false.
+    expect(res.json.data?.allMaterialized).toBe(false);
+    expect(readPersistedSource(id, actionA)).toBeDefined();
+    expect(readPersistedSource(id, actionB)).toBeUndefined();
+    expect(getSharedProposalEngine().getProposal(id).status).toBe("draft");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
@@ -50,6 +50,46 @@ import { resolveActor, resolveStatusCode } from "./routes/shared";
 const MATERIALIZE_COMMAND_NAME = "proposal.materialize";
 
 /**
+ * Parse + sanitize the OPTIONAL request body into a `changeNames` scope.
+ *
+ * NEVER trust client input: a missing/empty/malformed body, or any body that is
+ * not `{ changeNames: string[] }`, yields `undefined` (= materialize ALL, today's
+ * behavior). From a well-formed array we keep ONLY non-empty string entries
+ * (deduped); non-string garbage is dropped. If nothing survives, returns
+ * `undefined` so an all-garbage `changeNames` degrades to "materialize all"
+ * rather than scoping to the empty set (which would skip everything).
+ *
+ * This is STRING sanitation only. Membership against the proposal's ACTUAL
+ * change names is enforced in {@link runProposalMaterialization} once the
+ * proposal is loaded (names matching no change are dropped, and an all-unknown
+ * scope likewise degrades to "materialize all").
+ *
+ * Reading `await request.json()` THROWS on an empty body, so this is fully
+ * try/caught — an empty POST is the common "materialize all" call.
+ */
+async function parseChangeNamesBody(request: Request): Promise<readonly string[] | undefined> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    // No body / not JSON → materialize all (back-compat).
+    return undefined;
+  }
+  if (typeof body !== "object" || body === null) return undefined;
+  const raw = (body as { changeNames?: unknown }).changeNames;
+  if (!Array.isArray(raw)) return undefined;
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    // Drop non-strings and empty/whitespace-only names; dedupe.
+    if (typeof entry !== "string") continue;
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) continue;
+    seen.add(trimmed);
+  }
+  return seen.size > 0 ? [...seen] : undefined;
+}
+
+/**
  * Upper bound on the ontology Markdown embedded in the generation context. A real
  * project ontology can grow large; an unbounded summary would balloon the prompt
  * (cost + latency + truncation by the model). Past this many characters the
@@ -153,6 +193,14 @@ export interface RunProposalMaterializationDeps {
   context?: string;
   /** Max generation attempts per change (defaults to the materializer's default). */
   maxRetries?: number;
+  /**
+   * Optional scope: when provided (non-empty), ONLY changes whose `name` is in
+   * this list are (re)materialized; every other change is preserved untouched.
+   * When absent/empty, ALL materializable changes are materialized (current
+   * behavior). Lets a reviewer retry one FAILED change without regenerating —
+   * and risking regression of — the already-good ones.
+   */
+  changeNames?: readonly string[];
 }
 
 /**
@@ -191,6 +239,19 @@ export async function runProposalMaterialization(
     return { kind: "not_draft", status: proposal.status };
   }
 
+  // Resolve the effective scope against the loaded proposal's actual change
+  // names. Client `changeNames` is already string-sanitized at the route; here we
+  // additionally DROP names that match no change on THIS proposal (never trust a
+  // client to know the real names). If nothing survives, fall back to `undefined`
+  // so an all-unknown scope degrades to "materialize all" rather than scoping to
+  // a phantom set that would skip every change.
+  let effectiveChangeNames: readonly string[] | undefined;
+  if (deps.changeNames && deps.changeNames.length > 0) {
+    const known = new Set(proposal.changes.map((c) => c.name));
+    const filtered = deps.changeNames.filter((name) => known.has(name));
+    effectiveChangeNames = filtered.length > 0 ? filtered : undefined;
+  }
+
   try {
     const result = await materializeProposalChanges({
       proposal,
@@ -198,6 +259,7 @@ export async function runProposalMaterialization(
       qualityGate: deps.qualityGate,
       context: deps.context,
       maxRetries: deps.maxRetries,
+      changeNames: effectiveChangeNames,
     });
     // Persist the candidate source back onto the draft. `updateProposal` replaces
     // `changes` (recomputing impact) and is draft-only — never approves/graduates.
@@ -270,12 +332,24 @@ export interface MountProposalMaterializeAPIOptions {
 /**
  * Register `POST /api/proposals/:id/materialize` on the given Elysia app.
  *
+ * Request body (OPTIONAL): `{ changeNames?: string[] }`. When a non-empty
+ * `changeNames` is given, ONLY those changes are (re)materialized; every other
+ * change is preserved untouched (its existing `generatedSource` is kept) and
+ * reported as `skipped`. This lets a reviewer retry one FAILED change without
+ * re-calling the AI provider for — and risking regression of — the already-good
+ * ones. A missing/empty/malformed body materializes ALL changes (today's
+ * behavior, byte-for-byte). Client `changeNames` is sanitized: non-string
+ * entries and names that do not match an actual change on the proposal are
+ * dropped (never trusted).
+ *
  * Contract:
  *   - 404 `{ success: false, error }` — proposal not found.
  *   - 422 `{ success: false, error }` — proposal not a draft (draft-only guard).
  *   - 503 `{ success: false, error }` — command layer or AI provider not configured.
  *   - 500 `{ success: false, error }` — unexpected generation failure.
  *   - 200 `{ success: true, data: { proposalId, allMaterialized, outcomes, proposal } }`.
+ *     With a `changeNames` scope, out-of-scope changes appear in `outcomes` with
+ *     status `skipped` and their `generatedSource` on `proposal` is preserved.
  *
  * @param app Elysia app instance
  * @param options Engine + provider overrides (all optional; production uses defaults).
@@ -380,11 +454,19 @@ export function mountProposalMaterializeAPI(
         };
       }
 
+      // Parse the OPTIONAL body AFTER auth + provider preflight so the slot order
+      // (permission FIRST) is preserved and an unauthorized caller's body is never
+      // read. A missing/empty/malformed body → undefined → materialize all
+      // (today's behavior); a sanitized scope restricts (re)materialization to the
+      // named changes, preserving every out-of-scope change untouched.
+      const changeNames = await parseChangeNamesBody(request);
+
       const outcome = await runProposalMaterialization(params.id, {
         engine,
         provider,
         qualityGate,
         context: getContext(),
+        changeNames,
       });
 
       switch (outcome.kind) {

--- a/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts
@@ -50,7 +50,14 @@ import { resolveActor, resolveStatusCode } from "./routes/shared";
 const MATERIALIZE_COMMAND_NAME = "proposal.materialize";
 
 /**
- * Parse + sanitize the OPTIONAL request body into a `changeNames` scope.
+ * Sanitize the OPTIONAL, ALREADY-PARSED request body into a `changeNames` scope.
+ *
+ * The body is taken from the Elysia context (`context.body`), NOT re-read from
+ * the raw `Request`. Calling `request.json()` inside the handler would throw
+ * `TypeError: body stream already read` whenever Elysia's own body parser (or any
+ * upstream middleware/plugin/derive hook) has already consumed the body stream —
+ * which is the framework's default. Every other body-reading route in this addon
+ * destructures `body` from the context; this one now follows suit.
  *
  * NEVER trust client input: a missing/empty/malformed body, or any body that is
  * not `{ changeNames: string[] }`, yields `undefined` (= materialize ALL, today's
@@ -63,18 +70,8 @@ const MATERIALIZE_COMMAND_NAME = "proposal.materialize";
  * change names is enforced in {@link runProposalMaterialization} once the
  * proposal is loaded (names matching no change are dropped, and an all-unknown
  * scope likewise degrades to "materialize all").
- *
- * Reading `await request.json()` THROWS on an empty body, so this is fully
- * try/caught — an empty POST is the common "materialize all" call.
  */
-async function parseChangeNamesBody(request: Request): Promise<readonly string[] | undefined> {
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    // No body / not JSON → materialize all (back-compat).
-    return undefined;
-  }
+function sanitizeChangeNamesBody(body: unknown): readonly string[] | undefined {
   if (typeof body !== "object" || body === null) return undefined;
   const raw = (body as { changeNames?: unknown }).changeNames;
   if (!Array.isArray(raw)) return undefined;
@@ -387,10 +384,15 @@ export function mountProposalMaterializeAPI(
       params,
       set,
       request,
+      body,
     }: {
       params: { id: string };
       set: { status: number };
       request: Request;
+      // Elysia pre-parses the JSON body into the context. Read it from here, NOT
+      // via `request.json()` — the raw stream is already consumed by the time the
+      // handler runs, so re-reading it throws "body stream already read".
+      body: unknown;
     }) => {
       // ── Permission slot (CommandLayer) — run FIRST, before any provider build,
       // engine read, or AI call. Materialization invokes the AI and mutates a
@@ -454,12 +456,12 @@ export function mountProposalMaterializeAPI(
         };
       }
 
-      // Parse the OPTIONAL body AFTER auth + provider preflight so the slot order
-      // (permission FIRST) is preserved and an unauthorized caller's body is never
-      // read. A missing/empty/malformed body → undefined → materialize all
-      // (today's behavior); a sanitized scope restricts (re)materialization to the
-      // named changes, preserving every out-of-scope change untouched.
-      const changeNames = await parseChangeNamesBody(request);
+      // Sanitize the OPTIONAL pre-parsed body AFTER auth + provider preflight so
+      // the slot order (permission FIRST) is preserved. A missing/empty/malformed
+      // body → undefined → materialize all (today's behavior); a sanitized scope
+      // restricts (re)materialization to the named changes, preserving every
+      // out-of-scope change untouched.
+      const changeNames = sanitizeChangeNamesBody(body);
 
       const outcome = await runProposalMaterialization(params.id, {
         engine,

--- a/packages/core/__tests__/proposal-materializer.durable-status.test.ts
+++ b/packages/core/__tests__/proposal-materializer.durable-status.test.ts
@@ -207,4 +207,41 @@ describe("materializeProposalChanges — durable materialization status", () => 
     expect(change?.materializationErrors).toBeUndefined();
     expect(change?.generatedSource).toBe(GOOD);
   });
+
+  test("scoped run clears stale source on a NON-materializable out-of-scope change", async () => {
+    // A declarative change carrying STALE materialization artifacts (it was an
+    // action that got materialized, then edited to a declarative target). A
+    // SCOPED materialization of a DIFFERENT change must still clear the stale
+    // source so ProposalFileWriter never writes it at graduation — the scope
+    // protects already-good MATERIALIZABLE candidates, not invalid declarative
+    // state. (Regression for codex R3 on the scoped-materialization PR.)
+    const input = makeProposal([
+      { target: "action", operation: "create", name: "deduct_inventory" },
+      {
+        target: "entity",
+        operation: "create",
+        name: "stale_entity",
+        generatedSource: "export const stale = 1;",
+        materializationStatus: "materialized",
+      },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+      changeNames: ["deduct_inventory"], // scope to the action only
+    });
+
+    const action = result.proposal.changes.find((c) => c.name === "deduct_inventory");
+    const stale = result.proposal.changes.find((c) => c.name === "stale_entity");
+    expect(action?.materializationStatus).toBe("materialized");
+    // The out-of-scope, now-declarative change had its stale artifacts CLEARED.
+    expect(stale?.generatedSource).toBeUndefined();
+    expect(stale?.materializationStatus).toBeUndefined();
+    expect(stale?.materializationErrors).toBeUndefined();
+    expect(result.outcomes.find((o) => o.changeName === "stale_entity")?.status).toBe("skipped");
+    // The input proposal is never mutated.
+    expect(input.changes[1]?.generatedSource).toBe("export const stale = 1;");
+  });
 });

--- a/packages/core/src/engine/proposal-materializer.ts
+++ b/packages/core/src/engine/proposal-materializer.ts
@@ -59,6 +59,18 @@ export interface MaterializeProposalOptions {
    * to the provider on every attempt.
    */
   context?: string;
+  /**
+   * When provided (non-empty), ONLY changes whose `name` is in this set are
+   * (re)materialized; every other change is preserved UNTOUCHED (its existing
+   * `generatedSource` / `materializationStatus` / `materializationErrors` are
+   * kept) and reported with outcome status `skipped`. When absent/empty, ALL
+   * materializable changes are materialized (current behavior).
+   *
+   * Use case: retrying a single FAILED change without re-calling the AI provider
+   * for changes that already succeeded — the model is non-deterministic, so
+   * regenerating a good candidate can REGRESS it.
+   */
+  changeNames?: readonly string[];
 }
 
 export interface MaterializeChangeOutcome {
@@ -105,7 +117,58 @@ export async function materializeProposalChanges(
   const changes: ProposalChange[] = proposal.changes.map((c) => ({ ...c }));
   const outcomes: MaterializeChangeOutcome[] = [];
 
+  // Optional scope: when a non-empty `changeNames` is given, only those changes
+  // are (re)materialized. Out-of-scope changes are preserved untouched (their
+  // existing source/status/errors are NOT cleared) so retrying one FAILED change
+  // never regenerates — and risks regressing — the already-good ones.
+  const scope =
+    options.changeNames && options.changeNames.length > 0 ? new Set(options.changeNames) : null;
+
   for (const change of changes) {
+    // Out-of-scope (only when a scope was given): the point of scoping is to NOT
+    // regenerate already-good changes. But a non-materializable change must never
+    // be left with stale materialization artifacts.
+    if (scope && !scope.has(change.name)) {
+      // A NON-materializable out-of-scope change (e.g. one edited action→entity
+      // since it was last materialized) must NOT retain a stale `generatedSource`
+      // — `ProposalFileWriter` would write it at graduation. Clear it exactly as
+      // the in-scope declarative path does, and report "skipped".
+      if (!isMaterializable(change)) {
+        change.generatedSource = undefined;
+        change.materializationStatus = undefined;
+        change.materializationErrors = undefined;
+        outcomes.push({
+          changeName: change.name,
+          target: change.target,
+          status: "skipped",
+          attempts: 0,
+        });
+        continue;
+      }
+      // Materializable + out-of-scope: PRESERVE it untouched (don't regenerate a
+      // good candidate), and report its CARRIED-FORWARD durable status — NOT a
+      // blanket "skipped". A change still `failed` from an earlier pass must
+      // surface as "failed" so it is not hidden from the outcomes/`allMaterialized`
+      // summary (else a scoped retry of A could misreport the proposal as fully
+      // materialized while B is still broken).
+      const carried: MaterializeChangeOutcome["status"] =
+        change.materializationStatus === "failed"
+          ? "failed"
+          : change.materializationStatus === "materialized"
+            ? "materialized"
+            : "skipped";
+      outcomes.push({
+        changeName: change.name,
+        target: change.target,
+        status: carried,
+        attempts: 0,
+        ...(carried === "failed" && change.materializationErrors
+          ? { errors: change.materializationErrors }
+          : {}),
+      });
+      continue;
+    }
+
     // Clear any pre-existing source AND durable quality signal up front — BEFORE
     // the materializable check — so neither a re-materialization NOR a change
     // that became non-materializable (its target/operation was edited, e.g.
@@ -175,7 +238,16 @@ export async function materializeProposalChanges(
     );
   }
 
-  const allMaterialized = outcomes.every((o) => o.status !== "failed");
+  // `allMaterialized` = every MATERIALIZABLE change has successfully-materialized
+  // source. Derived from the durable change state (NOT the per-round outcomes) so
+  // a SCOPED run reports the WHOLE proposal honestly: an out-of-scope
+  // materializable change that is still `failed` OR was NEVER materialized (no
+  // source) keeps this false — only a non-materializable (declarative) change or
+  // a truly materialized one passes. Equivalent to the old outcomes check in the
+  // unscoped case (where every materializable change is attempted every run).
+  const allMaterialized = changes.every(
+    (c) => !isMaterializable(c) || c.materializationStatus === "materialized",
+  );
   return { proposal: { ...proposal, changes }, outcomes, allMaterialized };
 }
 


### PR DESCRIPTION
## Summary

Adds **scoped re-materialization** — the "fix" step of the `说→有` code-quality loop. A reviewer can now re-generate code for **one named change** of a draft proposal without regenerating the changes that already passed the build gate.

This is the backend half of the loop's closing arc:
- #513 persisted the durable materialization-failure signal on `ProposalChange`
- #514 rendered it in `/admin/proposals`
- #515 made Phase 4 validation BLOCK prod graduation of failed-gen changes
- **this PR** lets the reviewer re-generate a single failed change in place
- (#516, UI) wires a per-change "re-generate" button to this endpoint

## Changes

**`packages/core/src/engine/proposal-materializer.ts`**
- `MaterializeProposalOptions` gains `changeNames?: readonly string[]`. When set, only the named changes are (re-)materialized.
- Out-of-scope changes **carry forward** their durable status (`materialized`/`failed`) into the outcome list, so a scoped retry never silently hides a still-failed sibling.
- A now-declarative (non-materializable) out-of-scope change has its **stale `generatedSource`/status/errors cleared** so `ProposalFileWriter` never writes invalid source at graduation.
- `allMaterialized` is derived from durable change state — `changes.every(c => !isMaterializable(c) || c.materializationStatus === "materialized")` — not from this run's outcomes.

**`addons/adapter-server/cap-adapter-server/src/proposal-materialize-api.ts`**
- Route parses an OPTIONAL JSON body `{ changeNames?: string[] }` **after** the permission slot (CommandLayer-first preserved).
- Two-layer sanitization: non-string/empty names dropped + deduped at the route; unknown names dropped in the orchestrator; all-unknown falls back to materialize-all.

## Safety

- Draft-only; CommandLayer permission slot never skipped; AI never modifies production directly (graduation stays separately human-gated).
- No new dependencies.

## Tests

- `proposal-materialize-scope-smoke.test.ts` (NEW, real-boot) — 5 cases incl. the two codex regressions (scoped retry of A must not hide a still-failed B; scoping A on a never-materialized proposal keeps `allMaterialized` false).
- `proposal-materializer.durable-status.test.ts` — +1 case: scoped run clears stale source on a non-materializable out-of-scope change (codex R3).

## Review

codex review iterated 4 rounds (R1 allMaterialized misreport → R2 never-materialized out-of-scope → R3 stale-source-on-declarative → R4 clean). Final R4 verdict: out-of-scope changes preserved, whole-proposal state consistent, unscoped behavior unchanged, regressions covered, typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
