### PR TITLE
feat(core): execution dry-run seam + sync Phase 5 (Spec 70 P2)

### DIFF
--- a/docs/specs/70_execution_dry_run_sandbox.md
+++ b/docs/specs/70_execution_dry_run_sandbox.md
@@ -108,23 +108,22 @@ Run the generated TypeScript in a **separate Bun process** spawned by a hardened
 
 ## 5. Architecture and Data Flow
 
-**Core stays execution-free.** Core defines only the *interface* + the validation hook; the concrete runner lives in a capability (extend `cap-ai-provider`, or a new `cap-dry-run` addon — §10 Q2). This mirrors the existing `CodeGenerationProvider` injectable-seam pattern: core declares the seam, a capability supplies the impl, tests inject a fake.
+**Core stays execution-free.** Core defines only the *interface* + a synchronous validation reader; the concrete runner lives in a capability (extend `cap-ai-provider`, or a new `cap-dry-run` addon — §10 Q2). This mirrors the existing `CodeGenerationProvider` injectable-seam pattern: core declares the seam, a capability supplies the impl, tests inject a fake.
+
+**Where the async dry-run runs (durable-signal architecture).** The dry-run executes the handler in a sandbox, which is inherently asynchronous. Rather than make the whole validation pipeline async (`validateProposal` → `submitProposal` → the REST surface), the async run happens in the **already-async materialization path** (`materializeProposalChanges`) right after source is generated + build-gated; it stamps a **durable `dryRunStatus` / `dryRunOutcomes`** on the change — exactly mirroring how G5 stamps `materializationStatus` (Spec 55 §7.7, #513). Validation **Phase 5 then stays SYNCHRONOUS**: it only *reads* the persisted `dryRunStatus`, precisely as Phase 4 reads `materializationStatus: "failed"`. This keeps the entire validate/submit path synchronous and reuses the proven durable-signal + scoped-retry machinery (#513 → #517).
 
 ```
-ProposalChange.generatedSource  ──┐
-(valid, Phase-4 passed)           │
-                                  ▼
-        validation-engine ── Phase 5: execution dry-run (skipped if no runner) ──┐
-           fan out over (change × input case):                                   │
-       ExecutionDryRunProvider.dryRun({ source, input, inputCaseId, limits }) ───┤
-                                  │ (one isolated sandbox per call)               │
-        [capability] createSubprocessDryRunner()                                 │
-          network-denied Bun.spawn(child) → shimmed @linchkit/core → handler(input)│
-          collect { status, durationMs, peakMem, attemptedSideEffects, error }   │
-                                  ▼                                               ▼
-              DryRunOutcome[] (per case) ── aggregate per change ── map to PhaseResult ── warn|block
-                                  │
-                  (optional) persist dryRunStatus on the change → UI + scoped re-run
+materialize (async) per materializable change:                 validate (SYNC):
+  generate source → build-gate → fan out (change × input case):
+    ExecutionDryRunProvider.dryRun({ source, input,                Phase 5 reads
+      inputCaseId, tenantId, metadata, limits })  ─┐               change.dryRunStatus
+      [capability] createSubprocessDryRunner():     │                    │
+        network-denied Bun.spawn(child) →           │                    ▼
+        shimmed @linchkit/core → handler(input)     │           map to PhaseResult
+      collect DryRunOutcome (per case)  ────────────┤           (skipped if none) →
+                                                    ▼           warn | block (per
+   aggregate → STAMP durable dryRunStatus/Outcomes ───────────▶  strictExecutionDryRun)
+   on the change (persisted, like materializationStatus)        infra_error → always warn
 ```
 
 **Synthetic inputs** are derived from the action's declared input schema (a valid sample + a few edge cases). Optionally (§10 Q3) augmented with **historical inputs** from the execution log for that action — read-only, tenant-scoped (reuse the canonical `DataQueryOptions.tenantId` discipline), and field-masked (Spec 41) so no real PII enters the sandbox.
@@ -191,22 +190,24 @@ export interface ExecutionDryRunProvider {
 
 ## 7. Validation Integration and Gating
 
-Add **Phase 5 — Execution dry-run** to `validation-engine.ts`, after Phase 4. It runs only when ALL hold, else `skipped` (the same low-regret degrade as Phase 4):
+Add **Phase 5 — Execution dry-run** to `validation-engine.ts`, after Phase 4. Phase 5 is **synchronous**: it does NOT call the runner — it READS the durable `dryRunStatus` stamped on each materializable change during materialization (§5). It reports `skipped` (the same low-regret degrade as Phase 4) when no in-scope change carries a `dryRunStatus` — i.e. when:
 
-1. an `ExecutionDryRunProvider` is configured/injected, **and**
-2. the proposal has ≥1 materializable change with VALID `generatedSource` (its Phase 4 passed), **and**
-3. opt-in `features.executionDryRun` (or a per-call flag) is on.
+1. no `ExecutionDryRunProvider` was configured during materialization (nothing stamped a status), **or**
+2. no materializable change has a recorded dry-run result, **or**
+3. the dry-run feature (`features.executionDryRun`, consumed by the materialize path) was off, so nothing ran.
+
+Scope is guarded by `isMaterializable` (the same predicate as Phase 4): a change edited to a non-materializable target/operation after a dry-run carries a stale status that Phase 5 ignores.
 
 **Gating (mirrors Phase 2/3/4 low-regret):**
 
 - **DEFAULT — warn-only.** A dry-run failure is a strong signal, but synthetic inputs are imperfect; it must not block by default.
 - **GATED — `features.strictExecutionDryRun` flips warn→block.** Crucially this flag is **opt-in everywhere — NOT derived from `isProduction`** (unlike `strictCompatibility` / `strictGeneratedContract`). The dry-run depends on external sandbox infrastructure; auto-blocking in prod on an un-configured or flaky sandbox would wedge graduation. Blocking is enabled only when an operator has confirmed the sandbox is healthy.
 
-**Infra vs content failures — distinct handling:**
+**Infra vs content failures — distinct handling** (the dry-run stamps the status; Phase 5 reads it):
 
-- runner not configured → phase **skipped** (never blocks).
-- runner itself errors (spawn failure, infra down) → an **INFRA warning**, never a content error, never blocks — don't wedge graduation on a flaky sandbox.
-- sandbox kills the child (timeout/oom) or the handler throws / attempts a forbidden op → a **CONTENT finding** on that change, warn-or-block per the flag.
+- no runner configured during materialization → no `dryRunStatus` → phase **skipped** (never blocks).
+- runner itself failed (spawn failure, infra down, limits unenforceable) → `dryRunStatus: "infra_error"` → an **INFRA warning**, never a content error, never blocks — don't wedge graduation on a flaky sandbox.
+- sandbox killed the child (`timeout`/`oom`) or the handler threw / attempted a forbidden op / returned a bad shape → a **CONTENT finding** on that change, warn-or-block per the flag.
 
 ## 8. Failure and Safety Invariants
 
@@ -220,9 +221,9 @@ Add **Phase 5 — Execution dry-run** to `validation-engine.ts`, after Phase 4. 
 | Phase | Deliverable | Smoke test (real-boot) |
 |---|---|---|
 | **P1** | This spec; lean placeholder issues for P2–P5 | — |
-| **P2** | core `ExecutionDryRunProvider` + `DryRunOutcome` types + Phase 5 hook (skipped when no provider). No real execution. | validation pipeline emits Phase 5 = `skipped` with no runner; a fake provider returning `passed` flows through |
-| **P3** | capability `createSubprocessDryRunner()` (`Bun.spawn` + dropped env + temp cwd + timeout-kill + shimmed core). Warn-only. | a throwing handler → `threw`; an infinite loop → `timeout`; a clean handler → `passed`; **assert NO real side effect** in every case |
-| **P4** | forbidden-op detection (shimmed deps record attempts) + durable `dryRunStatus` on the change + `/admin/proposals` rendering (extends #514) + scoped single-change re-run (extends #517) | a handler that calls `store.create` → `forbidden_side_effect` with the attempt recorded, real store untouched |
+| **P2** ✅ | core `dry-run.ts` types + `ExecutionDryRunProvider` seam (for P3) + durable `dryRunStatus`/`dryRunOutcomes` on `ProposalChange` + `ValidationPhase` `1–4`→`1–5` + a **synchronous** `validatePhase5` that READS the durable signal (mirrors Phase 4). No execution; `validateProposal` stays sync. | `validatePhase5` unit: no status → `skipped`; `passed` → no finding; `threw` → warn (block under `strictExecutionDryRun`); `infra_error` → always warn; stale status on a non-materializable change ignored |
+| **P3** | capability `createSubprocessDryRunner()` (network-denied `Bun.spawn` + dropped env + temp cwd + timeout-kill + shimmed core), invoked from the **async materialize path** to STAMP `dryRunStatus`/`dryRunOutcomes`. Warn-only end-to-end. | a throwing handler → `threw`; an infinite loop → `timeout`; a clean handler → `passed`; **assert NO real side effect**; the stamped status reaches Phase 5 |
+| **P4** | forbidden-op detection (shimmed deps record attempts → `forbidden_side_effect` + `attemptedSideEffects`) + `/admin/proposals` rendering of `dryRunStatus` (extends #514) + scoped single-change re-run (extends #517) | a handler that calls `store.create` → `forbidden_side_effect` with the attempt recorded, real store untouched; UI shows it |
 | **P5** | `strictExecutionDryRun` block flag + microVM/container runner tier + OS resource-limit wrapper | block flag flips a `threw` finding to a blocking validation error; microvm runner parity smoke |
 
 Each phase follows the standard lifecycle (worktree → gates → cross-model review → PR) and keeps core execution-free (the runner is always a capability).

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -212,6 +212,7 @@ Capability definition, extension, composition, and distribution.
 
 | Date | Change |
 |------|--------|
+| 2026-06-09 | Spec 70 **P2 landed** + §5/§7 refined to the **durable-signal** architecture: the async dry-run runs in the (already-async) materialize path and stamps a durable `dryRunStatus`; validation **Phase 5 is synchronous** and only reads it (mirrors Phase 4 reading `materializationStatus`), so `validateProposal`/`submitProposal` stay sync. P2 ships core `dry-run.ts` types + `ExecutionDryRunProvider` seam + `ProposalChange.dryRunStatus`/`dryRunOutcomes` + `ValidationPhase`→`1–5` + `validatePhase5`. |
 | 2026-06-09 | Added Spec 70 (Execution Dry-Run Sandbox — Draft) — designs the deferred execution counterpart to Spec 55 §7.7's static Phase 4: run AI-generated handler source in a hardened Bun-subprocess sandbox as an opt-in, infra-gated validation Phase 5. Threat model + sandbox tech comparison + phased rollout. Stats: Total 72→73, Draft +1. |
 | 2026-06-07 | Spec 55 §7.7 代码物化 added — G5 materialization (provider #494, materializer+build-gate #495, live endpoint+UI #496) documented; old §7.7 反馈回路 renumbered to §7.8. |
 | 2026-06-01 | Spec 45 progress: `schedule` trigger implemented (croner, PR #439) + `_linchkit.watcher_state` debounce persistence (`WatcherStateStore` InMemory default + Drizzle PG backend) — restart-safe `once_until_reset`. Status stays Partial: the watcher admin UI `EntityDefinition` (§7.1) is still deferred. |

--- a/packages/core/__tests__/proposal-materializer.durable-status.test.ts
+++ b/packages/core/__tests__/proposal-materializer.durable-status.test.ts
@@ -244,4 +244,76 @@ describe("materializeProposalChanges — durable materialization status", () => 
     // The input proposal is never mutated.
     expect(input.changes[1]?.generatedSource).toBe("export const stale = 1;");
   });
+
+  test("re-materialization clears a stale dry-run signal (Spec 70 P2)", async () => {
+    // A change that was dry-run "passed" against its PRIOR source, then
+    // regenerated. The old dry-run verdict belongs to the old source, so
+    // re-materialization must CLEAR it — otherwise Phase 5 would read a stale
+    // "passed" and wrongly clear `strictExecutionDryRun` for the NEW, never-run
+    // source (or keep blocking on a stale "failed" after the code was fixed).
+    // (Regression for the codex review on the Spec 70 P2 seam.)
+    const input = makeProposal([
+      {
+        target: "action",
+        operation: "create",
+        name: "deduct_inventory",
+        dryRunStatus: "passed",
+        dryRunOutcomes: [{ changeName: "deduct_inventory", target: "action", status: "passed" }],
+      },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+    });
+
+    const change = result.proposal.changes[0];
+    expect(change?.materializationStatus).toBe("materialized");
+    // The regenerated change carries NO dry-run verdict — the P3 runner re-stamps
+    // it against the new source.
+    expect(change?.dryRunStatus).toBeUndefined();
+    expect(change?.dryRunOutcomes).toBeUndefined();
+  });
+
+  test("scoped retry of A clears A's dry-run but PRESERVES out-of-scope B's (Spec 70 P2)", async () => {
+    // A scoped retry regenerates A (→ its stale dry-run signal is invalidated)
+    // but leaves B untouched — B's source is unchanged, so B's dry-run verdict is
+    // still valid and must be preserved (it is bound to the same source).
+    const input = makeProposal([
+      {
+        target: "action",
+        operation: "create",
+        name: "action_a",
+        dryRunStatus: "failed",
+        dryRunOutcomes: [{ changeName: "action_a", target: "action", status: "threw" }],
+      },
+      {
+        target: "action",
+        operation: "create",
+        name: "action_b",
+        generatedSource: GOOD,
+        materializationStatus: "materialized",
+        dryRunStatus: "passed",
+        dryRunOutcomes: [{ changeName: "action_b", target: "action", status: "passed" }],
+      },
+    ]);
+
+    const result = await materializeProposalChanges({
+      proposal: input,
+      provider: makeProvider(GOOD),
+      qualityGate: createSyntaxQualityGate(),
+      changeNames: ["action_a"], // scope to A only
+    });
+
+    const a = result.proposal.changes.find((c) => c.name === "action_a");
+    const b = result.proposal.changes.find((c) => c.name === "action_b");
+    // A regenerated → its stale dry-run signal cleared.
+    expect(a?.materializationStatus).toBe("materialized");
+    expect(a?.dryRunStatus).toBeUndefined();
+    expect(a?.dryRunOutcomes).toBeUndefined();
+    // B out-of-scope (source untouched) → its dry-run verdict is preserved.
+    expect(b?.dryRunStatus).toBe("passed");
+    expect(b?.dryRunOutcomes?.[0]?.status).toBe("passed");
+  });
 });

--- a/packages/core/__tests__/proposal-validation-misc.test.ts
+++ b/packages/core/__tests__/proposal-validation-misc.test.ts
@@ -5,13 +5,13 @@ import { baseProposalOptions, createTestEngine } from "./proposal-fixtures";
 // ── validateProposal ────────────────────────────────────
 
 describe("validateProposal", () => {
-  it("returns full validation result with all 4 phases", () => {
+  it("returns full validation result with all 5 phases", () => {
     const engine = createTestEngine();
     const proposal = engine.createProposal(baseProposalOptions);
 
     const result = validateProposal({ proposal });
 
-    expect(result.phases).toHaveLength(4);
+    expect(result.phases).toHaveLength(5);
     expect(result.phases[0].phase).toBe(1);
     expect(result.phases[0].status).toBe("passed");
     expect(result.phases[1].phase).toBe(2);
@@ -20,6 +20,10 @@ describe("validateProposal", () => {
     expect(result.phases[2].status).toBe("skipped");
     expect(result.phases[3].phase).toBe(4);
     expect(result.phases[3].status).toBe("skipped");
+    // Phase 5 (execution dry-run signal) — skipped: the base proposal carries no
+    // durable `dryRunStatus` (Spec 70 P2).
+    expect(result.phases[4].phase).toBe(5);
+    expect(result.phases[4].status).toBe("skipped");
     expect(result.impactSummary).toContain("1 change(s)");
   });
 });

--- a/packages/core/src/__tests__/engine/validation-phase5.test.ts
+++ b/packages/core/src/__tests__/engine/validation-phase5.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import { validatePhase5 } from "../../engine/validation-phase5";
+import type { ProposalChange } from "../../types/proposal";
+
+function change(overrides: Partial<ProposalChange>): ProposalChange {
+  // A materializable change is an action create/update (mirrors the Phase 4 test).
+  return { target: "action", operation: "create", name: "do_thing", ...overrides };
+}
+
+describe("validatePhase5 — execution dry-run signal", () => {
+  test("skips when no change carries a dryRunStatus", () => {
+    const result = validatePhase5({
+      changes: [change({}), change({ target: "rule", name: "r1" })],
+    });
+    expect(result.phase).toBe(5);
+    expect(result.status).toBe("skipped");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a passed dry-run produces no finding and the phase passes", () => {
+    const result = validatePhase5({
+      changes: [change({ name: "do_thing", dryRunStatus: "passed" })],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a skipped dry-run on a materializable change produces no finding and passes", () => {
+    const result = validatePhase5({
+      changes: [change({ name: "do_thing", dryRunStatus: "skipped" })],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a threw dry-run is warn-only by default: warning, status stays passed", () => {
+    const result = validatePhase5({
+      changes: [change({ name: "do_thing", dryRunStatus: "threw" })],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.code).toBe("EXECUTION_DRY_RUN_FAILED");
+    expect(result.warnings[0]?.message).toContain("do_thing");
+    expect(result.warnings[0]?.message).toContain("threw");
+    expect(result.warnings[0]?.target).toBe("do_thing");
+  });
+
+  test("a threw dry-run under strictExecutionDryRun becomes a blocking error", () => {
+    const result = validatePhase5({
+      changes: [change({ name: "do_thing", dryRunStatus: "threw" })],
+      strictExecutionDryRun: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]?.code).toBe("EXECUTION_DRY_RUN_FAILED");
+    expect(result.errors[0]?.message).toContain("do_thing");
+    expect(result.errors[0]?.target).toBe("do_thing");
+  });
+
+  test("every content-failure status is reported (timeout/oom/forbidden_side_effect/malformed_output)", () => {
+    for (const status of ["timeout", "oom", "forbidden_side_effect", "malformed_output"] as const) {
+      const result = validatePhase5({
+        changes: [change({ name: "do_thing", dryRunStatus: status })],
+        strictExecutionDryRun: true,
+      });
+      expect(result.status).toBe("failed");
+      expect(result.errors.length).toBe(1);
+      expect(result.errors[0]?.code).toBe("EXECUTION_DRY_RUN_FAILED");
+      expect(result.errors[0]?.message).toContain(status);
+    }
+  });
+
+  test("infra_error is ALWAYS a warning, even under strictExecutionDryRun (never blocks)", () => {
+    const result = validatePhase5({
+      changes: [change({ name: "do_thing", dryRunStatus: "infra_error" })],
+      strictExecutionDryRun: true,
+    });
+    expect(result.status).toBe("passed"); // never blocks
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.code).toBe("EXECUTION_DRY_RUN_INFRA");
+    expect(result.warnings[0]?.message).toContain("do_thing");
+    expect(result.warnings[0]?.target).toBe("do_thing");
+  });
+
+  test("a NON-materializable change carrying a stray dryRunStatus is ignored → skipped", () => {
+    // An entity is not materializable; a stale dryRunStatus on it (e.g. edited
+    // from action→entity without re-running) must not be treated as a real
+    // dry-run result. Guarded by isMaterializable, so the phase degrades to
+    // "skipped" — and does NOT block even under strict.
+    const result = validatePhase5({
+      changes: [change({ target: "entity", name: "invoice", dryRunStatus: "threw" })],
+      strictExecutionDryRun: true,
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("a delete operation is not materializable → a stray dryRunStatus is ignored", () => {
+    const result = validatePhase5({
+      changes: [change({ operation: "delete", name: "do_thing", dryRunStatus: "threw" })],
+      strictExecutionDryRun: true,
+    });
+    expect(result.status).toBe("skipped");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("the first outcome's error is surfaced in the finding message", () => {
+    const result = validatePhase5({
+      changes: [
+        change({
+          name: "do_thing",
+          dryRunStatus: "threw",
+          dryRunOutcomes: [
+            {
+              changeName: "do_thing",
+              target: "action",
+              status: "threw",
+              error: "TypeError: cannot read 'id' of undefined",
+              inputCaseId: "case-1",
+            },
+          ],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.message).toContain("TypeError: cannot read 'id' of undefined");
+  });
+
+  test("a forbidden side-effect detail is surfaced when no error is present", () => {
+    const result = validatePhase5({
+      changes: [
+        change({
+          name: "do_thing",
+          dryRunStatus: "forbidden_side_effect",
+          dryRunOutcomes: [
+            {
+              changeName: "do_thing",
+              target: "action",
+              status: "forbidden_side_effect",
+              attemptedSideEffects: [{ kind: "db_write", detail: "store.create('order', …)" }],
+              inputCaseId: "case-1",
+            },
+          ],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.message).toContain("store.create('order', …)");
+  });
+
+  test("a long outcome detail is capped with an ellipsis", () => {
+    const longError = "x".repeat(500);
+    const result = validatePhase5({
+      changes: [
+        change({
+          name: "do_thing",
+          dryRunStatus: "threw",
+          dryRunOutcomes: [
+            { changeName: "do_thing", target: "action", status: "threw", error: longError },
+          ],
+        }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    const msg = result.warnings[0]?.message ?? "";
+    expect(msg).toContain("...");
+    expect(msg).not.toContain(longError);
+  });
+
+  test("a content failure with no outcome detail still flags (no Detail suffix, no crash)", () => {
+    const result = validatePhase5({
+      changes: [change({ name: "do_thing", dryRunStatus: "threw" })],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.message).not.toContain("Detail:");
+  });
+
+  test("mix: one passed + one threw + one infra_error → non-strict passes with two warnings", () => {
+    const result = validatePhase5({
+      changes: [
+        change({ name: "ok", dryRunStatus: "passed" }),
+        change({ name: "bad", dryRunStatus: "threw" }),
+        change({ name: "flaky", dryRunStatus: "infra_error" }),
+      ],
+    });
+    expect(result.status).toBe("passed");
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(2);
+    expect(result.warnings.some((w) => w.code === "EXECUTION_DRY_RUN_FAILED")).toBe(true);
+    expect(result.warnings.some((w) => w.code === "EXECUTION_DRY_RUN_INFRA")).toBe(true);
+  });
+
+  test("mix: one threw + one infra_error under strict → fails on content, infra stays warning", () => {
+    const result = validatePhase5({
+      changes: [
+        change({ name: "bad", dryRunStatus: "threw" }),
+        change({ name: "flaky", dryRunStatus: "infra_error" }),
+      ],
+      strictExecutionDryRun: true,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]?.code).toBe("EXECUTION_DRY_RUN_FAILED");
+    expect(result.errors[0]?.target).toBe("bad");
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]?.code).toBe("EXECUTION_DRY_RUN_INFRA");
+    expect(result.warnings[0]?.target).toBe("flaky");
+  });
+});

--- a/packages/core/src/engine/proposal-materializer.ts
+++ b/packages/core/src/engine/proposal-materializer.ts
@@ -131,12 +131,15 @@ export async function materializeProposalChanges(
     if (scope && !scope.has(change.name)) {
       // A NON-materializable out-of-scope change (e.g. one edited action→entity
       // since it was last materialized) must NOT retain a stale `generatedSource`
-      // — `ProposalFileWriter` would write it at graduation. Clear it exactly as
-      // the in-scope declarative path does, and report "skipped".
+      // — `ProposalFileWriter` would write it at graduation. Clear it (and its
+      // now-meaningless dry-run signal) exactly as the in-scope declarative path
+      // does, and report "skipped".
       if (!isMaterializable(change)) {
         change.generatedSource = undefined;
         change.materializationStatus = undefined;
         change.materializationErrors = undefined;
+        change.dryRunStatus = undefined;
+        change.dryRunOutcomes = undefined;
         outcomes.push({
           changeName: change.name,
           target: change.target,
@@ -169,15 +172,23 @@ export async function materializeProposalChanges(
       continue;
     }
 
-    // Clear any pre-existing source AND durable quality signal up front — BEFORE
+    // Clear any pre-existing source AND durable quality signals up front — BEFORE
     // the materializable check — so neither a re-materialization NOR a change
     // that became non-materializable (its target/operation was edited, e.g.
     // action→entity or create→delete) ever leaves a STALE source/status/errors
     // behind. They are set again only as a materializable attempt resolves; a
     // skipped (declarative) change correctly carries no materialization artifacts.
+    //
+    // The Spec 70 dry-run signal (`dryRunStatus`/`dryRunOutcomes`) belongs to the
+    // OLD source, so it is cleared here too: a regenerated change must NOT carry a
+    // prior source's dry-run verdict into Phase 5 (a stale "passed" would wrongly
+    // clear `strictExecutionDryRun`; a stale "failed" would wrongly keep blocking
+    // after the code was fixed). The P3 runner re-stamps it against the NEW source.
     change.generatedSource = undefined;
     change.materializationStatus = undefined;
     change.materializationErrors = undefined;
+    change.dryRunStatus = undefined;
+    change.dryRunOutcomes = undefined;
 
     if (!isMaterializable(change)) {
       outcomes.push({

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -28,6 +28,7 @@ import type { StateDefinition } from "../types/state";
 import { validatePhase2 } from "./validation-phase2";
 import { validatePhase3 } from "./validation-phase3";
 import { validatePhase4 } from "./validation-phase4";
+import { validatePhase5 } from "./validation-phase5";
 
 // ── Valid field types ────────────────────────────────────
 // Relationships are now declared via defineRelation(), not field types
@@ -87,6 +88,14 @@ export interface ValidationContext {
    * default. When no change carries generated source, Phase 4 is skipped.
    */
   strictGeneratedContract?: boolean;
+  /**
+   * Escalate Phase 5 (execution dry-run) findings from WARN to BLOCK. Default
+   * (false/undefined) → Phase 5 is warn-only. Unlike `strictGeneratedContract`
+   * this is NOT auto-derived from `isProduction` (Spec 70 §7) — it depends on
+   * configured sandbox infra. An `infra_error` dry-run status NEVER blocks, even
+   * when this is true.
+   */
+  strictExecutionDryRun?: boolean;
 }
 
 // ── Phase 1: Static checks ──────────────────────────────
@@ -700,7 +709,20 @@ export function validateProposal(options: {
     strictGeneratedContract: context?.strictGeneratedContract,
   });
 
-  const phases = [phase1, phase2, phase3, phase4];
+  // Phase 5: Execution dry-run SIGNAL (Spec 70 P2) — reads the DURABLE
+  // `dryRunStatus` a sandbox runner stamps on a change (the actual sandboxed
+  // execution runs LATER in a capability, P3, never here). A failing dry-run
+  // (threw/timeout/oom/forbidden_side_effect/malformed_output) becomes a content
+  // finding; `infra_error` is always a non-blocking warning. Warn-only by
+  // default; gated to BLOCK via strictExecutionDryRun (opt-in, NOT derived from
+  // isProduction). No change carries a `dryRunStatus` → "skipped". Stays SYNC —
+  // it executes nothing.
+  const phase5 = validatePhase5({
+    changes: proposal.changes,
+    strictExecutionDryRun: context?.strictExecutionDryRun,
+  });
+
+  const phases = [phase1, phase2, phase3, phase4, phase5];
   const passed = phases.filter((p) => p.status !== "skipped").every((p) => p.status === "passed");
 
   // Generate impact summary

--- a/packages/core/src/engine/validation-phase5.ts
+++ b/packages/core/src/engine/validation-phase5.ts
@@ -1,0 +1,185 @@
+/**
+ * Validation Phase 5 — Execution dry-run signal (Spec 70 P2).
+ *
+ * Phase 5 reads the DURABLE `dryRunStatus` that a Spec 70 sandbox runner stamps
+ * on a materializable change (during materialization in P3) and turns a failing
+ * outcome into a validation finding. It is the execution counterpart to the
+ * static Phase 4 contract check: where Phase 4 verifies the generated source
+ * *looks* right, the dry-run observed whether it actually *ran*.
+ *
+ * SAFETY — EXECUTION-FREE BY DESIGN ("AI never modifies production directly"):
+ * this Phase NEVER `eval`s, `import`s, transpiles-and-runs, or invokes an
+ * `ExecutionDryRunProvider`. The untrusted AI code is run LATER, once, inside a
+ * locked-down capability sandbox (P3) — never as a side effect of validation.
+ * Phase 5 only READS the persisted `dryRunStatus`, exactly as Phase 4 reads
+ * `materializationStatus: "failed"`. `validateProposal` therefore stays SYNC.
+ *
+ * Status → finding mapping:
+ *   - threw / timeout / oom / forbidden_side_effect / malformed_output → a CONTENT
+ *     finding (code `EXECUTION_DRY_RUN_FAILED`). Warn-or-block per the flag below.
+ *   - infra_error → ALWAYS a WARNING (distinct code `EXECUTION_DRY_RUN_INFRA`),
+ *     regardless of the flag: a flaky/down sandbox is not a content verdict and
+ *     must never wedge graduation (Spec 70 §7).
+ *   - passed / skipped → no finding.
+ *
+ * Severity / gating mirrors Phase 2 / Phase 3 / Phase 4 (low-regret):
+ *   - DEFAULT: WARN-ONLY. Content findings are `warnings`; `passed` is unaffected.
+ *     Synthetic inputs are imperfect, so the dry-run must not block by default.
+ *   - GATED: when `strictExecutionDryRun` is true, CONTENT findings become
+ *     `errors` (status "failed" → proposal `passed` = false → blocks). Unlike
+ *     `strictGeneratedContract`, this flag is OPT-IN everywhere and is NEVER
+ *     derived from `isProduction` (Spec 70 §7): the dry-run depends on external
+ *     sandbox infra, so auto-blocking on an un-configured/flaky sandbox would
+ *     wedge graduation. `infra_error` stays a warning even when this is true.
+ *
+ * A proposal where no change carries a `dryRunStatus` degrades to "skipped".
+ */
+
+import type {
+  PhaseResult,
+  ProposalChange,
+  ValidationError,
+  ValidationWarning,
+} from "../types/proposal";
+import { isMaterializable } from "./proposal-materializer";
+
+// ── Options ──────────────────────────────────────────────
+
+export interface ValidatePhase5Options {
+  /** The proposal's changes to inspect for a durable `dryRunStatus`. */
+  changes: ProposalChange[];
+  /**
+   * When true, CONTENT dry-run findings become ERRORS (blocking). Default
+   * (false / undefined) → content findings are WARNINGS only and do not affect
+   * `passed`. Synthetic inputs are imperfect, so warn-only is the safe default.
+   * NOT derived from `isProduction` (Spec 70 §7). `infra_error` is always a
+   * warning regardless.
+   */
+  strictExecutionDryRun?: boolean;
+}
+
+// ── Status classification ────────────────────────────────
+
+/**
+ * Dry-run statuses that are a CONTENT verdict — the generated handler misbehaved
+ * (threw, ran away on resources, attempted a forbidden op, or returned a bad
+ * shape). These warn-or-block per `strictExecutionDryRun`.
+ */
+const CONTENT_FAILURE_STATUSES = new Set<ProposalChange["dryRunStatus"]>([
+  "threw",
+  "timeout",
+  "oom",
+  "forbidden_side_effect",
+  "malformed_output",
+]);
+
+/** Cap a detail string so a single finding message stays reasonable. */
+function cap(detail: string): string {
+  return detail.length > 300 ? `${detail.slice(0, 297)}...` : detail;
+}
+
+/**
+ * Extract the first useful human-readable detail from a change's per-case
+ * outcomes: an outcome's `error`, else the first recorded `attemptedSideEffects`
+ * detail. The outcomes can be rehydrated from persisted JSON, so guard against a
+ * malformed array / non-string entries producing a malformed finding message.
+ */
+function firstOutcomeDetail(change: ProposalChange): string {
+  const outcomes = Array.isArray(change.dryRunOutcomes) ? change.dryRunOutcomes : [];
+  for (const outcome of outcomes) {
+    if (!outcome || typeof outcome !== "object") continue;
+    if (typeof outcome.error === "string" && outcome.error.trim().length > 0) {
+      return outcome.error.trim();
+    }
+    const effects = Array.isArray(outcome.attemptedSideEffects) ? outcome.attemptedSideEffects : [];
+    for (const effect of effects) {
+      if (
+        effect &&
+        typeof effect === "object" &&
+        typeof effect.detail === "string" &&
+        effect.detail.trim().length > 0
+      ) {
+        return effect.detail.trim();
+      }
+    }
+  }
+  return "";
+}
+
+// ── Entry point ──────────────────────────────────────────
+
+/**
+ * Run Phase 5 (execution dry-run signal) validation on a proposal's changes.
+ *
+ * Returns a PhaseResult:
+ *  - no change carries a `dryRunStatus` → status "skipped"
+ *  - content findings + strictExecutionDryRun=false → status "passed" with
+ *    `warnings` (infra findings are also warnings)
+ *  - content findings + strictExecutionDryRun=true  → status "failed" with
+ *    `errors` (infra findings stay `warnings`)
+ */
+export function validatePhase5(options: ValidatePhase5Options): PhaseResult {
+  const { changes, strictExecutionDryRun = false } = options;
+  const start = Date.now();
+
+  // Only MATERIALIZABLE changes carrying a durable `dryRunStatus` are in scope.
+  //
+  // Guard with `isMaterializable` (the SAME predicate the materializer and Phase
+  // 4 use) so a change carrying a STALE dry-run status from when it WAS
+  // materializable but has since been edited to a non-materializable
+  // target/operation (e.g. action→entity, create→delete) is NOT flagged — it no
+  // longer needs code at all, so reporting it (and blocking under strict) would
+  // be wrong.
+  const withStatus = changes.filter((c) => c.dryRunStatus !== undefined && isMaterializable(c));
+
+  // Skip when no in-scope change carries a dry-run result — same low-regret
+  // degrade as Phase 4 (an all-declarative / never-dry-run proposal).
+  if (withStatus.length === 0) {
+    return { phase: 5, status: "skipped", errors: [], warnings: [], duration: Date.now() - start };
+  }
+
+  // Content findings warn-or-block per the flag; infra findings are ALWAYS
+  // warnings (a flaky sandbox must never wedge graduation — Spec 70 §7).
+  const contentFindings: Array<{ code: string; message: string; target?: string }> = [];
+  const infraWarnings: ValidationWarning[] = [];
+
+  for (const change of withStatus) {
+    const status = change.dryRunStatus;
+    // passed / skipped → nothing to report.
+    if (status === "passed" || status === "skipped") continue;
+
+    if (status === "infra_error") {
+      infraWarnings.push({
+        code: "EXECUTION_DRY_RUN_INFRA",
+        message: `Execution dry-run for ${change.target} "${change.name}" could not run (sandbox infra error); no behavioral verdict was produced.`,
+        target: change.name,
+      });
+      continue;
+    }
+
+    if (CONTENT_FAILURE_STATUSES.has(status)) {
+      const detail = firstOutcomeDetail(change);
+      const suffix = detail ? ` Detail: ${cap(detail)}` : "";
+      contentFindings.push({
+        code: "EXECUTION_DRY_RUN_FAILED",
+        message: `Execution dry-run for ${change.target} "${change.name}" failed (status "${status}") — the generated handler did not run cleanly against the synthetic inputs.${suffix}`,
+        target: change.name,
+      });
+    }
+  }
+
+  const errors: ValidationError[] = [];
+  const warnings: ValidationWarning[] = [...infraWarnings];
+  if (strictExecutionDryRun) {
+    for (const f of contentFindings) errors.push(f);
+  } else {
+    for (const f of contentFindings) warnings.push(f);
+  }
+
+  // Warn-only by default: status stays "passed" even with warnings — `passed` is
+  // only dragged false when strictExecutionDryRun escalated CONTENT findings to
+  // errors. infra_error warnings never affect `passed`.
+  const status: PhaseResult["status"] = errors.length === 0 ? "passed" : "failed";
+
+  return { phase: 5, status, errors, warnings, duration: Date.now() - start };
+}

--- a/packages/core/src/types/dry-run.ts
+++ b/packages/core/src/types/dry-run.ts
@@ -1,0 +1,138 @@
+/**
+ * Execution dry-run types — Spec 70 P2 seam.
+ *
+ * This is the CORE seam for the generated-code execution dry-run (Spec 70 — the
+ * execution companion to Spec 55 §7.7 G5 static materialization). It defines the
+ * data shapes a dry-run produces plus the `ExecutionDryRunProvider` interface —
+ * the injectable seam a CAPABILITY (e.g. a subprocess sandbox runner) implements
+ * in P3. It mirrors the existing `CodeGenerationProvider` pattern: core declares
+ * the seam, a capability supplies the impl, tests inject a fake.
+ *
+ * SAFETY — CORE STAYS EXECUTION-FREE BY DESIGN ("AI never modifies production
+ * directly"): core NEVER runs an `ExecutionDryRunProvider` here. P2 only declares
+ * the interface (for P3 to implement) and the durable-signal types. The actual
+ * sandboxed execution runs LATER (P3) inside a capability, behind opt-in
+ * `features.executionDryRun`, and stamps a durable `dryRunStatus` on the change.
+ * Validation Phase 5 (`validatePhase5`) only READS that durable status — exactly
+ * as Phase 4 reads `materializationStatus` — and never executes anything.
+ *
+ * `import type` is used throughout so these type-only declarations create no
+ * runtime import cycle with `proposal.ts`.
+ */
+
+import type { ProposalChangeTarget } from "./proposal";
+
+// ── Dry-run status ───────────────────────────────────────
+
+/**
+ * Aggregate outcome of a generated change's execution dry-run. The change-level
+ * durable `dryRunStatus` is the WORST-CASE across that change's input cases (any
+ * `threw` / `timeout` / `oom` / `forbidden_side_effect` / `malformed_output`
+ * dominates `passed`).
+ */
+export type DryRunStatus =
+  /** Ran to completion, well-formed output, no forbidden op. */
+  | "passed"
+  /** The handler threw. */
+  | "threw"
+  /** Exceeded the wall-clock limit → killed by the sandbox. */
+  | "timeout"
+  /** Exceeded the memory cap → killed by the sandbox. */
+  | "oom"
+  /** Attempted DB / network / fs / env access (recorded, not performed). */
+  | "forbidden_side_effect"
+  /** Returned a shape violating the action's declared output contract. */
+  | "malformed_output"
+  /**
+   * The sandbox itself failed (spawn error, missing binary, limits
+   * unenforceable). This is NOT a content verdict — Phase 5 surfaces it as a
+   * WARNING that never blocks, even under strict gating (Spec 70 §7).
+   */
+  | "infra_error"
+  /** Not materializable / no valid source / no runner configured. */
+  | "skipped";
+
+// ── Recorded side-effect attempt ─────────────────────────
+
+/**
+ * A side-effecting operation the handler ATTEMPTED inside the sandbox. The
+ * shimmed dependencies RECORD the attempt rather than performing it, so a
+ * forbidden op is detected, never executed for real.
+ */
+export interface AttemptedSideEffect {
+  /** Which I/O surface the handler reached for. */
+  kind: "db_write" | "db_read" | "network" | "fs" | "env" | "unknown";
+  /** e.g. "store.create('order', …)" — truncated, no payload. */
+  detail: string;
+}
+
+// ── Per-input-case dry-run outcome ───────────────────────
+
+/**
+ * The outcome of running ONE generated change against ONE input case in the
+ * sandbox. The P3 materialize-path runner fans the provider out over every
+ * (change × synthetic/historical input) pair, collects the per-case array, and
+ * stamps the worst-case aggregate as the durable change-level `dryRunStatus`
+ * that validation Phase 5 then reads.
+ */
+export interface DryRunOutcome {
+  /** The change whose generated source was run. */
+  changeName: string;
+  /** The change's target (today only `action` is materializable). */
+  target: ProposalChangeTarget;
+  /** This case's outcome. */
+  status: DryRunStatus;
+  /** Wall-clock duration of this case, when measured. */
+  durationMs?: number;
+  /** Peak memory observed for this case, when measured. */
+  peakMemoryBytes?: number;
+  /** Side-effecting ops the handler attempted (recorded, never performed). */
+  attemptedSideEffects?: AttemptedSideEffect[];
+  /** Truncated message if it threw. */
+  error?: string;
+  /**
+   * Captured + truncated child stdout/stderr (stack traces, console.*) so the
+   * reviewer can debug a failing dry-run in the UI.
+   */
+  logs?: string;
+  /** Which synthetic/historical input produced this outcome (repro). */
+  inputCaseId?: string;
+}
+
+// ── Provider seam (P3 implements; core never calls it here) ──
+
+/**
+ * Injectable seam for the execution dry-run (Spec 70). A CAPABILITY implements
+ * this in P3 (e.g. a hardened `Bun.spawn` subprocess runner); core declares the
+ * interface only and NEVER invokes it during validation. Mirrors the
+ * `CodeGenerationProvider` injectable-seam pattern.
+ */
+export interface ExecutionDryRunProvider {
+  /**
+   * Run ONE generated change against ONE input case in the sandbox, returning
+   * that case's outcome (carrying its `inputCaseId` for reproducibility). The P3
+   * materialize-path runner fans this out over every (change × synthetic/
+   * historical input) pair — each in its own isolated sandbox — collects the
+   * per-case `DryRunOutcome[]`, and stamps the WORST-CASE aggregate as the
+   * durable `dryRunStatus` (validation Phase 5 only READS that; it never calls
+   * this provider).
+   */
+  dryRun(job: {
+    /** The AI-materialized TypeScript source to run. */
+    source: string;
+    /** The change's target (today only `action`). */
+    target: ProposalChangeTarget;
+    /** The declared change name. */
+    changeName: string;
+    /** The synthetic/historical input fed to the handler. */
+    input: unknown;
+    /** Identifies the input case for reproducibility. */
+    inputCaseId: string;
+    /** Injected into the shimmed, tenant-scoped sandbox context. */
+    tenantId?: string;
+    /** ExecutionMeta-like fields the handler may read (Spec 65). */
+    metadata?: Record<string, unknown>;
+    /** Hard resource bounds the sandbox enforces (kill on breach). */
+    limits: { timeoutMs: number; memoryBytes: number };
+  }): Promise<DryRunOutcome>;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -22,6 +22,7 @@ export type * from "./cli";
 export type * from "./command";
 export type * from "./config";
 export type * from "./database";
+export type * from "./dry-run";
 export type * from "./entity";
 export type * from "./error";
 // Non-type exports

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -9,6 +9,7 @@
 import type { ProposalPreAnalysisResult } from "../life-system/proposal-preanalysis/types";
 import type { ImpactNode } from "../ontology/impact-analysis";
 import type { ActionDefinition } from "./action";
+import type { DryRunOutcome, DryRunStatus } from "./dry-run";
 import type { EntityDefinition } from "./entity";
 import type { EventDefinition } from "./event";
 import type { FieldOverlayDefinition } from "./overlay";
@@ -142,6 +143,24 @@ export interface ProposalChange {
    * candidate source without re-running materialization.
    */
   materializationErrors?: string[];
+  /**
+   * Durable result of the Spec 70 execution dry-run for this change (P3).
+   *
+   * The async sandbox dry-run runs LATER (during materialization in P3) and
+   * stamps the WORST-CASE aggregate status here — mirroring the
+   * `materializationStatus` arc (#513). Validation Phase 5 (`validatePhase5`)
+   * READS this synchronously and emits findings; core never executes the dry-run
+   * as a side effect of validation. Undefined when the change was never
+   * dry-run (no runner configured, not materializable, or feature off).
+   * Candidate signal only — it never auto-advances the proposal.
+   */
+  dryRunStatus?: DryRunStatus;
+  /**
+   * Per-input-case outcomes behind the aggregate `dryRunStatus` (Spec 70 P3) —
+   * for the `/admin/proposals` UI and reproducibility. Each entry carries the
+   * `inputCaseId` that produced it. Undefined when the change was never dry-run.
+   */
+  dryRunOutcomes?: DryRunOutcome[];
 }
 
 // ── Impact analysis ──────────────────────────────────────
@@ -158,7 +177,7 @@ export interface ProposalImpact {
 
 // ── Validation types ─────────────────────────────────────
 
-export type ValidationPhase = 1 | 2 | 3 | 4;
+export type ValidationPhase = 1 | 2 | 3 | 4 | 5;
 
 export type ValidationPhaseStatus = "passed" | "failed" | "skipped";
 


### PR DESCRIPTION
## Summary

Lands **P2 — the core seam** of Spec 70 (Execution Dry-Run Sandbox), closing #519. Uses the **durable-signal architecture** (decided with the owner) so the validation pipeline stays **synchronous**: the async dry-run runs LATER (P3) in the already-async materialize path and stamps a durable `dryRunStatus`; validation Phase 5 only *reads* it — exactly as Phase 4 reads `materializationStatus`.

## Changes

- **`packages/core/src/types/dry-run.ts`** (new) — `DryRunStatus` (incl. `infra_error`), `AttemptedSideEffect`, `DryRunOutcome` (per-input-case, with `logs`), and the `ExecutionDryRunProvider` interface for the P3 capability runner. Type-only imports (no cycle). **Core never calls the provider here** — it stays execution-free.
- **`ProposalChange`** gains durable `dryRunStatus` / `dryRunOutcomes` (mirrors `materializationStatus`). **`ValidationPhase`** widened `1|2|3|4` → `1|2|3|4|5`.
- **`ValidationContext.strictExecutionDryRun`** — opt-in, **NOT** `isProduction`-derived (Spec 70 §7).
- **`packages/core/src/engine/validation-phase5.ts`** (new) — synchronous `validatePhase5` reading `dryRunStatus`: content failures (`threw`/`timeout`/`oom`/`forbidden_side_effect`/`malformed_output`) warn (block under `strictExecutionDryRun`); `infra_error` is **always** a non-blocking warning; `isMaterializable` scoping ignores a stale status on a change edited to a non-materializable target. Wired into `validateProposal` after Phase 4 — `validateProposal` stays **sync**.
- **`proposal-materializer.ts`** — re-materialization now also clears the durable dry-run signal (see Review).
- Spec 70 §5/§7/§9 refined to the durable-signal flow; INDEX changelog updated.

## Tests

- `validation-phase5.test.ts` (15 cases): skipped/passed/threw-warn-vs-block/infra-always-warn/stale-status-ignored/detail-surfaced/capping/mixed-batch.
- `proposal-materializer.durable-status.test.ts` (+2): re-materialization clears a stale dry-run signal; a scoped retry of A clears A's but preserves out-of-scope B's.
- Updated the engine `validateProposal` phase-count test (4 → 5 phases). Full suite green.

## Review

codex review (1 round) found a real correctness bug: re-materialization cleared `generatedSource`/materialization fields but **preserved** the old `dryRunStatus`, so a regenerated change would carry a prior source's dry-run verdict into Phase 5 (stale `passed` wrongly clears strict gating; stale `failed` wrongly keeps blocking). **Fixed**: both materializer clear-sites now also clear `dryRunStatus`/`dryRunOutcomes` (out-of-scope changes whose source is untouched correctly keep theirs) — pinned by the 2 new regression tests. CLI gemini was unavailable (ECONNRESET); the PR gemini-code-assist + CodeRabbit bots provide the second-model pass.

## Safety

Core stays execution-free — the provider interface is defined for P3 but never invoked. No execution, no new deps. P3 (the actual sandbox runner, where untrusted code first executes) remains gated on the owner's Spec 70 §10 answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
