### PR TITLE
feat(permission,adapter-server): honor meta.evolution authz target + evolution-loop integration spine

### DIFF
--- a/.changeset/honor-meta-evolution-permission-target.md
+++ b/.changeset/honor-meta-evolution-permission-target.md
@@ -1,0 +1,14 @@
+---
+"@linchkit/cap-permission": patch
+---
+
+Permission middleware now honours the documented `meta.evolution` permission
+target. A non-action dispatch (`skipActionSlots`, e.g. the evolution run-cycle
+route) publishes its authoritative target in `ctx.meta.evolution = { operation }`
+— a contract `command-layer.ts` documents — but the middleware previously
+ignored it and gated on the synthetic command name, so a natural grant could
+never authorize it (silent default-deny / admin-only). The middleware now
+resolves `meta.evolution.operation` to the `evolution`/`<operation>` target, so a
+group granting `grant.evolution.actions.run_cycle` authorizes the cycle as
+intended. Scoped to non-action dispatches (`ctx.action` absent) — a real action's
+authorization target is never affected.

--- a/addons/adapter-server/cap-adapter-server/__tests__/evolution-loop-spine.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/evolution-loop-spine.test.ts
@@ -1,0 +1,402 @@
+/**
+ * "说→有" evolution-loop INTEGRATION SPINE — real components at every seam.
+ *
+ * WHY this file exists
+ * ────────────────────
+ * Three sibling smokes each prove ONE segment of the autonomous evolution loop,
+ * but each fakes the OTHER side of its seam, so no single test proves the loop
+ * assembles as one running system:
+ *   - `evolution-run-cycle-smoke.test.ts` drives the REAL server route but injects
+ *     a FAKE `EvolutionRuntime` (canned proposals) and an ALLOW-ALL permission
+ *     stub — it proves route wiring, not that a real cycle emits proposals nor
+ *     that real authorization gates it.
+ *   - `proposal-materialize-dryrun-smoke.test.ts` runs the REAL sandbox but with a
+ *     FAKE code-gen provider and a FAKE in-memory engine.
+ *   - `proposal-graduate-smoke.test.ts` drives the REAL server but stops at the
+ *     draft guard, never exercising a real write.
+ *
+ * This spine closes the gap for the loop's FRONT HALF (autonomous origination):
+ * it wires a REAL `createEvolutionRuntime` (real sensor + real view-less ontology
+ * + the real default translator registry + the real pre-analysis pipeline — the
+ * EXACT option shape `dev-wiring.ts` boots) into the REAL `createServer` route,
+ * behind a REAL `cap-permission` middleware whose authorization is decided by a
+ * REAL `PermissionRegistry` grant. Then it asserts the cycle's proposal lands as
+ * a governed `draft` in the same shared engine the review UI reads.
+ *
+ * It pins TWO things no existing test does together:
+ *   1. A real cycle (Sense→Insight→Proposal) actually EMITS a proposal through
+ *      the production server assembly — not a canned fake.
+ *   2. The real `cap-permission` middleware GATES it: an actor whose group grants
+ *      the documented `grant.evolution.actions.run_cycle` target is ALLOWED; an
+ *      actor without it is DENIED. (This is the seam that blocked the loop live —
+ *      the route publishes its permission target in `meta.evolution`, a contract
+ *      `command-layer.ts` documents and the middleware now honours.)
+ *
+ * HONEST SCOPE: the autonomous cycle currently originates STRUCTURAL `add_view`
+ * proposals (the only built-in translators are `schema_no_view` + rollback-
+ * candidate). It does not yet autonomously originate executable ACTION-handler
+ * code — that materialize → sandbox dry-run → graduate half is exercised against
+ * action proposals by the sibling smokes above. The two halves MEET at the shared
+ * ProposalEngine draft store (proven here); autonomous origination of executable
+ * code is a later phase. Test 3 below carries the real cycle's draft one seam
+ * further (into the real materialize path) to prove the pipe is connected, and
+ * asserts the honest outcome for a non-executable view change.
+ *
+ * Dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ * `app.listen(PORT)` is intentionally avoided — a bound socket per suite
+ * SEGFAULTS the batched addons run.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createPermissionMiddlewareRegistration } from "@linchkit/cap-permission";
+import type {
+  Actor,
+  EntityDefinition,
+  EntityDescriptor,
+  ImpactDataProvider,
+  OntologyRegistry,
+  PendingProposalStore,
+  ProposalChange,
+  ProposalDefinition,
+} from "@linchkit/core";
+import {
+  createDedupAnalyzer,
+  createDefaultInsightTranslatorRegistry,
+  createImpactAnalyzer,
+  createPreAnalysisPipeline,
+  definePermissionGroup,
+} from "@linchkit/core";
+import {
+  type CodeGenerationProvider,
+  type CommandLayer,
+  createActionExecutor,
+  createCommandLayer,
+  createEvolutionRuntime,
+  defineSensor,
+  type EvolutionRuntime,
+  InMemoryExecutionLogger,
+  InMemoryStore,
+  PermissionRegistry,
+  type ProposalEngine,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { getSharedProposalEngine } from "../src/proposal-api";
+import {
+  type MaterializeEngine,
+  runProposalMaterialization,
+} from "../src/proposal-materialize-api";
+import { createServer } from "../src/server";
+
+const BASE = "http://local.test";
+
+const taskSchema: EntityDefinition = {
+  name: "task",
+  label: "Task",
+  fields: { title: { type: "string", required: true, label: "Title" } },
+};
+
+// ── Real evolution-runtime composition (mirrors dev-wiring.ts exactly) ────────
+
+/**
+ * A view-less ontology carrying ONE entity — the trigger for the `schema_no_view`
+ * structural issue → insight → `add_view` proposal pipeline. The entity name is
+ * caller-supplied so every test mints a globally-unique one, keeping the shared
+ * engine's capability+change-set dedup collision-free across the batched run.
+ */
+function createViewlessOntology(entityName: string): OntologyRegistry {
+  const schemas: Record<string, Partial<EntityDescriptor>> = {
+    [entityName]: {
+      views: [],
+      actions: [],
+      fields: {
+        id: { type: "string" },
+        value: { type: "number" },
+      } as EntityDescriptor["fields"],
+    },
+  };
+  return {
+    describe: (name) => schemas[name] as EntityDescriptor | undefined,
+    listEntities: () => Object.keys(schemas),
+    searchEntities: () => [],
+    actionsFor: () => [],
+    rulesFor: () => [],
+    stateFor: () => undefined,
+    viewsFor: () => [],
+    flowsFor: () => [],
+    handlersFor: () => [],
+    relatedEntities: () => [],
+    entitiesImplementing: () => [],
+    toJSON: () => ({}) as ReturnType<OntologyRegistry["toJSON"]>,
+    toMarkdown: () => "",
+    searchByIntent: () => [],
+    searchByDomain: () => [],
+    getSemanticsFor: () => undefined,
+    dependencyGraph: (ref) => ({ root: ref, nodes: [ref], edges: [] }),
+    impactAnalysis: (ref) => [[ref]],
+  };
+}
+
+/** Single-emit sensor so one `runCycle()` ingests exactly one signal. */
+function createOneShotSensor(entityName: string) {
+  let emitted = false;
+  return defineSensor({
+    name: `${entityName}_tick`,
+    source: "server",
+    entity: entityName,
+    async detect(ctx) {
+      if (emitted) return null;
+      emitted = true;
+      return {
+        sensor: `${entityName}_tick`,
+        source: "server",
+        timestamp: ctx.timestamp,
+        value: 42,
+        baseline: 40,
+        deviation: 0.05,
+        confidence: 0.95,
+        context: { entity: entityName, metric: "value", tenantId: "dev" },
+      };
+    },
+  });
+}
+
+function createEmptyPendingProposalStore(): PendingProposalStore {
+  return {
+    async listPending(): Promise<ProposalDefinition[]> {
+      return [];
+    },
+  };
+}
+
+function createEmptyImpactDataProvider(): ImpactDataProvider {
+  return {
+    async countRecords(): Promise<number> {
+      return 0;
+    },
+    async sampleRecordIds(): Promise<string[]> {
+      return [];
+    },
+  };
+}
+
+/** Build a REAL evolution runtime for `entityName`, stamping `capability`. */
+function buildRealRuntime(entityName: string, capability: string): EvolutionRuntime {
+  return createEvolutionRuntime({
+    sensors: [createOneShotSensor(entityName)],
+    ontology: createViewlessOntology(entityName),
+    translatorRegistry: createDefaultInsightTranslatorRegistry(),
+    proposalCapability: capability,
+    proposalPreAnalysisPipeline: createPreAnalysisPipeline({
+      analyzers: [
+        createDedupAnalyzer({ store: createEmptyPendingProposalStore() }),
+        createImpactAnalyzer({ dataProvider: createEmptyImpactDataProvider() }),
+      ],
+    }),
+  });
+}
+
+// ── Real cap-permission grant for the documented evolution target ─────────────
+
+const EVOLUTION_OPERATOR = "evolution_operator";
+
+/**
+ * A real `PermissionRegistry` whose `evolution_operator` group grants the
+ * NATURAL run-cycle target (`grant.evolution.actions.run_cycle`). This is the
+ * grant shape a human would author; the middleware resolves the run-cycle
+ * dispatch's `meta.evolution.operation` to exactly this target.
+ */
+function evolutionRegistry(): PermissionRegistry {
+  const registry = new PermissionRegistry();
+  registry.register(
+    definePermissionGroup({
+      name: EVOLUTION_OPERATOR,
+      label: "Evolution Operator",
+      grant: { evolution: { actions: { run_cycle: true } } },
+    }),
+  );
+  return registry;
+}
+
+const OPERATOR_ACTOR: Actor = { type: "human", id: "op_spine", groups: [EVOLUTION_OPERATOR] };
+const STRANGER_ACTOR: Actor = { type: "human", id: "stranger_spine", groups: ["unrelated_group"] };
+
+/**
+ * Build the REAL server via the canonical factory with a REAL cap-permission
+ * middleware backed by a real grant, a REAL evolution runtime, and a fixed actor.
+ */
+function buildApp(opts: { runtime: EvolutionRuntime; actor: Actor }): {
+  handle: (req: Request) => Promise<Response>;
+} {
+  const store = new InMemoryStore();
+  const executor = createActionExecutor({
+    dataProvider: store,
+    executionLogger: new InMemoryExecutionLogger(),
+  });
+  const commandLayer: CommandLayer = createCommandLayer({ executor });
+  // The REAL permission slot — NOT an allow-all stub. Decides via the registry.
+  commandLayer.use(createPermissionMiddlewareRegistration({ registry: evolutionRegistry() }));
+  const graphqlSchema = buildGraphQLSchema([taskSchema], {
+    executor,
+    commandLayer,
+    dataProvider: store,
+  });
+  return createServer(graphqlSchema, {
+    executor,
+    commandLayer,
+    evolutionRuntime: opts.runtime,
+    resolveRequestActor: () => opts.actor,
+  });
+}
+
+interface RunCycleJson {
+  success: boolean;
+  data?: { created?: number; deduped?: number; total?: number; createdIds?: string[] };
+  error?: { code?: string; message?: string };
+}
+
+async function postRunCycle(app: {
+  handle: (req: Request) => Promise<Response>;
+}): Promise<{ status: number; json: RunCycleJson }> {
+  const res = await app.handle(new Request(`${BASE}/api/evolution/run-cycle`, { method: "POST" }));
+  const body = await res.text();
+  let json: RunCycleJson;
+  try {
+    json = JSON.parse(body) as RunCycleJson;
+  } catch {
+    throw new Error(`run-cycle returned non-JSON (status ${res.status}): ${body.slice(0, 300)}`);
+  }
+  return { status: res.status, json };
+}
+
+function sharedEngine(): ProposalEngine {
+  return getSharedProposalEngine();
+}
+
+/**
+ * A code-gen provider that records whether it was asked to generate anything.
+ * For a view change the materializer must NOT call it (no executable source), so
+ * `calls.count === 0` is the assertion that pins the code-gen no-op boundary.
+ */
+function makeRecordingProvider(): { provider: CodeGenerationProvider; calls: { count: number } } {
+  const calls = { count: 0 };
+  return {
+    calls,
+    provider: {
+      async generateCode() {
+        calls.count += 1;
+        return "export const generated = 1;\n";
+      },
+    },
+  };
+}
+
+let uid = 0;
+function uniqueNames(): { entity: string; capability: string } {
+  uid += 1;
+  const suffix = `${uid}-${Date.now().toString(36)}`;
+  return { entity: `spine_metric_${suffix}`, capability: `cap-spine-${suffix}` };
+}
+
+describe("说→有 evolution-loop spine — real cycle + real authz + real draft", () => {
+  test("operator with grant: real cycle emits a proposal that lands as a governed DRAFT", async () => {
+    const { entity, capability } = uniqueNames();
+    const runtime = buildRealRuntime(entity, capability);
+    const app = buildApp({ runtime, actor: OPERATOR_ACTOR });
+
+    const { status, json } = await postRunCycle(app);
+
+    // The run-cycle dispatch passed the REAL permission slot (grant matched the
+    // documented meta.evolution target) and the REAL cycle produced a proposal.
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.created).toBe(1);
+    expect(json.data?.total).toBe(1);
+    expect(json.data?.createdIds).toHaveLength(1);
+
+    // The proposal really landed in the shared governance engine the review UI
+    // reads — status `draft`, NEVER auto-approved/graduated, minted with a fresh
+    // engine id, and it is a structural add_view origination for our entity.
+    const createdId = json.data?.createdIds?.[0] as string;
+    const persisted = sharedEngine().getProposal(createdId);
+    expect(persisted.status).toBe("draft");
+    expect(persisted.capability).toBe(capability);
+    const addViewChange = persisted.changes.find(
+      (c) => c.target === "view" && c.operation === "create",
+    );
+    expect(addViewChange).toBeDefined();
+  });
+
+  test("stranger without the grant: run-cycle is DENIED and NOTHING is persisted", async () => {
+    const { entity, capability } = uniqueNames();
+    const runtime = buildRealRuntime(entity, capability);
+    const app = buildApp({ runtime, actor: STRANGER_ACTOR });
+
+    const { status, json } = await postRunCycle(app);
+
+    // The REAL permission engine default-denies an actor whose groups grant no
+    // evolution target — the canonical AUTHZ_DENIED envelope, NOT an allow-all leak.
+    expect(status === 401 || status === 403).toBe(true);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+
+    // The cycle never ran past the permission slot, so no draft exists for it.
+    const drafts = sharedEngine().listProposals({ status: "draft" });
+    expect(drafts.filter((p) => p.capability === capability)).toHaveLength(0);
+  });
+
+  test("the cycle's real draft reaches the materialize seam — a view change is a code-gen no-op today (honest boundary)", async () => {
+    // Carry the cycle's REAL draft (not a hand-built fixture) one seam further,
+    // into the real materialize orchestrator, to prove the autonomously-originated
+    // proposal is actually WIRED to the code-materialization path.
+    //
+    // HONEST BOUNDARY (the truthful end-to-end outcome): the autonomous cycle
+    // currently originates a structural `view` change, and the materializer only
+    // synthesises code for executable targets (actions). So the view change is a
+    // code-gen NO-OP — no `generatedSource`, no `materializationStatus`, and no
+    // execution dry-run runs (there is no handler to sandbox). The orchestrator
+    // still returns `ok` with `allMaterialized: true` (vacuously — zero
+    // materializable changes, zero failures), and the proposal stays a `draft`.
+    // The executable-code half (materialize → REAL sandbox dry-run → graduate) is
+    // exercised against ACTION proposals by the sibling `*-dryrun-smoke` /
+    // `*-graduate-smoke` tests. When autonomous origination of action handlers
+    // lands, THIS same draft would instead carry `generatedSource` + a real
+    // `dryRunStatus` — this assertion is the canary that pins today's boundary.
+    const { entity, capability } = uniqueNames();
+    const runtime = buildRealRuntime(entity, capability);
+    const app = buildApp({ runtime, actor: OPERATOR_ACTOR });
+
+    const { json } = await postRunCycle(app);
+    const createdId = json.data?.createdIds?.[0] as string;
+    expect(createdId).toBeTruthy();
+
+    const engine = sharedEngine() as unknown as MaterializeEngine;
+    const provider = makeRecordingProvider();
+    const outcome = await runProposalMaterialization(createdId, {
+      engine,
+      provider: provider.provider,
+      qualityGate: { check: async () => [] },
+    });
+
+    // The orchestrator ran end-to-end against the real cycle draft (draft-only,
+    // never approves/graduates) and returned a structured `ok` — the seam is
+    // connected, not throwing.
+    expect(outcome.kind).toBe("ok");
+    if (outcome.kind === "ok") {
+      expect(outcome.allMaterialized).toBe(true);
+      const change = outcome.proposal.changes[0] as ProposalChange & {
+        materializationStatus?: string;
+        dryRunStatus?: string;
+        generatedSource?: string;
+      };
+      expect(change.target).toBe("view");
+      // No code synthesised for a view change → provider never invoked, no source,
+      // no durable materialization/dry-run signal stamped.
+      expect(provider.calls.count).toBe(0);
+      expect(change.generatedSource).toBeUndefined();
+      expect(change.materializationStatus).toBeUndefined();
+      expect(change.dryRunStatus).toBeUndefined();
+    }
+    // The proposal is still a draft — materialize never promotes it.
+    expect(sharedEngine().getProposal(createdId).status).toBe("draft");
+  });
+});

--- a/addons/permission/cap-permission/__tests__/middleware.test.ts
+++ b/addons/permission/cap-permission/__tests__/middleware.test.ts
@@ -176,3 +176,99 @@ describe("permission middleware", () => {
     expect(nextCalled).toBe(true);
   });
 });
+
+/**
+ * Meta-target permission resolution (`skipActionSlots` dispatch).
+ *
+ * The onchange / evolution routes dispatch through CommandLayer with
+ * `skipActionSlots: true` and NO `ctx.action`; their synthetic command name is a
+ * metrics label only, and the authoritative permission target is published in
+ * `ctx.meta` (`meta.evolution = { operation }`). `command-layer.ts` documents
+ * this contract — these tests pin that the middleware HONOURS it: a natural grant
+ * (`grant.evolution.actions.<operation>`) authorizes the dispatch, a missing grant
+ * is denied, and a real action dispatch is never affected by a stray `meta`.
+ */
+describe("permission middleware — meta.evolution target (skipActionSlots dispatch)", () => {
+  /** A run-cycle-shaped dispatch: synthetic command, no action, meta target. */
+  function runCycleCtx(actor: CommandContext["actor"]): CommandContext {
+    return {
+      command: "evolution.run_cycle",
+      input: {},
+      channel: "http",
+      actor,
+      meta: { evolution: { operation: "run_cycle" } },
+      // No `action` — this is a non-action dispatch (skipActionSlots).
+    } as CommandContext;
+  }
+
+  function registryWithEvolutionGrant(): PermissionRegistry {
+    const registry = new PermissionRegistry();
+    registry.register(
+      definePermissionGroup({
+        name: "evolution_operator",
+        label: "Evolution Operator",
+        // The NATURAL grant shape a human would author for the run-cycle target.
+        grant: { evolution: { actions: { run_cycle: true } } },
+      }),
+    );
+    return registry;
+  }
+
+  it("authorizes run-cycle via grant.evolution.actions.run_cycle (the documented target)", async () => {
+    const middleware = createPermissionMiddleware({ registry: registryWithEvolutionGrant() });
+    const ctx = runCycleCtx({ type: "human", id: "op_1", groups: ["evolution_operator"] });
+    let nextCalled = false;
+
+    await middleware(ctx, async () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+  });
+
+  it("denies run-cycle when the actor's groups grant no evolution target", async () => {
+    const middleware = createPermissionMiddleware({ registry: registryWithEvolutionGrant() });
+    const ctx = runCycleCtx({ type: "human", id: "stranger", groups: ["some_unrelated_group"] });
+
+    await expect(middleware(ctx, async () => {})).rejects.toThrow(AuthorizationError);
+  });
+
+  it("denies run-cycle when the synthetic command name was the only thing granted (regression)", async () => {
+    // Before the meta-target fix the middleware gated on the synthetic command
+    // name. Granting THAT must NOT authorize the operation — the target is the
+    // meta operation, so this still denies. Guards against a silent regression to
+    // command-name gating.
+    const registry = new PermissionRegistry();
+    registry.register(
+      definePermissionGroup({
+        name: "command_name_only",
+        label: "Command-name grant (wrong shape)",
+        grant: { "evolution.run_cycle": { actions: { "evolution.run_cycle": true } } },
+      }),
+    );
+    const middleware = createPermissionMiddleware({ registry });
+    const ctx = runCycleCtx({ type: "human", id: "op_2", groups: ["command_name_only"] });
+
+    await expect(middleware(ctx, async () => {})).rejects.toThrow(AuthorizationError);
+  });
+
+  it("ignores a stray meta.evolution on a real ACTION dispatch (target stays the action)", async () => {
+    // Defensive: meta-target resolution is scoped to non-action dispatches. A real
+    // action carrying meta.evolution must still authorize against its action target
+    // (here `submit_request`), never silently switch to the evolution target.
+    const registry = createTestRegistry();
+    const middleware = createPermissionMiddleware({ registry });
+    const ctx = createTestContext({
+      meta: { evolution: { operation: "run_cycle" } },
+    });
+    let nextCalled = false;
+
+    await middleware(ctx, async () => {
+      nextCalled = true;
+    });
+
+    // `editors` grants `submit_request` (the action target), proving the action
+    // path won — the evolution meta was ignored because `ctx.action` is present.
+    expect(nextCalled).toBe(true);
+  });
+});

--- a/addons/permission/cap-permission/src/middleware/permission-middleware.ts
+++ b/addons/permission/cap-permission/src/middleware/permission-middleware.ts
@@ -64,6 +64,37 @@ export interface PermissionMiddlewareOptions {
 /** TTL for permission decision cache entries: 10 minutes (spec §4) */
 const PERM_CACHE_TTL_MS = 10 * 60 * 1000;
 
+/** The permission target (capability + action) a grant is matched against. */
+interface PermissionTarget {
+  capability: string;
+  action: string;
+}
+
+/**
+ * Resolve the authoritative permission target for a NON-ACTION dispatch that
+ * carries it in `ctx.meta` rather than an action lookup.
+ *
+ * `command-layer.ts` documents this contract: a `skipActionSlots` dispatch (the
+ * onchange / evolution routes) bypasses the ActionExecutor entirely, so there is
+ * no `ctx.action` to derive a target from. Its synthetic `command` name exists
+ * only for metrics/tracing — the authoritative target is published in `ctx.meta`
+ * (`meta.evolution = { operation }`). Gate on that target so a NATURAL grant
+ * (`grant.evolution.actions.<operation>`) authorizes it, instead of the synthetic
+ * command name which no group would ever grant (→ silent default-deny / admin-only).
+ *
+ * Returns `null` when no recognised meta target is present, leaving the caller on
+ * its normal action-based resolution. Only consulted for non-action dispatches
+ * (`ctx.action` absent), so a real action's authorization is never affected.
+ */
+function resolveMetaTarget(ctx: CommandContext): PermissionTarget | null {
+  const meta = ctx.meta as Record<string, unknown> | undefined;
+  const evolution = meta?.evolution as { operation?: unknown } | undefined;
+  if (evolution && typeof evolution.operation === "string" && evolution.operation.length > 0) {
+    return { capability: "evolution", action: evolution.operation };
+  }
+  return null;
+}
+
 // ── Middleware factory ─────────────────────────────────────
 
 /**
@@ -97,15 +128,27 @@ export function createPermissionMiddleware(
       return;
     }
 
-    // Resolve capability name from action
-    const capabilityName = resolveCapability
-      ? resolveCapability(command, ctx)
-      : (action?.entity ?? command);
+    // Resolve the permission target. A non-action dispatch (`skipActionSlots`,
+    // no `ctx.action`) publishes its target in `ctx.meta` — honour that documented
+    // contract first; otherwise fall back to the action-based resolution. Scoping
+    // the meta lookup to `!action` guarantees a real action's target is unchanged.
+    const metaTarget = action ? null : resolveMetaTarget(ctx);
+    const capabilityName = metaTarget
+      ? metaTarget.capability
+      : resolveCapability
+        ? resolveCapability(command, ctx)
+        : (action?.entity ?? command);
+    // The action name a grant is matched against: the meta target's operation for
+    // a meta-targeted dispatch, else the (synthetic) command name as before.
+    const actionName = metaTarget ? metaTarget.action : command;
 
     // ── Cache lookup ─────────────────────────────────────────
+    // Key on the RESOLVED target (capability + action), not the raw command — a
+    // meta-targeted dispatch reuses a synthetic command name across operations, so
+    // keying on the command alone could collide distinct targets in the cache.
     const tenantId = (ctx.meta?.tenantId as string | undefined) ?? "";
     const schemaKey = action?.entity ?? "";
-    const cacheKey = `perm:${tenantId}:${actor.id}:${command}:${schemaKey}`;
+    const cacheKey = `perm:${tenantId}:${actor.id}:${capabilityName}:${actionName}:${schemaKey}`;
     const cacheTags = [`perm:${tenantId}`, `perm`];
 
     if (cacheManager) {
@@ -135,7 +178,7 @@ export function createPermissionMiddleware(
     }
 
     // ── Step 1: Check action permission ──────────────────────
-    const permResult = checkActionPermission(registry, actor, capabilityName, command);
+    const permResult = checkActionPermission(registry, actor, capabilityName, actionName);
 
     if (!permResult.allowed) {
       // Cache negative result too (prevents repeat lookups for denied actions)
@@ -146,10 +189,10 @@ export function createPermissionMiddleware(
       );
       throw new AuthorizationError({
         code: "authz.action.denied",
-        message: `Permission denied for action "${command}": ${permResult.reason ?? "no matching permission group"}`,
+        message: `Permission denied for action "${actionName}": ${permResult.reason ?? "no matching permission group"}`,
         requiredGroups: actor.groups.length > 0 ? undefined : ["(any)"],
         details: {
-          action: command,
+          action: actionName,
           capability: capabilityName,
           decidedBy: permResult.decidedBy,
         },

--- a/addons/permission/cap-permission/src/middleware/permission-middleware.ts
+++ b/addons/permission/cap-permission/src/middleware/permission-middleware.ts
@@ -157,10 +157,12 @@ export function createPermissionMiddleware(
         if (!cached.allowed) {
           throw new AuthorizationError({
             code: "authz.action.denied",
-            message: `Permission denied for action "${command}": ${cached.reason ?? "no matching permission group"}`,
+            // Use the RESOLVED actionName (not the raw command) so a cached denial
+            // surfaces the same action identifier as the non-cached path above.
+            message: `Permission denied for action "${actionName}": ${cached.reason ?? "no matching permission group"}`,
             requiredGroups: actor.groups.length > 0 ? undefined : ["(any)"],
             details: {
-              action: command,
+              action: actionName,
               capability: capabilityName,
               decidedBy: cached.decidedBy,
             },


### PR DESCRIPTION
## Make the "说→有" loop demonstrably RUN — front-half integration spine + the authz seam that blocked it

The autonomous evolution loop (Sense→Insight→Proposal → Validation → Approval → materialize → graduate) had never run end-to-end **as one assembled system**. Each segment had a green smoke, but every smoke **faked the other side of its seam**:

| Existing smoke | Real | Faked |
|---|---|---|
| `evolution-run-cycle-smoke` | server route assembly | **fake `EvolutionRuntime` (canned proposals) + allow-all permission stub** |
| `proposal-materialize-dryrun-smoke` | real sandbox dry-run | fake code-gen provider + fake engine |
| `proposal-graduate-smoke` | real `createServer` | stops at the draft guard (no real write) |

This is the classic "two units each mock the other side of a seam, both pass, the integration is broken" trap. Two concrete consequences this PR addresses:

### 1. Fix a documented-but-unimplemented authorization seam (`cap-permission`)

The run-cycle route dispatches through CommandLayer with `skipActionSlots: true` and publishes its **authoritative permission target in `ctx.meta.evolution = { operation }`** — a contract `command-layer.ts` explicitly documents ("derive the target from meta when present"). But `createPermissionMiddleware` **never read it**: it gated on the *synthetic* command name (`"evolution.run_cycle"`), which no group would ever grant → silent **default-deny / admin-only**. (This is exactly the `AUTHZ_DENIED` wall the loop hit when run live.)

The middleware now honours the contract: a non-action dispatch (`ctx.action` absent) resolves `meta.evolution.operation` to the `evolution`/`<operation>` target, so the **natural** grant `grant.evolution.actions.run_cycle` authorizes the cycle as intended. Scoped to non-action dispatches — **a real action's target is never affected** (proven by a regression test). The decision-cache key now keys on the *resolved* target, not the raw command.

- **No bypass risk:** `meta.evolution` is populated server-side by the route, never client-controllable; a forged `operation` only changes *which grant is consulted* — without a matching grant it still default-denies. A stray `meta.evolution` on a real action dispatch is ignored (target stays the action).
- 4 new middleware unit tests pin the contract: natural grant allows · missing grant denies · granting only the synthetic command name still denies (regression) · stray meta on a real action is ignored.

### 2. Add the missing front-half integration spine (`adapter-server`)

`evolution-loop-spine.test.ts` wires a **REAL** `createEvolutionRuntime` (real sensor + view-less ontology + the real default translator registry + the real pre-analysis pipeline — the *exact* shape `dev-wiring.ts` boots) into the **REAL** `createServer` route, behind the **REAL** `cap-permission` middleware whose decision comes from a **REAL** `PermissionRegistry` grant. It proves, in one assembled system:

1. **A real cycle EMITS a proposal** through the production server assembly (not a canned fake) and it lands as a governed `draft` in the same shared engine the review UI reads.
2. **The real permission engine GATES it** — an operator carrying the `grant.evolution.actions.run_cycle` target is **allowed**; an actor without it is **denied** (`AUTHZ_DENIED`, nothing persisted). Not an allow-all leak.
3. **The cycle's real draft reaches the materialize seam** — honestly pinning today's boundary: a structural `view` change is a **code-gen no-op** (no `generatedSource`, no dry-run; the orchestrator returns `ok`/`allMaterialized` vacuously, the proposal stays a draft). The executable-code half (materialize → real sandbox dry-run → graduate) is exercised against **action** proposals by the sibling dryrun/graduate smokes. The two halves meet at the shared ProposalEngine draft store; autonomous origination of executable *action* code is a later phase, and this assertion is the canary for that boundary.

These tests run in the normal `bun run test` suite, so **CI now continuously proves the integrated front-half loop assembles and runs** — not just isolated units.

### Verification

- `bun run check` · `bun run typecheck` · full `bun run test` — all green (no regression across the repo from the shared-middleware change).
- cap-permission subtree: 81 pass · spine + sibling evolution/materialize smokes: green.

### Review note

CLI cross-model review was unavailable this run (codex usage-limited until Jun 11; gemini CLI `ECONNRESET`). Relying on the PR bots (gemini-code-assist / coderabbit) for the external cross-model pass, plus a self-adversarial review of the authz-bypass surface and the spine assertions. Please scrutinise the `meta.evolution` target resolution and the `!action` scoping.

Part of the loop-goes-live arc (Spec 55 §7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed permission middleware to correctly honor documented evolution operation targets for non-action dispatches, preventing incorrectly denied authorizations.

* **Tests**
  * Added comprehensive test coverage for permission resolution and evolution-loop authorization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->