### PR TITLE
feat(cap-dry-run): hardened Bun-subprocess execution dry-run runner (Spec 70 P3)

### DIFF
--- a/addons/dry-run/cap-dry-run/README.md
+++ b/addons/dry-run/cap-dry-run/README.md
@@ -69,7 +69,7 @@ const outcome = await runner.dryRun({
   inputCaseId: "case-0",
   limits: { timeoutMs: 5000, memoryBytes: 256 * 1024 * 1024 },
 });
-// outcome.status ∈ passed | threw | timeout | forbidden_side_effect |
+// outcome.status ∈ passed | threw | timeout | oom | forbidden_side_effect |
 //                  malformed_output | infra_error
 ```
 

--- a/addons/dry-run/cap-dry-run/README.md
+++ b/addons/dry-run/cap-dry-run/README.md
@@ -1,0 +1,77 @@
+# @linchkit/cap-dry-run
+
+Execution dry-run runner — **Spec 70 P3**. Implements the core `ExecutionDryRunProvider`
+seam by running AI-generated handler source in a **hardened, network-denied Bun
+subprocess** and returning a `DryRunOutcome`.
+
+Core stays execution-free: it declares the seam (Spec 70 P2); this capability runs
+the untrusted code in a sandbox.
+
+## Safety posture
+
+Each `dryRun` call runs one change against one synthetic input in a throwaway temp
+dir, then cleans up. Layered defense:
+
+- **OS sandbox denies network egress AND confines writes** — `sandbox-exec` (macOS),
+  `bwrap` (Linux, read-only root + per-run writable bind), or a declared `--network none`
+  container (`LINCHKIT_DRYRUN_TRUST_CONTAINER=1`). `unshare` alone is rejected: it denies
+  the network but leaves the host filesystem writable. The detected primitive is also
+  **probed for usability** (a present-but-broken `sandbox-exec` is treated as absent). No
+  usable sandbox → **fail closed**: report `infra_error`, run nothing.
+- **No output exfiltration channel** — the child's stdout/stderr are **discarded**, never
+  returned. The verdict comes only from the structured result the harness writes, so a
+  handler that reads a host file and prints it cannot surface its contents in the outcome.
+- **Credential reads blocked** — common secret dirs are denied (`sandbox-exec` deny-read
+  of `~/.ssh`/`~/.aws`/… ; `bwrap` hides `/home` + `/root`). A full deny-default read
+  sandbox is impractical for a runtime, so airtight read-isolation is the P5 microVM tier.
+- **Minimal env** — no secrets (no `DATABASE_URL`/keys); `HOME`/`TMPDIR` point at the
+  throwaway dir.
+- **Shimmed `@linchkit/core`** — `define*()` resolves to a fake; the real DB/provider
+  wiring never loads. The change to dry-run is selected by name, so a multi-export module
+  never silently runs the wrong definition. The handler runs against a faithful
+  `ActionContext`: real read-only fields (`input`/`logger`/`actor`/`tenantId`/an
+  `ExecutionMeta` shim) so valid handlers don't falsely fail, while every I/O method
+  (`create`/`query`/`update`/`delete`/`execute`/`emit`/`ai`/…) records a
+  `forbidden_side_effect` and throws.
+- **Hard timeout** — the child runs as a process-group leader (`detached`), so past
+  `limits.timeoutMs` the whole group is killed → `timeout`, reaping any subprocess the
+  handler spawned.
+- **Memory guard (best-effort)** — the child's RSS is sampled against `limits.memoryBytes`;
+  a runaway allocation is killed → `oom`. This sees the handler's process directly on
+  `sandbox-exec`/trusted-container; under `bwrap` the launcher is sampled, so a precise,
+  descendant-inclusive cap is the P5 cgroup/microVM tier (the timeout still backstops).
+
+With network denied, captured output discarded, an empty env, and a shimmed core, a
+file read cannot be exfiltrated and the DB cannot be reached. File **writes** are confined to the temp
+dir (macOS profile / bwrap bind).
+
+**Verdict integrity.** The generated code shares the child's JS realm with the harness,
+so the harness snapshots the intrinsics it relies on (`JSON.stringify`, `Object.values`,
+`Proxy`, …) and pre-builds the context **before** importing the source, scrubs the
+randomly named result path from `argv`, neutralises the exit functions, and writes the
+verdict with the snapshots — a top-level forge attempt (fake `passed` + early exit, or
+mutating those globals) cannot win. Airtight verdict integrity against a determined
+same-realm adversary, a precise descendant-inclusive memory cap, and a kernel-level
+boundary (gVisor/Firecracker microVM) are the Spec 70 P5 hardening tier. The dry-run is
+warn-only and human-gated, so its signal is advisory in P3.
+
+## Usage
+
+```ts
+import { createSubprocessDryRunner } from "@linchkit/cap-dry-run";
+
+const runner = createSubprocessDryRunner();
+const outcome = await runner.dryRun({
+  source,            // AI-materialized TypeScript (a defineAction module)
+  target: "action",
+  changeName: "deduct_inventory",
+  input: { qty: 5 }, // synthetic input
+  inputCaseId: "case-0",
+  limits: { timeoutMs: 5000, memoryBytes: 256 * 1024 * 1024 },
+});
+// outcome.status ∈ passed | threw | timeout | forbidden_side_effect |
+//                  malformed_output | infra_error
+```
+
+A P3 follow-up wires this provider into the async materialize path to stamp the
+durable `dryRunStatus` that validation Phase 5 reads (Spec 70 §5).

--- a/addons/dry-run/cap-dry-run/__tests__/subprocess-dry-runner.smoke.test.ts
+++ b/addons/dry-run/cap-dry-run/__tests__/subprocess-dry-runner.smoke.test.ts
@@ -1,0 +1,454 @@
+/**
+ * cap-dry-run — REAL subprocess smoke test (Spec 70 P3).
+ *
+ * Proves the hardened runner's safety + outcome mapping by actually spawning the
+ * sandboxed child. The behavioural tests run ONLY where an OS sandbox that denies
+ * network egress is available (macOS `sandbox-exec`, Linux `bwrap`); on
+ * a host without one they are skipped (the runner there correctly fails closed,
+ * which the always-on tests cover). Nothing here ever runs untrusted code outside
+ * a sandbox.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildSandboxArgv,
+  createSubprocessDryRunner,
+  detectSandboxStrategy,
+  isSandboxStrategyUsable,
+  type SandboxEnv,
+} from "../src/index";
+
+const TARGET = "action" as const;
+
+/** Build generated source whose `defineAction` handler has the given body. LinchKit
+ * handlers take a single `ctx`, with inputs at `ctx.input`. */
+function sourceFor(handlerBody: string): string {
+  return [
+    'import { defineAction } from "@linchkit/core";',
+    "export const generated = defineAction({",
+    '  name: "dry_run_probe",',
+    "  handler: async (ctx) => {",
+    `    ${handlerBody}`,
+    "  },",
+    "});",
+    "",
+  ].join("\n");
+}
+
+function job(source: string, input: unknown = {}, timeoutMs = 5_000) {
+  return {
+    source,
+    target: TARGET,
+    changeName: "dry_run_probe",
+    input,
+    inputCaseId: "case-0",
+    limits: { timeoutMs, memoryBytes: 256 * 1024 * 1024 },
+  };
+}
+
+// A SandboxEnv that reports no usable sandbox — drives the fail-closed path
+// deterministically on any host.
+const NO_SANDBOX_ENV: SandboxEnv = {
+  which: () => null,
+  getEnv: () => undefined,
+  platform: "darwin",
+};
+
+describe("createSubprocessDryRunner — fail closed + detection (host-independent)", () => {
+  test("no OS sandbox available → infra_error, runs nothing, never blocks", async () => {
+    const runner = createSubprocessDryRunner({ sandboxEnv: NO_SANDBOX_ENV });
+    const outcome = await runner.dryRun(job(sourceFor("return { ok: true };")));
+    expect(outcome.status).toBe("infra_error");
+    expect(outcome.changeName).toBe("dry_run_probe");
+    expect(outcome.inputCaseId).toBe("case-0");
+    expect(outcome.error ?? "").toContain("failing closed");
+  });
+
+  test("detectSandboxStrategy: darwin needs sandbox-exec; linux needs bwrap; else null", () => {
+    const mk = (over: Partial<SandboxEnv>): SandboxEnv => ({
+      which: () => null,
+      getEnv: () => undefined,
+      platform: "linux",
+      ...over,
+    });
+    expect(
+      detectSandboxStrategy(mk({ platform: "darwin", which: () => "/usr/bin/sandbox-exec" })),
+    ).toBe("sandbox-exec");
+    expect(detectSandboxStrategy(mk({ platform: "darwin", which: () => null }))).toBeNull();
+    expect(
+      detectSandboxStrategy(
+        mk({ platform: "linux", which: (b) => (b === "bwrap" ? "/usr/bin/bwrap" : null) }),
+      ),
+    ).toBe("bwrap");
+    // `unshare` alone does NOT confine filesystem writes → we fail closed, not run it.
+    expect(
+      detectSandboxStrategy(
+        mk({ platform: "linux", which: (b) => (b === "unshare" ? "/usr/bin/unshare" : null) }),
+      ),
+    ).toBeNull();
+    expect(detectSandboxStrategy(mk({ platform: "linux", which: () => null }))).toBeNull();
+    // Explicit container opt-in wins on any platform.
+    expect(
+      detectSandboxStrategy(
+        mk({
+          platform: "win32",
+          getEnv: (k) => (k === "LINCHKIT_DRYRUN_TRUST_CONTAINER" ? "1" : undefined),
+        }),
+      ),
+    ).toBe("trusted-container");
+  });
+
+  test("isSandboxStrategyUsable: a present-but-broken sandbox-exec is rejected", () => {
+    // bwrap / trusted-container are usable when present (no probe).
+    expect(isSandboxStrategyUsable("bwrap", () => ({ exitCode: 1 }))).toBe(true);
+    expect(isSandboxStrategyUsable("trusted-container", () => ({ exitCode: 1 }))).toBe(true);
+    // sandbox-exec is probed: exit 0 → usable, non-zero or throw → fail closed.
+    expect(isSandboxStrategyUsable("sandbox-exec", () => ({ exitCode: 0 }))).toBe(true);
+    expect(isSandboxStrategyUsable("sandbox-exec", () => ({ exitCode: 1 }))).toBe(false);
+    expect(
+      isSandboxStrategyUsable("sandbox-exec", () => {
+        throw new Error("sandbox_apply: Operation not permitted");
+      }),
+    ).toBe(false);
+  });
+
+  test("buildSandboxArgv: sandbox-exec wraps with the profile; bwrap unshares the net", () => {
+    const exec = buildSandboxArgv({
+      strategy: "sandbox-exec",
+      childArgv: ["/bin/bun", "x.ts"],
+      tempDir: "/tmp/d",
+      profilePath: "/tmp/d/p.sb",
+    });
+    expect(exec.slice(0, 4)).toEqual(["sandbox-exec", "-f", "/tmp/d/p.sb", "/bin/bun"]);
+    const bwrap = buildSandboxArgv({
+      strategy: "bwrap",
+      childArgv: ["/bin/bun"],
+      tempDir: "/tmp/d",
+    });
+    expect(bwrap[0]).toBe("bwrap");
+    expect(bwrap).toContain("--unshare-net");
+  });
+});
+
+// ── Behavioural tests — require a real, USABLE OS sandbox on this host ─────────
+const DETECTED = detectSandboxStrategy();
+const HAS_SANDBOX = DETECTED !== null && isSandboxStrategyUsable(DETECTED);
+const itReal = HAS_SANDBOX ? test : test.skip;
+// The memory guard sums RSS across the whole process tree, so it covers the descendant
+// bun under bwrap too. We assert `oom` deterministically only on the strategies this
+// host can actually exercise (sandbox-exec / trusted-container); the bwrap path is left
+// lenient since it cannot be run here.
+const RSS_GUARD_EFFECTIVE = DETECTED === "sandbox-exec" || DETECTED === "trusted-container";
+
+describe(`createSubprocessDryRunner — real sandboxed execution (${HAS_SANDBOX ? "active" : "SKIPPED: no host sandbox"})`, () => {
+  itReal("a clean handler returning a value → passed", async () => {
+    const runner = createSubprocessDryRunner();
+    const outcome = await runner.dryRun(
+      job(sourceFor("return { ok: true, n: ctx.input.qty };"), { qty: 7 }),
+    );
+    expect(outcome.status).toBe("passed");
+    expect(outcome.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  itReal(
+    "a side-effect-style handler with no declared output returning void → passed",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // LinchKit `output` is optional; a handler that declares no output and returns nothing
+      // runs fine in the real engine, so the dry-run must NOT stamp a content failure.
+      const outcome = await runner.dryRun(job(sourceFor("const x = ctx.input.qty;"), { qty: 1 }));
+      expect(outcome.status).toBe("passed");
+    },
+  );
+
+  itReal(
+    "a handler that DECLARES an output contract but returns undefined → malformed_output",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // When the definition declares a non-empty `output`, a void return IS a content
+      // failure — it promised a value and produced none.
+      const source = [
+        'import { defineAction } from "@linchkit/core";',
+        "export const generated = defineAction({",
+        '  name: "dry_run_probe",',
+        "  output: { ok: { type: 'boolean' } },",
+        "  handler: async (ctx) => { const x = ctx.input.qty; },",
+        "});",
+        "",
+      ].join("\n");
+      const outcome = await runner.dryRun({
+        source,
+        target: TARGET,
+        changeName: "dry_run_probe",
+        input: { qty: 1 },
+        inputCaseId: "case-0",
+        limits: { timeoutMs: 5_000, memoryBytes: 256 * 1024 * 1024 },
+      });
+      expect(outcome.status).toBe("malformed_output");
+    },
+  );
+
+  itReal("a handler reading real ctx fields (input/tenantId/logger) → passed", async () => {
+    const runner = createSubprocessDryRunner();
+    // Reading the standard read-only context surface must NOT be a false failure.
+    const outcome = await runner.dryRun(
+      job(
+        sourceFor(
+          'ctx.logger.info("hi"); return { tenant: ctx.tenantId, qty: ctx.input.qty, who: ctx.actor.id };',
+        ),
+        { qty: 3 },
+      ),
+    );
+    expect(outcome.status).toBe("passed");
+  });
+
+  itReal("a handler reading ctx.actor.groups → passed (full actor shape)", async () => {
+    const runner = createSubprocessDryRunner();
+    // A permission-aware handler inspecting ctx.actor.groups must not falsely throw.
+    const outcome = await runner.dryRun(
+      job(sourceFor("return { admin: ctx.actor.groups.includes('admin'), who: ctx.actor.id };")),
+    );
+    expect(outcome.status).toBe("passed");
+  });
+
+  itReal("a handler reading ctx.meta.get(...) → passed (ExecutionMeta shim)", async () => {
+    const runner = createSubprocessDryRunner();
+    const outcome = await runner.dryRun({
+      source: sourceFor(
+        "if (!ctx.meta.has('trace')) throw new Error('meta.has broken'); return { t: ctx.meta.get('trace') };",
+      ),
+      target: TARGET,
+      changeName: "dry_run_probe",
+      input: {},
+      inputCaseId: "case-0",
+      metadata: { trace: "abc-123" },
+      limits: { timeoutMs: 5_000, memoryBytes: 256 * 1024 * 1024 },
+    });
+    expect(outcome.status).toBe("passed");
+  });
+
+  itReal("a handler that throws → threw, raw message withheld (no exfil channel)", async () => {
+    const runner = createSubprocessDryRunner();
+    // A thrown message is attacker-controlled, so it must NOT be surfaced (it could be
+    // the contents of a file the handler read). The status still classifies the failure.
+    const outcome = await runner.dryRun(
+      job(sourceFor('throw new Error("SECRET-THROW-MARKER-9999");')),
+    );
+    expect(outcome.status).toBe("threw");
+    expect(JSON.stringify(outcome)).not.toContain("SECRET-THROW-MARKER");
+  });
+
+  itReal(
+    "a multi-export module runs the def matching changeName, NOT the first export",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // A clean helper is exported FIRST; the actual change throws. Selecting by name
+      // must run the change (→ threw), never the helper that would falsely pass.
+      const source = [
+        'import { defineAction } from "@linchkit/core";',
+        'export const aaa_helper = defineAction({ name: "aaa_helper", handler: async () => ({ ok: true }) });',
+        'export const target = defineAction({ name: "deduct_inventory", handler: async () => { throw new Error("real-target-ran"); } });',
+        "",
+      ].join("\n");
+      const outcome = await runner.dryRun({
+        source,
+        target: "action",
+        changeName: "deduct_inventory",
+        input: {},
+        inputCaseId: "case-0",
+        limits: { timeoutMs: 5_000, memoryBytes: 256 * 1024 * 1024 },
+      });
+      // The throwing target → "threw"; had the helper (exported first) wrongly run, it
+      // would have "passed". So the status alone proves the by-name selection.
+      expect(outcome.status).toBe("threw");
+    },
+  );
+
+  itReal("untrusted top-level code cannot forge a passed verdict", async () => {
+    const runner = createSubprocessDryRunner();
+    // Module top-level code (runs at import, before the handler) tries every forge
+    // vector: mutate the intrinsics the harness serialises with, write a fake "passed"
+    // to the old fixed result name, then exit early. The harness snapshots intrinsics
+    // and uses a random + argv-scrubbed result path with neutralised exits, so the
+    // actual (throwing) handler's verdict must win.
+    const source = [
+      'import { defineAction } from "@linchkit/core";',
+      'try { JSON.stringify = () => "{\\"status\\":\\"passed\\"}"; } catch (e) {}',
+      "try { globalThis.Proxy = function () { return {}; }; } catch (e) {}",
+      "try { Object.values = () => []; } catch (e) {}",
+      'try { const fs = await import("node:fs"); fs.writeFileSync("__dryrun_result.json", "{\\"status\\":\\"passed\\"}"); } catch (e) {}',
+      "try { process.exit(0); } catch (e) {}",
+      "try { Bun.exit(0); } catch (e) {}",
+      'export const evil = defineAction({ name: "dry_run_probe", handler: async () => { throw new Error("should-not-pass"); } });',
+      "",
+    ].join("\n");
+    const outcome = await runner.dryRun({
+      source,
+      target: TARGET,
+      changeName: "dry_run_probe",
+      input: {},
+      inputCaseId: "case-0",
+      limits: { timeoutMs: 5_000, memoryBytes: 256 * 1024 * 1024 },
+    });
+    expect(outcome.status).not.toBe("passed");
+  });
+
+  itReal("an ambiguous multi-export module with no name match → malformed_output", async () => {
+    const runner = createSubprocessDryRunner();
+    const source = [
+      'import { defineAction } from "@linchkit/core";',
+      'export const one = defineAction({ name: "one", handler: async () => ({ ok: true }) });',
+      'export const two = defineAction({ name: "two", handler: async () => ({ ok: true }) });',
+      "",
+    ].join("\n");
+    const outcome = await runner.dryRun({
+      source,
+      target: "action",
+      changeName: "neither",
+      input: {},
+      inputCaseId: "case-0",
+      limits: { timeoutMs: 5_000, memoryBytes: 256 * 1024 * 1024 },
+    });
+    expect(outcome.status).toBe("malformed_output");
+  });
+
+  itReal("an infinite loop → timeout (killed)", async () => {
+    const runner = createSubprocessDryRunner();
+    const outcome = await runner.dryRun(job(sourceFor("while (true) {}"), {}, 1_200));
+    expect(outcome.status).toBe("timeout");
+  });
+
+  itReal(
+    "a handler that spawns a lingering child + loops → timeout, reaped, call returns promptly",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // The handler starts a long-lived child, then loops forever. The child is in the
+      // dry-run's process group (`detached`), so the timeout kills the whole tree — the
+      // call must return near the 800ms timeout, NOT wait the ~9s the `sleep` imposes.
+      const started = Date.now();
+      const outcome = await runner.dryRun(
+        job(
+          sourceFor(
+            'Bun.spawn(["sleep", "9"], { stdout: "inherit", stderr: "inherit" }); while (true) {}',
+          ),
+          {},
+          800,
+        ),
+      );
+      const elapsed = Date.now() - started;
+      expect(outcome.status).toBe("timeout");
+      expect(elapsed).toBeLessThan(4_000);
+    },
+  );
+
+  itReal("a handler that allocates past the memory limit → oom (RSS guard)", async () => {
+    const runner = createSubprocessDryRunner();
+    const outcome = await runner.dryRun({
+      source: sourceFor(
+        "const big = new Uint8Array(220 * 1024 * 1024); big.fill(7); while (true) {}",
+      ),
+      target: TARGET,
+      changeName: "dry_run_probe",
+      input: {},
+      inputCaseId: "case-0",
+      limits: { timeoutMs: 5_000, memoryBytes: 128 * 1024 * 1024 },
+    });
+    if (RSS_GUARD_EFFECTIVE) {
+      expect(outcome.status).toBe("oom");
+    } else {
+      // Under bwrap the bomb is not sampled directly; the wall-clock timeout backstops.
+      expect(["oom", "timeout"]).toContain(outcome.status);
+    }
+  });
+
+  itReal("the untrusted child's stdout/stderr is NOT surfaced in the outcome", async () => {
+    const runner = createSubprocessDryRunner();
+    // A handler that reads a host file and prints it must not be able to exfiltrate it
+    // through the returned outcome: captured output is the channel, so we discard it.
+    const outcome = await runner.dryRun(
+      job(
+        sourceFor(
+          'console.log("EXFIL-MARKER-12345"); console.error("EXFIL-ERR-678"); return { ok: true };',
+        ),
+      ),
+    );
+    expect(outcome.status).toBe("passed");
+    expect(JSON.stringify(outcome)).not.toContain("EXFIL-MARKER");
+    expect(JSON.stringify(outcome)).not.toContain("EXFIL-ERR");
+  });
+
+  itReal("a handler that fetches the network → threw (egress DENIED, nothing leaked)", async () => {
+    const runner = createSubprocessDryRunner();
+    const outcome = await runner.dryRun(
+      job(
+        sourceFor(
+          'const r = await fetch("http://example.com", { signal: AbortSignal.timeout(3000) }); return { leaked: r.status };',
+        ),
+      ),
+    );
+    // The sandbox blocks egress, so the handler's fetch fails — it must NEVER come
+    // back "passed" with a real status code.
+    expect(outcome.status).not.toBe("passed");
+    expect(["threw", "timeout"]).toContain(outcome.status);
+  });
+
+  itReal(
+    "a handler that reaches for ctx I/O → forbidden_side_effect (recorded, not performed)",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      const outcome = await runner.dryRun(
+        job(sourceFor('await ctx.create("order", {}); return { ok: true };')),
+      );
+      expect(outcome.status).toBe("forbidden_side_effect");
+      expect(
+        (outcome.attemptedSideEffects ?? []).some((e) => e.detail.includes("ctx.create")),
+      ).toBe(true);
+    },
+  );
+
+  itReal(
+    "a handler that SWALLOWS a forbidden side-effect error still → forbidden_side_effect",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // Catching the shim error must not let the attempt be reported as a clean pass.
+      const outcome = await runner.dryRun(
+        job(sourceFor('try { await ctx.create("order", {}); } catch (e) {} return { ok: true };')),
+      );
+      expect(outcome.status).toBe("forbidden_side_effect");
+    },
+  );
+
+  itReal(
+    "a handler that writes outside the sandbox → blocked, the sentinel never exists",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // A path under this repo worktree — outside every dir the profile allows writes.
+      const sentinel = `${process.cwd()}/__dryrun_sentinel_${Date.now()}.txt`;
+      const outcome = await runner.dryRun(
+        job(sourceFor("await Bun.write(ctx.input.sentinel, 'leaked'); return { ok: true };"), {
+          sentinel,
+        }),
+      );
+      // The write is denied → the handler throws (or it is otherwise not "passed").
+      expect(outcome.status).not.toBe("passed");
+      expect(await Bun.file(sentinel).exists()).toBe(false);
+    },
+  );
+
+  itReal(
+    "a handler that writes to a shared temp path (/tmp) → blocked, no persistent leak",
+    async () => {
+      const runner = createSubprocessDryRunner();
+      // A shared temp path OUTSIDE this run's dir. The profile used to allow all of
+      // /private/tmp; writes there must now be denied so nothing persists between runs.
+      const sentinel = `/tmp/__dryrun_leak_${Date.now()}.txt`;
+      const outcome = await runner.dryRun(
+        job(sourceFor("await Bun.write(ctx.input.sentinel, 'leaked'); return { ok: true };"), {
+          sentinel,
+        }),
+      );
+      expect(outcome.status).not.toBe("passed");
+      expect(await Bun.file(sentinel).exists()).toBe(false);
+    },
+  );
+});

--- a/addons/dry-run/cap-dry-run/__tests__/subprocess-dry-runner.smoke.test.ts
+++ b/addons/dry-run/cap-dry-run/__tests__/subprocess-dry-runner.smoke.test.ts
@@ -293,6 +293,33 @@ describe(`createSubprocessDryRunner — real sandboxed execution (${HAS_SANDBOX 
     expect(outcome.status).not.toBe("passed");
   });
 
+  itReal("prototype-method pollution cannot suppress a forbidden side-effect record", async () => {
+    const runner = createSubprocessDryRunner();
+    // Untrusted top-level replaces the PROTOTYPE methods the recording path uses
+    // (push/has/split/hasOwnProperty) — a higher-order forge than mutating the
+    // intrinsics. The harness uncurried these BEFORE importing the source, so a
+    // swallowed forbidden `ctx.create` is still RECORDED → forbidden_side_effect,
+    // never the `{ ok: true }` the handler returns.
+    const source = [
+      'import { defineAction } from "@linchkit/core";',
+      "try { Array.prototype.push = function () { return 0; }; } catch (e) {}",
+      "try { Set.prototype.has = function () { return true; }; } catch (e) {}",
+      "try { String.prototype.split = function () { return []; }; } catch (e) {}",
+      "try { Object.prototype.hasOwnProperty = function () { return false; }; } catch (e) {}",
+      'export const evil = defineAction({ name: "dry_run_probe", handler: async (ctx) => { try { await ctx.create("order", {}); } catch (e) {} return { ok: true }; } });',
+      "",
+    ].join("\n");
+    const outcome = await runner.dryRun({
+      source,
+      target: TARGET,
+      changeName: "dry_run_probe",
+      input: {},
+      inputCaseId: "case-0",
+      limits: { timeoutMs: 5_000, memoryBytes: 256 * 1024 * 1024 },
+    });
+    expect(outcome.status).toBe("forbidden_side_effect");
+  });
+
   itReal("an ambiguous multi-export module with no name match → malformed_output", async () => {
     const runner = createSubprocessDryRunner();
     const source = [

--- a/addons/dry-run/cap-dry-run/package.json
+++ b/addons/dry-run/cap-dry-run/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@linchkit/cap-dry-run",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "@linchkit/devtools": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "coreVersion": "^0.2.0",
+    "type": "adapter",
+    "category": "integration"
+  }
+}

--- a/addons/dry-run/cap-dry-run/src/child-harness.ts
+++ b/addons/dry-run/cap-dry-run/src/child-harness.ts
@@ -1,0 +1,306 @@
+/**
+ * Source for the two files the dry-run child process runs, emitted as string
+ * constants so the runner can write them into a throwaway temp dir per call (no
+ * separate shipped child entrypoints to resolve). Both are plain Bun-run TS.
+ *
+ * - {@link PRELOAD_SOURCE} is `bun --preload`ed FIRST: it registers a Bun plugin
+ *   that aliases `@linchkit/core` to a SHIM, so the generated source's
+ *   `import { defineAction } from "@linchkit/core"` resolves to a fake that just
+ *   returns the definition object (capturing its `handler`) — the real core, its
+ *   DB wiring, and its side-effecting providers never load in the sandbox.
+ * - {@link RUNNER_SOURCE} imports the generated source (now shimmed), finds the
+ *   exported definition's `handler`, runs it once against the synthetic input with
+ *   a RECORDING Proxy context (every `ctx.*` call is logged as an attempted side
+ *   effect and throws — the handler can perform no real I/O), and writes a single
+ *   JSON outcome to the result-file path. Handler stdout/stderr stay separate and
+ *   become the outcome `logs`.
+ */
+
+/** Filename the runner imports the generated source from (written by the parent). */
+export const SOURCE_FILENAME = "__dryrun_source.ts";
+/** Filename of the preload shim (passed to `bun --preload`). */
+export const PRELOAD_FILENAME = "__dryrun_preload.ts";
+/** Filename of the runner harness. */
+export const RUNNER_FILENAME = "__dryrun_runner.ts";
+
+export const PRELOAD_SOURCE = `import { plugin } from "bun";
+
+// Alias @linchkit/core to a shim so the generated source's define*() calls resolve
+// to fakes that just return their definition object. The real core never loads in
+// the sandbox, so no DB/provider/secret wiring is reachable.
+plugin({
+  name: "linchkit-core-dryrun-shim",
+  setup(build) {
+    build.module("@linchkit/core", () => ({
+      exports: {
+        defineAction: (def) => def,
+        defineRule: (def) => def,
+        defineEntity: (def) => def,
+      },
+      loader: "object",
+    }));
+  },
+});
+`;
+
+export const RUNNER_SOURCE = `// Untrusted-code harness. Runs the generated handler ONCE in this sandboxed child
+// and writes a JSON outcome to the (randomly named) result path. argv: [2]=input JSON,
+// [3]=result path, [4]=change/def name, [5]=tenant id, [6]=metadata JSON.
+//
+// The generated source runs in THIS process and could try to forge the verdict (write
+// a fake "passed" result and exit before we run the handler). We defend by: capturing
+// the write primitive + the real exit BEFORE importing it; SCRUBBING process.argv so it
+// cannot learn the result path (which is also randomly named, so it cannot guess it);
+// and neutralising the exit functions so it cannot terminate before we record the real
+// verdict, which we then write with the captured primitive and force-exit immediately.
+import { writeFileSync } from "node:fs";
+
+// ── Snapshot intrinsics BEFORE importing untrusted code ───────────────────────
+// The generated module runs top-level code in THIS realm and could mutate any global
+// the harness later relies on (\`JSON.stringify\`, \`Object.values\`, \`Proxy\`, …) to forge
+// a passing verdict. We snapshot everything we use up front and reference only the
+// snapshots afterward; verdict-shaping work (context, def selection, serialisation) is
+// done with these, never with live globals.
+const jsonStringify = JSON.stringify;
+const jsonParse = JSON.parse;
+const objectValues = Object.values;
+const objectKeys = Object.keys;
+const ProxyCtor = Proxy;
+const SetCtor = Set;
+const DateCtor = Date;
+const StringFn = String;
+const hasOwn = Object.prototype.hasOwnProperty;
+const bunFileText = (p) => Bun.file(p).text();
+
+const inputPath = process.argv[2];
+const resultPath = process.argv[3];
+const targetName = process.argv[4] || "";
+const tenantId = process.argv[5] || "dry-run";
+const metaPath = process.argv[6] || "";
+const realExit = process.exit.bind(process);
+
+// Hide the args (incl. the result path) and disable early termination before any
+// untrusted module code runs.
+process.argv.length = 2;
+const blockExit = () => {
+  throw new Error("FORBIDDEN_SIDE_EFFECT:process.exit()");
+};
+process.exit = blockExit;
+try {
+  if (typeof Bun !== "undefined") Bun.exit = blockExit;
+} catch (_e) {}
+
+const sideEffects = [];
+function recordEffect(path) {
+  sideEffects.push({ kind: "unknown", detail: StringFn(path).slice(0, 200) });
+}
+
+// The known ActionContext I/O surfaces. Anything else a handler reaches for is an
+// arbitrary property name we must NOT echo back: untrusted code could read a host
+// file and use its contents as a property name (\`ctx[secret]()\`), turning the
+// recorded path into an exfiltration channel. We keep the recognised first segment
+// and redact the rest.
+const KNOWN_CTX_IO = new SetCtor([
+  "get", "query", "create", "update", "delete", "execute", "emit", "ai", "config",
+]);
+function sanitizePath(path) {
+  const parts = StringFn(path).split(".");
+  const method = parts[1] || "";
+  if (!KNOWN_CTX_IO.has(method)) return "ctx.<redacted>";
+  return parts.length > 2 ? "ctx." + method + ".<redacted>" : "ctx." + method;
+}
+
+// A callable Proxy for an I/O surface: any property chain is callable; CALLING it
+// records a forbidden side effect and throws. Used for the parts of the context the
+// handler must NOT exercise in a dry-run (DB, events, nested actions, AI, config).
+function makeForbidden(path) {
+  return new ProxyCtor(function () {}, {
+    get(_t, prop) {
+      if (typeof prop === "symbol") return undefined;
+      if (prop === "then") return undefined; // not a thenable
+      return makeForbidden(path + "." + StringFn(prop));
+    },
+    apply() {
+      const safe = sanitizePath(path);
+      recordEffect(safe + "()");
+      throw new Error("FORBIDDEN_SIDE_EFFECT:" + safe + "()");
+    },
+  });
+}
+
+// A read-only ExecutionMeta shim (Spec 65) over the supplied metadata payload, so a
+// handler using \`ctx.meta.get('key')\` / has / require / toJSON behaves as it would
+// under the real action engine instead of falsely throwing.
+function makeMeta(data) {
+  const d = data && typeof data === "object" ? data : {};
+  return {
+    get(key) { return d[key]; },
+    has(key) { return hasOwn.call(d, key); },
+    require(key) {
+      if (!hasOwn.call(d, key)) {
+        throw new Error("ExecutionMeta missing required key: " + StringFn(key));
+      }
+      return d[key];
+    },
+    toJSON() {
+      const out = {};
+      for (const k in d) if (hasOwn.call(d, k)) out[k] = d[k];
+      return out;
+    },
+  };
+}
+
+// Build a LinchKit ActionContext for the dry-run. Handlers are \`(ctx) => ...\` with
+// inputs at \`ctx.input\`. Read-only context fields are REAL (so a handler reading
+// them does not falsely fail); every I/O method (get/query/create/update/delete/
+// execute/emit/ai/config/…) is a forbidden surface that records + throws when called.
+function makeCtx(input, meta) {
+  const real = {
+    input: input || {},
+    logger: { info() {}, warn() {}, error() {}, debug() {}, trace() {} },
+    meta: makeMeta(meta),
+    actor: { id: "dry-run", type: "system", groups: [], tenantId: tenantId },
+    tenantId: tenantId,
+    executionId: "dry-run",
+    timestamp: new DateCtor(),
+    hasCapability: function () { return false; },
+  };
+  return new ProxyCtor(real, {
+    get(t, prop) {
+      if (typeof prop === "symbol") return undefined;
+      if (prop === "then") return undefined; // not a thenable
+      if (hasOwn.call(t, prop)) return t[prop];
+      return makeForbidden("ctx." + StringFn(prop));
+    },
+  });
+}
+
+async function readJson(path, fallback) {
+  try {
+    return jsonParse(await bunFileText(path));
+  } catch {
+    return fallback;
+  }
+}
+
+// Select the definition to dry-run, using the snapshotted \`Object.values\` and manual
+// loops (no \`Array.prototype\` methods untrusted code could have replaced). A single
+// handler-def is the materializer's normal output; with MORE than one, never guess the
+// first — require a name match, else fail closed as malformed.
+function selectDef(mod) {
+  const vals = objectValues(mod);
+  const defs = [];
+  for (let i = 0; i < vals.length; i++) {
+    const v = vals[i];
+    if (v && typeof v === "object" && typeof v.handler === "function") defs.push(v);
+  }
+  if (defs.length === 1) return { def: defs[0], count: 1 };
+  if (defs.length > 1 && targetName) {
+    for (let i = 0; i < defs.length; i++) {
+      if (defs[i].name === targetName) return { def: defs[i], count: defs.length };
+    }
+  }
+  return { def: null, count: defs.length };
+}
+
+async function main() {
+  // Read the integrity nonce from stdin FIRST — before any untrusted code runs — and
+  // consume it. The parent passes it on stdin (not argv/env), so it is not recoverable
+  // via /proc/self/cmdline or /proc/self/environ; once read, the stream is at EOF. The
+  // parent rejects any result whose nonce does not match, so a forged result file (the
+  // untrusted code can still discover the path via /proc) is ignored.
+  let nonce = "";
+  try {
+    nonce = (await Bun.stdin.text()).trim();
+  } catch (_e) {}
+  // Read inputs and BUILD THE CONTEXT before importing untrusted code, so a later
+  // top-level mutation of Proxy/etc cannot subvert the recording context.
+  const input = inputPath ? await readJson(inputPath, {}) : {};
+  const metaData = metaPath ? await readJson(metaPath, {}) : {};
+  const ctx = makeCtx(input, metaData);
+  let outcome;
+  try {
+    const mod = await import("./${SOURCE_FILENAME}");
+    const sel = selectDef(mod);
+    if (!sel.def) {
+      outcome = {
+        status: "malformed_output",
+        error:
+          sel.count === 0
+            ? "generated source exports no define*() definition with a handler"
+            : "generated source exports " +
+              sel.count +
+              " definitions; none named '" +
+              targetName +
+              "' to disambiguate which to dry-run",
+        sideEffects,
+      };
+    } else {
+      const result = await sel.def.handler(ctx);
+      // A void/null return is only malformed when the definition DECLARES an output
+      // contract (a non-empty \`output\` map). LinchKit handlers are \`(ctx) => Promise<unknown>\`
+      // and \`output\` is optional, so a side-effect-style action with no declared output may
+      // legitimately return nothing — the real action engine runs it fine, so the dry-run
+      // must not stamp a false content failure. \`output\` is read with snapshotted Object.keys.
+      let requiresOutput = false;
+      try {
+        const out = sel.def.output;
+        requiresOutput = !!out && typeof out === "object" && objectKeys(out).length > 0;
+      } catch (_e) {
+        requiresOutput = false;
+      }
+      if (result !== undefined && result !== null) {
+        outcome = { status: "passed", sideEffects };
+      } else if (requiresOutput) {
+        outcome = {
+          status: "malformed_output",
+          error: "handler declares an output contract but returned null/undefined",
+          sideEffects,
+        };
+      } else {
+        outcome = { status: "passed", sideEffects };
+      }
+    }
+  } catch (e) {
+    const msg = e && e.message ? StringFn(e.message) : StringFn(e);
+    if (msg.indexOf("FORBIDDEN_SIDE_EFFECT:") === 0) {
+      // The message here is the sanitised forbidden path (no attacker text).
+      outcome = { status: "forbidden_side_effect", error: msg.slice(0, 200), sideEffects };
+    } else {
+      // A thrown message is attacker-controlled (\`throw new Error(secret)\`), and so is
+      // a custom \`error.name\`; surface only a BUILT-IN error class name (else "Error"),
+      // never raw text, so the outcome cannot become a file-read exfiltration channel.
+      const builtins = new SetCtor([
+        "Error", "TypeError", "RangeError", "ReferenceError",
+        "SyntaxError", "EvalError", "URIError", "AggregateError",
+      ]);
+      const name = e && typeof e.name === "string" && builtins.has(e.name) ? e.name : "Error";
+      outcome = {
+        status: "threw",
+        error: "Handler threw during dry-run (" + name + "; message withheld)",
+        sideEffects,
+      };
+    }
+  }
+  // A forbidden side-effect ATTEMPT taints the verdict even if the handler swallowed the
+  // thrown error and returned a value (\`try { await ctx.create(...) } catch {}\`): the
+  // attempt is the signal Phase 5 must act on, so a non-empty record forces the status.
+  if (sideEffects.length > 0 && outcome.status !== "forbidden_side_effect") {
+    outcome = {
+      status: "forbidden_side_effect",
+      error: "Handler attempted a forbidden side effect during dry-run",
+      sideEffects,
+    };
+  }
+
+  // Stamp the integrity nonce so the parent can distinguish this real verdict from any
+  // result the untrusted code may have forged. Serialise + write with SNAPSHOTTED
+  // primitives (untrusted code may have replaced \`JSON.stringify\` / \`Bun.write\`), then
+  // force-exit via the REAL exit so no deferred task can overwrite the verdict.
+  outcome.__nonce = nonce;
+  writeFileSync(resultPath, jsonStringify(outcome));
+  realExit(0);
+}
+
+main().catch(() => realExit(1));
+`;

--- a/addons/dry-run/cap-dry-run/src/child-harness.ts
+++ b/addons/dry-run/cap-dry-run/src/child-harness.ts
@@ -69,8 +69,25 @@ const ProxyCtor = Proxy;
 const SetCtor = Set;
 const DateCtor = Date;
 const StringFn = String;
-const hasOwn = Object.prototype.hasOwnProperty;
 const bunFileText = (p) => Bun.file(p).text();
+
+// Snapshotting the constructors/functions above is not enough: the recording path
+// (\`sideEffects.push\`, \`set.has\`, \`str.split\`, …) runs AFTER importing the untrusted
+// module, which could replace PROTOTYPE methods (\`Array.prototype.push\`,
+// \`Set.prototype.has\`, \`String.prototype.split\`, \`Object.prototype.hasOwnProperty\`) to
+// hijack the harness and forge the verdict. Uncurry each method we call on an instance
+// via the captured \`Function.prototype.call\`/\`bind\` (so even mutating those cannot
+// subvert us) and invoke ONLY these snapshots afterward, never instance methods.
+const fnCall = Function.prototype.call;
+const fnBind = Function.prototype.bind;
+const uncurry = (fn) => fnBind.call(fnCall, fn);
+const arrayPush = uncurry(Array.prototype.push);
+const stringSlice = uncurry(String.prototype.slice);
+const stringSplit = uncurry(String.prototype.split);
+const stringIndexOf = uncurry(String.prototype.indexOf);
+const stringTrim = uncurry(String.prototype.trim);
+const setHas = uncurry(Set.prototype.has);
+const hasOwnFn = uncurry(Object.prototype.hasOwnProperty);
 
 const inputPath = process.argv[2];
 const resultPath = process.argv[3];
@@ -92,7 +109,7 @@ try {
 
 const sideEffects = [];
 function recordEffect(path) {
-  sideEffects.push({ kind: "unknown", detail: StringFn(path).slice(0, 200) });
+  arrayPush(sideEffects, { kind: "unknown", detail: stringSlice(StringFn(path), 0, 200) });
 }
 
 // The known ActionContext I/O surfaces. Anything else a handler reaches for is an
@@ -104,9 +121,9 @@ const KNOWN_CTX_IO = new SetCtor([
   "get", "query", "create", "update", "delete", "execute", "emit", "ai", "config",
 ]);
 function sanitizePath(path) {
-  const parts = StringFn(path).split(".");
+  const parts = stringSplit(StringFn(path), ".");
   const method = parts[1] || "";
-  if (!KNOWN_CTX_IO.has(method)) return "ctx.<redacted>";
+  if (!setHas(KNOWN_CTX_IO, method)) return "ctx.<redacted>";
   return parts.length > 2 ? "ctx." + method + ".<redacted>" : "ctx." + method;
 }
 
@@ -135,16 +152,16 @@ function makeMeta(data) {
   const d = data && typeof data === "object" ? data : {};
   return {
     get(key) { return d[key]; },
-    has(key) { return hasOwn.call(d, key); },
+    has(key) { return hasOwnFn(d, key); },
     require(key) {
-      if (!hasOwn.call(d, key)) {
+      if (!hasOwnFn(d, key)) {
         throw new Error("ExecutionMeta missing required key: " + StringFn(key));
       }
       return d[key];
     },
     toJSON() {
       const out = {};
-      for (const k in d) if (hasOwn.call(d, k)) out[k] = d[k];
+      for (const k in d) if (hasOwnFn(d, k)) out[k] = d[k];
       return out;
     },
   };
@@ -169,7 +186,7 @@ function makeCtx(input, meta) {
     get(t, prop) {
       if (typeof prop === "symbol") return undefined;
       if (prop === "then") return undefined; // not a thenable
-      if (hasOwn.call(t, prop)) return t[prop];
+      if (hasOwnFn(t, prop)) return t[prop];
       return makeForbidden("ctx." + StringFn(prop));
     },
   });
@@ -192,7 +209,7 @@ function selectDef(mod) {
   const defs = [];
   for (let i = 0; i < vals.length; i++) {
     const v = vals[i];
-    if (v && typeof v === "object" && typeof v.handler === "function") defs.push(v);
+    if (v && typeof v === "object" && typeof v.handler === "function") arrayPush(defs, v);
   }
   if (defs.length === 1) return { def: defs[0], count: 1 };
   if (defs.length > 1 && targetName) {
@@ -211,7 +228,7 @@ async function main() {
   // untrusted code can still discover the path via /proc) is ignored.
   let nonce = "";
   try {
-    nonce = (await Bun.stdin.text()).trim();
+    nonce = stringTrim(await Bun.stdin.text());
   } catch (_e) {}
   // Read inputs and BUILD THE CONTEXT before importing untrusted code, so a later
   // top-level mutation of Proxy/etc cannot subvert the recording context.
@@ -263,9 +280,9 @@ async function main() {
     }
   } catch (e) {
     const msg = e && e.message ? StringFn(e.message) : StringFn(e);
-    if (msg.indexOf("FORBIDDEN_SIDE_EFFECT:") === 0) {
+    if (stringIndexOf(msg, "FORBIDDEN_SIDE_EFFECT:") === 0) {
       // The message here is the sanitised forbidden path (no attacker text).
-      outcome = { status: "forbidden_side_effect", error: msg.slice(0, 200), sideEffects };
+      outcome = { status: "forbidden_side_effect", error: stringSlice(msg, 0, 200), sideEffects };
     } else {
       // A thrown message is attacker-controlled (\`throw new Error(secret)\`), and so is
       // a custom \`error.name\`; surface only a BUILT-IN error class name (else "Error"),
@@ -274,7 +291,7 @@ async function main() {
         "Error", "TypeError", "RangeError", "ReferenceError",
         "SyntaxError", "EvalError", "URIError", "AggregateError",
       ]);
-      const name = e && typeof e.name === "string" && builtins.has(e.name) ? e.name : "Error";
+      const name = e && typeof e.name === "string" && setHas(builtins, e.name) ? e.name : "Error";
       outcome = {
         status: "threw",
         error: "Handler threw during dry-run (" + name + "; message withheld)",

--- a/addons/dry-run/cap-dry-run/src/index.ts
+++ b/addons/dry-run/cap-dry-run/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @linchkit/cap-dry-run
+ *
+ * Execution dry-run runner capability — Spec 70 P3. Implements the core
+ * `ExecutionDryRunProvider` seam by running AI-generated handler source in a
+ * hardened, network-denied Bun subprocess and reporting a `DryRunOutcome`.
+ *
+ * Core stays execution-free: it declares the seam (Spec 70 P2); this capability
+ * supplies the implementation. The runner FAILS CLOSED (reports `infra_error`,
+ * runs nothing) on any host where no OS sandbox can deny network egress.
+ */
+
+export {
+  buildSandboxArgv,
+  buildSandboxExecProfile,
+  defaultSandboxEnv,
+  detectSandboxStrategy,
+  isSandboxStrategyUsable,
+  type SandboxEnv,
+  type SandboxStrategy,
+} from "./sandbox";
+export {
+  createSubprocessDryRunner,
+  type SubprocessDryRunnerOptions,
+} from "./subprocess-dry-runner";

--- a/addons/dry-run/cap-dry-run/src/sandbox.ts
+++ b/addons/dry-run/cap-dry-run/src/sandbox.ts
@@ -147,8 +147,10 @@ export function buildSandboxExecProfile(tempDir: string): string {
     '  (literal "/dev/null")',
     '  (literal "/dev/stdout")',
     '  (literal "/dev/stderr")',
-    '  (literal "/dev/dtracehelper")',
-    '  (literal "/dev/tty"))',
+    // No `/dev/tty`: the child runs with stdout/stderr discarded, so it needs no
+    // controlling terminal — denying tty writes removes a terminal-hijack (escape
+    // sequence injection) vector.
+    '  (literal "/dev/dtracehelper"))',
     "",
   ].join("\n");
 }

--- a/addons/dry-run/cap-dry-run/src/sandbox.ts
+++ b/addons/dry-run/cap-dry-run/src/sandbox.ts
@@ -1,0 +1,223 @@
+/**
+ * OS-level sandbox strategy for the execution dry-run (Spec 70 §4).
+ *
+ * The dry-run runs UNTRUSTED AI-generated code in a child process. A bare
+ * `Bun.spawn` does NOT deny network egress, so the spawn is ALWAYS wrapped in a
+ * platform-appropriate OS sandbox whose non-negotiable job is to **deny network
+ * egress** (the exfiltration vector). If no usable primitive exists on this host,
+ * detection returns `null` and the runner FAILS CLOSED — it reports `infra_error`
+ * and runs nothing, never a bare unsandboxed child (Spec 70 §3).
+ *
+ * Strategy ladder:
+ *   - darwin  → `sandbox-exec` with a deny-network profile (always present on macOS).
+ *   - linux   → `bwrap` (rootless bubblewrap): denies network AND confines writes to
+ *     a per-run bind (read-only root). `unshare` alone is NOT used: it would deny the
+ *     network but leave the host filesystem writable, so untrusted code could tamper
+ *     with the repo yet be reported `passed` — a sandbox must deny BOTH egress and
+ *     out-of-sandbox writes, so without `bwrap` Linux fails closed.
+ *   - any OS  → `LINCHKIT_DRYRUN_TRUST_CONTAINER=1` declares the process is ALREADY
+ *     inside a network-denied container (orchestration provides isolation), so a
+ *     bare subprocess is acceptable. Set this ONLY when the deployment guarantees
+ *     it (e.g. a `--network none` / NetworkPolicy-denied pod with a read-only rootfs).
+ *   - else    → `null` (fail closed).
+ */
+
+import { realpathSync } from "node:fs";
+import { platform } from "node:os";
+import { dirname } from "node:path";
+
+export type SandboxStrategy = "sandbox-exec" | "bwrap" | "trusted-container";
+
+export interface SandboxEnv {
+  /** Looks up an executable on PATH; returns its path or null. Injectable for tests. */
+  which: (bin: string) => string | null;
+  /** Reads an env var; injectable for tests. */
+  getEnv: (key: string) => string | undefined;
+  /** The OS platform string (`process.platform`); injectable for tests. */
+  platform: NodeJS.Platform;
+}
+
+/** Default environment probe backed by Bun/Node. */
+export function defaultSandboxEnv(): SandboxEnv {
+  return {
+    which: (bin) => Bun.which(bin),
+    getEnv: (key) => process.env[key],
+    platform: platform() as NodeJS.Platform,
+  };
+}
+
+/**
+ * Detect a usable OS sandbox that can deny network egress for an untrusted child.
+ * Returns `null` when none is available — the caller MUST then fail closed.
+ */
+export function detectSandboxStrategy(
+  env: SandboxEnv = defaultSandboxEnv(),
+): SandboxStrategy | null {
+  // An explicit operator opt-in: the surrounding container already denies the
+  // network. Honoured on any platform.
+  if (env.getEnv("LINCHKIT_DRYRUN_TRUST_CONTAINER") === "1") return "trusted-container";
+
+  if (env.platform === "darwin") {
+    return env.which("sandbox-exec") ? "sandbox-exec" : null;
+  }
+  if (env.platform === "linux") {
+    // Only `bwrap` is trusted: it denies the network AND confines filesystem writes
+    // (read-only root + a per-run writable bind). `unshare` would leave the host fs
+    // writable, so we deliberately fail closed without bwrap.
+    return env.which("bwrap") ? "bwrap" : null;
+  }
+  // Unknown platform → no network-denial primitive we trust → fail closed.
+  return null;
+}
+
+/**
+ * Verify a detected strategy is actually USABLE, not merely present on PATH. On some
+ * macOS hosts `/usr/bin/sandbox-exec` exists but cannot apply a profile (restricted
+ * or already-nested sandbox); there every dry-run would return `infra_error`. We
+ * probe by applying a trivial profile to `/usr/bin/true` — a non-zero exit means the
+ * primitive is broken, so the caller must fail closed. `bwrap`/`trusted-container`
+ * are assumed usable when present (a broken `bwrap` still yields `infra_error` at run
+ * time, which fails closed). `run` is injectable for host-independent tests.
+ */
+export function isSandboxStrategyUsable(
+  strategy: SandboxStrategy,
+  run: (argv: string[]) => { exitCode: number | null } = (argv) => Bun.spawnSync(argv),
+): boolean {
+  if (strategy !== "sandbox-exec") return true;
+  try {
+    return (
+      run(["sandbox-exec", "-p", "(version 1)(allow default)", "/usr/bin/true"]).exitCode === 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Home-relative paths that commonly hold credentials, denied for reads (defense in
+ * depth — the runner also never surfaces handler output, so a read has no egress). */
+const SECRET_HOME_SUBPATHS = [
+  ".ssh",
+  ".aws",
+  ".gnupg",
+  ".config",
+  ".kube",
+  ".docker",
+  ".gcloud",
+  ".azure",
+];
+const SECRET_HOME_FILES = [".npmrc", ".netrc", ".pgpass", ".git-credentials"];
+
+/**
+ * The macOS `sandbox-exec` profile: deny ALL network, deny file WRITES outside THIS
+ * run's temp dir (so a handler cannot tamper with the repo, the system, or a shared
+ * temp path like `/tmp/leak`), and deny READS of common credential locations under the
+ * caller's home. A full deny-default read sandbox is impractical for a runtime like bun
+ * (it needs broad library reads), so airtight read-isolation is the P5 microVM tier;
+ * here the read blocklist plus the runner never surfacing handler stdout/stderr remove
+ * the practical exfiltration path.
+ *
+ * Writes are scoped to the per-run dir only. `mkdtemp` returns a `/var/folders/…`
+ * (or `/tmp/…`) path while the kernel canonicalises it to `/private/…` before the
+ * sandbox matches it, so we allow BOTH the given path and its realpath.
+ */
+export function buildSandboxExecProfile(tempDir: string): string {
+  const writable = new Set<string>([tempDir]);
+  try {
+    writable.add(realpathSync(tempDir));
+  } catch {
+    // tempDir may not exist yet in a unit test; the given path is still emitted.
+  }
+  const home = process.env.HOME;
+  const denyReads = home
+    ? [
+        "(deny file-read*",
+        ...SECRET_HOME_SUBPATHS.map((p) => `  (subpath ${JSON.stringify(`${home}/${p}`)})`),
+        ...SECRET_HOME_FILES.map((f) => `  (literal ${JSON.stringify(`${home}/${f}`)})`),
+        ")",
+      ]
+    : [];
+  return [
+    "(version 1)",
+    "(allow default)",
+    "(deny network*)",
+    ...denyReads,
+    "(deny file-write*)",
+    "(allow file-write*",
+    ...[...writable].map((p) => `  (subpath ${JSON.stringify(p)})`),
+    '  (literal "/dev/null")',
+    '  (literal "/dev/stdout")',
+    '  (literal "/dev/stderr")',
+    '  (literal "/dev/dtracehelper")',
+    '  (literal "/dev/tty"))',
+    "",
+  ].join("\n");
+}
+
+/**
+ * Wrap the child command with the chosen sandbox so the resulting argv can be
+ * handed to `Bun.spawn`. `profilePath` is required for `sandbox-exec` (the path of
+ * a profile written via {@link buildSandboxExecProfile}); `tempDir` is the
+ * writable working dir bound into the sandbox.
+ */
+export function buildSandboxArgv(args: {
+  strategy: SandboxStrategy;
+  childArgv: readonly string[];
+  tempDir: string;
+  profilePath?: string;
+}): string[] {
+  const { strategy, childArgv, tempDir, profilePath } = args;
+  switch (strategy) {
+    case "sandbox-exec": {
+      if (!profilePath) throw new Error("sandbox-exec requires a profilePath");
+      return ["sandbox-exec", "-f", profilePath, ...childArgv];
+    }
+    case "bwrap":
+      // Rootless bubblewrap: no network, read-only root, a writable bind for the
+      // temp dir, an ephemeral /tmp, and die-with-parent so a leaked child is
+      // reaped. `--new-session` drops the controlling terminal.
+      //
+      // `--tmpfs /tmp` hides the host /tmp, which is where `mkdtemp` usually puts
+      // `tempDir`. `--dir tempDir` recreates the bind TARGET inside that fresh tmpfs
+      // BEFORE `--bind` (bubblewrap requires the destination to exist), otherwise
+      // every Linux dry-run would fail to launch.
+      return [
+        "bwrap",
+        "--unshare-all",
+        "--unshare-net",
+        "--die-with-parent",
+        "--new-session",
+        "--ro-bind",
+        "/",
+        "/",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--tmpfs",
+        "/tmp",
+        // Hide credential-bearing home dirs from the read-only root (defense in depth;
+        // bun runs with HOME pointed at the temp dir, so it needs neither).
+        "--tmpfs",
+        "/root",
+        "--tmpfs",
+        "/home",
+        // …but the Bun executable itself often lives under the home dir (~/.bun/bin),
+        // which the tmpfs just masked — re-expose its directory so the child can launch.
+        "--ro-bind-try",
+        dirname(childArgv[0] ?? ""),
+        dirname(childArgv[0] ?? ""),
+        "--dir",
+        tempDir,
+        "--bind",
+        tempDir,
+        tempDir,
+        "--chdir",
+        tempDir,
+        "--",
+        ...childArgv,
+      ];
+    case "trusted-container":
+      // The orchestration already denies the network; run the child directly.
+      return [...childArgv];
+  }
+}

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -1,0 +1,394 @@
+/**
+ * Hardened Bun-subprocess execution dry-run runner — Spec 70 P3.
+ *
+ * Implements the core `ExecutionDryRunProvider` seam (Spec 70 P2) by running ONE
+ * generated change against ONE synthetic input in a locked-down child process:
+ *
+ *   - OS sandbox (Spec 70 §4): the spawn is ALWAYS wrapped so network egress is
+ *     denied AND writes are confined (`sandbox-exec` on macOS, `bwrap` on Linux, or a
+ *     declared `--network none` container). No usable sandbox → FAIL CLOSED: report
+ *     `infra_error` and run nothing (never a bare unsandboxed child).
+ *   - Dropped ambient authority: a MINIMAL env (no secrets — no DATABASE_URL etc.),
+ *     a throwaway temp `cwd`, stdin ignored.
+ *   - Shimmed `@linchkit/core`: the generated `define*()` resolves to a fake; the
+ *     real DB/provider wiring never loads. A recording Proxy context turns any
+ *     `ctx.*` call into a `forbidden_side_effect` (the handler performs no real I/O).
+ *   - Hard timeout: the child is killed past `limits.timeoutMs` → `timeout`.
+ *
+ * Warn-only by construction: this runner only PRODUCES a `DryRunOutcome`. Whether
+ * a failing outcome blocks graduation is decided later by `strictExecutionDryRun`
+ * (Spec 70 §7, default off). Core never calls this — a P3-follow-up wires it into
+ * the async materialize path to stamp the durable `dryRunStatus`.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DryRunOutcome, DryRunStatus, ExecutionDryRunProvider } from "@linchkit/core";
+import {
+  PRELOAD_FILENAME,
+  PRELOAD_SOURCE,
+  RUNNER_FILENAME,
+  RUNNER_SOURCE,
+  SOURCE_FILENAME,
+} from "./child-harness";
+import {
+  buildSandboxArgv,
+  buildSandboxExecProfile,
+  defaultSandboxEnv,
+  detectSandboxStrategy,
+  isSandboxStrategyUsable,
+  type SandboxEnv,
+  type SandboxStrategy,
+} from "./sandbox";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MEMORY_BYTES = 256 * 1024 * 1024;
+/** How often the memory guard samples the process tree's RSS. */
+const MEM_POLL_MS = 250;
+
+/**
+ * Best-effort resident-memory sample of a process AND ALL its descendants, in bytes
+ * (0 if unavailable). Summing the tree (not just the root pid) is what makes the cap
+ * effective under `bwrap`, where the spawned pid is the launcher and the real handler
+ * runs in a descendant bun process; on macOS/trusted-container the root IS bun, so the
+ * tree is just that. A single `ps` snapshot is walked by parent→child links.
+ */
+function readTreeRssBytes(rootPid: number): number {
+  try {
+    const res = Bun.spawnSync(["ps", "-axo", "pid=,ppid=,rss="]);
+    const text = new TextDecoder().decode(res.stdout);
+    const rssByPid = new Map<number, number>();
+    const childrenByPid = new Map<number, number[]>();
+    for (const line of text.split("\n")) {
+      const cols = line.trim().split(/\s+/);
+      if (cols.length < 3) continue;
+      const pid = Number(cols[0]);
+      const ppid = Number(cols[1]);
+      const kb = Number(cols[2]);
+      if (!Number.isFinite(pid) || !Number.isFinite(ppid)) continue;
+      rssByPid.set(pid, Number.isFinite(kb) && kb > 0 ? kb * 1024 : 0);
+      const siblings = childrenByPid.get(ppid);
+      if (siblings) siblings.push(pid);
+      else childrenByPid.set(ppid, [pid]);
+    }
+    let total = 0;
+    const queue = [rootPid];
+    const seen = new Set<number>([rootPid]);
+    while (queue.length > 0) {
+      const pid = queue.shift() as number;
+      total += rssByPid.get(pid) ?? 0;
+      for (const child of childrenByPid.get(pid) ?? []) {
+        if (!seen.has(child)) {
+          seen.add(child);
+          queue.push(child);
+        }
+      }
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+/** Child statuses the harness can report. Any other value is treated as infra. */
+const CHILD_STATUSES = new Set<DryRunStatus>([
+  "passed",
+  "threw",
+  "forbidden_side_effect",
+  "malformed_output",
+]);
+
+/** Raw JSON the child harness writes to the result file. */
+interface ChildResult {
+  status?: string;
+  error?: string;
+  sideEffects?: unknown;
+  /** Integrity nonce stamped by the harness; verified against the value we passed. */
+  __nonce?: string;
+}
+
+export interface SubprocessDryRunnerOptions {
+  /** Default resource bounds when a job omits them. */
+  defaultLimits?: { timeoutMs: number; memoryBytes: number };
+  /** Override the sandbox/platform probe (tests). */
+  sandboxEnv?: SandboxEnv;
+  /** Root dir for the throwaway per-run temp dir (defaults to the OS temp dir). */
+  tmpRoot?: string;
+  /** Absolute path to the Bun executable for the child (defaults to this process's). */
+  bunPath?: string;
+}
+
+/** Build the `infra_error` outcome (warn-only; never blocks). */
+function infraOutcome(
+  job: { changeName: string; target: DryRunOutcome["target"]; inputCaseId: string },
+  reason: string,
+): DryRunOutcome {
+  return {
+    changeName: job.changeName,
+    target: job.target,
+    status: "infra_error",
+    error: reason,
+    inputCaseId: job.inputCaseId,
+  };
+}
+
+/**
+ * Create a hardened-subprocess `ExecutionDryRunProvider`. Each `dryRun` call runs
+ * in its own throwaway temp dir, sandboxed, and is fully cleaned up afterward.
+ */
+export function createSubprocessDryRunner(
+  options: SubprocessDryRunnerOptions = {},
+): ExecutionDryRunProvider {
+  const sandboxEnv = options.sandboxEnv ?? defaultSandboxEnv();
+  const bunPath = options.bunPath ?? process.execPath;
+  const defaults = options.defaultLimits ?? {
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    memoryBytes: DEFAULT_MEMORY_BYTES,
+  };
+
+  // Probe the detected strategy's usability once per runner (the result is stable for
+  // a given host) so a present-but-broken sandbox-exec fails closed without spawning
+  // an unsandboxed child.
+  const usableMemo = new Map<SandboxStrategy, boolean>();
+  const strategyUsable = (strategy: SandboxStrategy): boolean => {
+    let usable = usableMemo.get(strategy);
+    if (usable === undefined) {
+      usable = isSandboxStrategyUsable(strategy);
+      usableMemo.set(strategy, usable);
+    }
+    return usable;
+  };
+
+  return {
+    async dryRun(job): Promise<DryRunOutcome> {
+      const inputCaseId = job.inputCaseId;
+      const base = { changeName: job.changeName, target: job.target, inputCaseId };
+      const timeoutMs = job.limits?.timeoutMs ?? defaults.timeoutMs;
+      const memoryBytes = job.limits?.memoryBytes ?? defaults.memoryBytes;
+      // Integrity nonce: passed to the child on STDIN (not argv/env, so it is not
+      // recoverable via /proc), stamped into the real verdict, and verified below — a
+      // result forged by the untrusted code cannot carry it.
+      const nonce = crypto.randomUUID();
+
+      // Fail closed when no OS sandbox can deny network egress on this host, or when
+      // the detected primitive is present but cannot actually apply a sandbox.
+      const strategy = detectSandboxStrategy(sandboxEnv);
+      if (!strategy) {
+        return infraOutcome(
+          base,
+          "No OS sandbox available to deny network egress on this host — failing closed (no untrusted code was run).",
+        );
+      }
+      if (!strategyUsable(strategy)) {
+        return infraOutcome(
+          base,
+          `The '${strategy}' sandbox is present but cannot apply a profile on this host — failing closed (no untrusted code was run).`,
+        );
+      }
+
+      const dir = await mkdtemp(join(options.tmpRoot ?? tmpdir(), "linchkit-dryrun-"));
+      const startedAt = Date.now();
+      // Hoisted so `finally` can reap the child's process group on EVERY path — even a
+      // handler that backgrounds a process and then returns normally leaves nothing
+      // alive past the dry-run.
+      let proc: ReturnType<typeof Bun.spawn> | undefined;
+      const reapGroup = (): void => {
+        if (!proc) return;
+        try {
+          // Negative pid targets the whole group (the child is its leader via
+          // `detached`), reaping descendants too; fall back to the lone process.
+          process.kill(-proc.pid, 9);
+        } catch {
+          try {
+            proc.kill(9);
+          } catch {
+            /* already exited */
+          }
+        }
+      };
+      try {
+        const sourcePath = join(dir, SOURCE_FILENAME);
+        const preloadPath = join(dir, PRELOAD_FILENAME);
+        const runnerPath = join(dir, RUNNER_FILENAME);
+        const inputPath = join(dir, "__dryrun_input.json");
+        const metaPath = join(dir, "__dryrun_meta.json");
+        // Randomly named so the untrusted source (which has its argv scrubbed) cannot
+        // guess the path and forge the verdict by writing it directly.
+        const resultPath = join(dir, `__dryrun_result_${crypto.randomUUID()}.json`);
+        const profilePath = join(dir, "__dryrun_profile.sb");
+
+        await Promise.all([
+          writeFile(sourcePath, job.source, "utf8"),
+          writeFile(preloadPath, PRELOAD_SOURCE, "utf8"),
+          writeFile(runnerPath, RUNNER_SOURCE, "utf8"),
+          writeFile(inputPath, JSON.stringify(job.input ?? {}), "utf8"),
+          writeFile(metaPath, JSON.stringify(job.metadata ?? {}), "utf8"),
+          // A minimal package.json so `bun` does not walk up out of the temp dir.
+          writeFile(
+            join(dir, "package.json"),
+            '{"name":"linchkit-dryrun-child","type":"module"}',
+            "utf8",
+          ),
+          strategy === "sandbox-exec"
+            ? writeFile(profilePath, buildSandboxExecProfile(dir), "utf8")
+            : Promise.resolve(),
+        ]);
+
+        // argv[4] = the change name, so the child can disambiguate a multi-export
+        // module and never silently run the wrong definition; argv[5] = the tenant id
+        // exposed on the dry-run context; argv[6] = the execution-metadata JSON path.
+        const childArgv = [
+          bunPath,
+          "--preload",
+          preloadPath,
+          runnerPath,
+          inputPath,
+          resultPath,
+          job.changeName,
+          job.tenantId ?? "dry-run",
+          metaPath,
+        ];
+        const argv = buildSandboxArgv({ strategy, childArgv, tempDir: dir, profilePath });
+        // Resolve the wrapper binary (argv[0]) to an absolute path so spawning does
+        // not depend on the child's (minimal) PATH.
+        const wrapperBin = argv[0];
+        if (wrapperBin) argv[0] = sandboxEnv.which(wrapperBin) ?? wrapperBin;
+
+        // Minimal env: enough for bun to run, but NO secrets (no inherited
+        // DATABASE_URL / API keys / tokens). HOME + TMPDIR point at the throwaway dir.
+        const env: Record<string, string> = {
+          PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
+          HOME: dir,
+          TMPDIR: dir,
+          LANG: process.env.LANG ?? "C",
+        };
+
+        // `detached` makes the child a process-group leader (POSIX `setsid`), so we can
+        // kill the WHOLE group — reaping any subprocess the handler spawned, not just
+        // the sandbox command — and nothing outlives the dry-run.
+        //
+        // stdout/stderr are DISCARDED, not captured: returning the untrusted child's
+        // output would be an exfiltration channel (a handler that reads a host file and
+        // prints it would surface its contents in the outcome). The verdict comes only
+        // from the structured result file the harness writes. Discarding also means no
+        // pipe a leaked descendant could hold open to defeat the timeout.
+        proc = Bun.spawn(argv, {
+          cwd: dir,
+          env,
+          stdin: new Blob([nonce]),
+          stdout: "ignore",
+          stderr: "ignore",
+          detached: true,
+        });
+
+        // Race the child's exit against the hard timeout and a memory guard.
+        let timedOut = false;
+        let oomKilled = false;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        let memTimer: ReturnType<typeof setInterval> | undefined;
+        const childPid = proc.pid;
+        const exitCode = await Promise.race([
+          proc.exited,
+          new Promise<number>((resolve) => {
+            timer = setTimeout(() => {
+              timedOut = true;
+              reapGroup();
+              resolve(-1);
+            }, timeoutMs);
+            // Best-effort memory cap: sample the process tree's RSS and kill if it
+            // exceeds the limit.
+            memTimer = setInterval(() => {
+              if (readTreeRssBytes(childPid) > memoryBytes) {
+                oomKilled = true;
+                reapGroup();
+                resolve(-1);
+              }
+            }, MEM_POLL_MS);
+          }),
+        ]);
+        if (timer) clearTimeout(timer);
+        if (memTimer) clearInterval(memTimer);
+
+        const durationMs = Date.now() - startedAt;
+
+        if (oomKilled) {
+          return {
+            ...base,
+            status: "oom",
+            error: `Execution exceeded the ${memoryBytes}-byte dry-run memory limit and was killed.`,
+            durationMs,
+          };
+        }
+
+        if (timedOut) {
+          return {
+            ...base,
+            status: "timeout",
+            error: `Execution exceeded the ${timeoutMs}ms dry-run timeout and was killed.`,
+            durationMs,
+          };
+        }
+
+        // The harness writes its outcome to resultPath. Its absence means the child
+        // died before reporting (bun failed to start, OOM-killed, sandbox blocked
+        // it) — an INFRA failure, not a content verdict.
+        let childOutcome: ChildResult | null = null;
+        try {
+          childOutcome = (await Bun.file(resultPath).json()) as ChildResult;
+        } catch {
+          childOutcome = null;
+        }
+        if (!childOutcome || typeof childOutcome.status !== "string") {
+          return infraOutcome(
+            base,
+            `Dry-run child produced no result (exit ${exitCode}); treating as an infrastructure failure.`,
+          );
+        }
+        // Integrity check: only the harness knows the nonce (passed on stdin, consumed
+        // before untrusted code ran). A mismatch means the result was forged or
+        // truncated — never trust it as a content verdict.
+        if (childOutcome.__nonce !== nonce) {
+          return infraOutcome(
+            base,
+            "Dry-run result failed its integrity check (nonce mismatch); treating as an infrastructure failure.",
+          );
+        }
+
+        const status: DryRunStatus = CHILD_STATUSES.has(childOutcome.status as DryRunStatus)
+          ? (childOutcome.status as DryRunStatus)
+          : "infra_error";
+
+        const attempted = Array.isArray(childOutcome.sideEffects)
+          ? (childOutcome.sideEffects as Array<{ kind?: string; detail?: string }>)
+              .filter((e) => e && typeof e.detail === "string")
+              .map((e) => ({
+                kind: "unknown" as const,
+                detail: String(e.detail).slice(0, 200),
+              }))
+          : undefined;
+
+        return {
+          ...base,
+          status,
+          durationMs,
+          ...(typeof childOutcome.error === "string"
+            ? { error: childOutcome.error.slice(0, 500) }
+            : {}),
+          ...(attempted && attempted.length > 0 ? { attemptedSideEffects: attempted } : {}),
+        };
+      } catch (err) {
+        // Spawn/setup failure (e.g. the sandbox binary vanished) — infra, never a
+        // content verdict, so it can never wrongly block graduation.
+        return infraOutcome(
+          base,
+          `Dry-run could not be launched: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } finally {
+        // Reap any process the handler may have backgrounded (normal path too), then
+        // remove the throwaway dir.
+        reapGroup();
+        await rm(dir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  };
+}

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -23,7 +23,7 @@
 
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { DryRunOutcome, DryRunStatus, ExecutionDryRunProvider } from "@linchkit/core";
 import {
   PRELOAD_FILENAME,
@@ -133,6 +133,19 @@ function infraOutcome(
 }
 
 /**
+ * Resolve the Bun executable to an absolute path. `undefined` → the current
+ * executable; an absolute override is honoured as-is; a relative/bare override is
+ * looked up on PATH and, failing that, falls back to the current executable — so
+ * `dirname(bunPath)` can never resolve to "." (which would bind the caller's CWD
+ * into the bwrap sandbox).
+ */
+function resolveBunPath(provided: string | undefined, env: SandboxEnv): string {
+  if (!provided) return process.execPath;
+  if (isAbsolute(provided)) return provided;
+  return env.which(provided) ?? process.execPath;
+}
+
+/**
  * Create a hardened-subprocess `ExecutionDryRunProvider`. Each `dryRun` call runs
  * in its own throwaway temp dir, sandboxed, and is fully cleaned up afterward.
  */
@@ -140,7 +153,12 @@ export function createSubprocessDryRunner(
   options: SubprocessDryRunnerOptions = {},
 ): ExecutionDryRunProvider {
   const sandboxEnv = options.sandboxEnv ?? defaultSandboxEnv();
-  const bunPath = options.bunPath ?? process.execPath;
+  // Resolve the Bun executable to an ABSOLUTE path. A relative/bare `bunPath`
+  // (e.g. "bun") would make `dirname(bunPath)` in sandbox.ts resolve to "." and
+  // bind the caller's CWD into the bwrap sandbox (leaking arbitrary files), so a
+  // non-absolute override is resolved on PATH, falling back to the current
+  // executable when that fails — the sandbox never exposes an unintended dir.
+  const bunPath = resolveBunPath(options.bunPath, sandboxEnv);
   const defaults = options.defaultLimits ?? {
     timeoutMs: DEFAULT_TIMEOUT_MS,
     memoryBytes: DEFAULT_MEMORY_BYTES,

--- a/bun.lock
+++ b/bun.lock
@@ -300,6 +300,18 @@
         "@linchkit/core": "workspace:*",
       },
     },
+    "addons/dry-run/cap-dry-run": {
+      "name": "@linchkit/cap-dry-run",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "@linchkit/devtools": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
     "addons/file-storage/cap-file-storage": {
       "name": "@linchkit/cap-file-storage",
       "version": "0.0.1",
@@ -921,6 +933,8 @@
     "@linchkit/cap-chatter": ["@linchkit/cap-chatter@workspace:addons/chatter/cap-chatter"],
 
     "@linchkit/cap-chatter-ui": ["@linchkit/cap-chatter-ui@workspace:addons/chatter/cap-chatter-ui"],
+
+    "@linchkit/cap-dry-run": ["@linchkit/cap-dry-run@workspace:addons/dry-run/cap-dry-run"],
 
     "@linchkit/cap-file-storage": ["@linchkit/cap-file-storage@workspace:addons/file-storage/cap-file-storage"],
 


### PR DESCRIPTION
## Spec 70 P3 — hardened Bun-subprocess execution dry-run runner

New capability `@linchkit/cap-dry-run` implementing the core `ExecutionDryRunProvider` seam (Spec 70 P2, #523). It runs ONE AI-materialized change against ONE synthetic input in a locked-down child process and returns a `DryRunOutcome`. **Warn-only and human-gated**: it only PRODUCES outcomes; whether a failing outcome blocks graduation is decided later by `strictExecutionDryRun` (P5). Core stays execution-free.

Part of #520. Tracks Spec 70 (`docs/specs/70_execution_dry_run_sandbox.md`).

### Safety posture (layered)
- **OS sandbox denies network egress AND confines writes** — `sandbox-exec` (macOS), `bwrap` (Linux: read-only root + per-run writable bind + `--dir` mount fix + Bun-exe re-bind), or a declared `--network none` container (`LINCHKIT_DRYRUN_TRUST_CONTAINER=1`). `unshare` alone is rejected (no fs confinement). The primitive is **probed for usability** (present-but-broken `sandbox-exec` → treated as absent). No usable sandbox → **fail closed** (`infra_error`, runs nothing).
- **No output-exfiltration channel** — child stdout/stderr are **discarded**; thrown messages and custom `error.name` are **never surfaced** (only a built-in error class name). Credential dirs are read-denied (`~/.ssh`/`~/.aws`/… on macOS; `/home`+`/root` hidden on bwrap).
- **Faithful, recording `ActionContext`** — real read-only fields (`input`/`logger`/`actor{groups}`/`tenantId`/`ExecutionMeta` shim) so valid handlers don't falsely fail; every I/O method (`create`/`query`/`update`/`delete`/`execute`/`emit`/`ai`/…) records a `forbidden_side_effect` and throws. A swallowed (caught) attempt still taints the verdict. The change is selected **by name** (multi-export modules never run the wrong def).
- **Verdict integrity** — the harness snapshots the intrinsics it uses (`JSON.stringify`/`Object.values`/`Proxy`/…) and pre-builds the context **before** importing untrusted source; the result path is random + scrubbed from `argv`; exits are neutralised; and a **stdin-delivered nonce** (not in `argv`/`env`, so /proc-proof) is stamped into the verdict and **verified by the parent** — a forged result is rejected as `infra_error`.
- **Hard timeout + memory guard** — child runs as a process-group leader (`detached`); past `limits.timeoutMs` the **whole group** is killed (reaping descendants). RSS is summed across the **process tree** against `limits.memoryBytes` → `oom`.

Airtight read-isolation, a precise descendant-inclusive memory cap, and full verdict integrity against a determined same-realm adversary are the Spec 70 P5 microVM/cgroup tier.

### Tests
23 smoke tests (4 host-independent: fail-closed, detection, usability probe, argv; 19 real-sandbox-gated): passed / threw(message-withheld) / timeout / oom / forbidden(+swallowed) / multi-export-by-name / ambiguous→malformed / real-ctx-fields / actor.groups / meta.get / **void-return-without-output-contract→passed** / **output-contract-but-void→malformed** / **anti-forge** / no-stdout-exfil / network-denied / write-outside-blocked / /tmp-write-blocked / lingering-child-reaped. All green on macOS; behavioral tests skip where no usable host sandbox.

### Reviews
Codex iterative review R1→R12 — each round's findings fixed and regression-tested: unshare fs-gap, descendant reaping (process-group kill), write-scope, lockfile, handler-by-name selection, sandbox usability probe, bwrap `--dir` + Bun-exe visibility, descendant-inclusive memory, `(ctx)` handler signature, `ExecutionMeta` shim, output/error exfiltration, **result-file forgery (intrinsic snapshots + stdin nonce + scrubbed random path + neutralised exits)**, `actor.groups`, swallowed side-effects, and **void returns for actions with no declared `output` contract no longer falsely flagged `malformed_output`** (R11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dry-run adapter that safely executes generated handlers in a hardened, network-denied subprocess with sandbox selection (macOS, Linux, container), enforced time/memory limits, suppressed untrusted output, and integrity-checked results.

* **Tests**
  * Added comprehensive smoke and conditional end-to-end tests covering sandbox detection, outcome classification, timeouts, memory limits, side‑effect blocking, and verdict forgery resistance.

* **Documentation**
  * Added detailed README with usage examples, safety controls, outcome descriptions, and integration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->