### PR TITLE
feat(permission,adapter-server): honor meta.onchange authz target (companion to #527)

### DIFF
--- a/.changeset/honor-meta-onchange-permission-target.md
+++ b/.changeset/honor-meta-onchange-permission-target.md
@@ -1,0 +1,15 @@
+---
+"@linchkit/cap-permission": patch
+---
+
+Permission middleware now honours the documented `meta.onchange` permission
+target — the second half of the meta-target contract `command-layer.ts` documents
+(the `meta.evolution` half was wired in the prior patch). The onchange route
+(`POST /api/entities/:name/onchange`, Spec 64) dispatches with `skipActionSlots`
+and no `ctx.action`, publishing its target in `ctx.meta.onchange = { entity }`. The
+middleware now resolves this to an entity-level **READ** check: the actor may run
+the onchange computation iff `grant.<entity>.data.read` resolves to anything other
+than `none` (explicit `none` still wins). Previously the dispatch was gated on the
+synthetic command name `"<entity>.onchange"`, which no group grants → silent
+default-deny / admin-only. Scoped to non-action dispatches (`ctx.action` absent),
+so a real action's authorization target is never affected.

--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-authz-spine.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-authz-spine.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Onchange authorization SPINE — real route + real cap-permission, one seam.
+ *
+ * `command-layer.ts` documents a `meta.onchange = { entity }` permission contract:
+ * the onchange route (`POST /api/entities/:name/onchange`) dispatches with
+ * `skipActionSlots: true` and publishes its authoritative target in `meta.onchange`
+ * so the permission middleware can derive an **entity-level READ check** instead of
+ * looking up an action named "onchange". The route faithfully populates that meta,
+ * but `cap-permission` previously ignored it (gating on the synthetic command name
+ * `"<entity>.onchange"` no group grants → silent default-deny / admin-only) — the
+ * same producer-fills-meta / consumer-ignores-meta seam #527 fixed for evolution.
+ *
+ * The sibling `onchange-api.test.ts` drives the real route but with a STUB
+ * permission middleware (allow-all / throw-all), so it never proves the REAL
+ * `cap-permission` honours `meta.onchange`. This spine fills exactly that gap: it
+ * drives the real route through `createServer` behind the REAL `cap-permission`
+ * middleware whose decision comes from a REAL `PermissionRegistry` grant, and
+ * asserts producer + consumer AGREE on the `meta.onchange.entity` signal:
+ *   - an actor with READ access to the entity (`grant.invoice.data.read`) is
+ *     allowed and gets the computed onchange result;
+ *   - an actor without it is denied (canonical `AUTHZ_DENIED`, 403).
+ *
+ * Dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createPermissionMiddlewareRegistration } from "@linchkit/cap-permission";
+import type { Actor, EntityDefinition } from "@linchkit/core";
+import { definePermissionGroup } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  createEntityRegistry,
+  createOnchangeEvaluator,
+  InMemoryStore,
+  PermissionRegistry,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+const BASE = "http://local.test";
+
+/** A minimal entity with a self-contained onchange hook (no store lookup). */
+const invoiceEntity: EntityDefinition = {
+  name: "invoice",
+  label: "Invoice",
+  fields: {
+    qty: { type: "number", label: "Qty" },
+    unit_price: { type: "number", label: "Unit Price" },
+    total: { type: "number", label: "Total" },
+  },
+  onchange: {
+    "qty,unit_price": {
+      updates: ["total"],
+      compute: (ctx) => ({
+        total: ((ctx.values.qty as number) ?? 0) * ((ctx.values.unit_price as number) ?? 0),
+      }),
+    },
+  },
+};
+
+/** A registry whose `invoice_reader` group grants READ on `invoice`; the
+ * `order_reader` group exists but grants the WRONG entity (proves default-deny). */
+function invoiceRegistry(): PermissionRegistry {
+  const registry = new PermissionRegistry();
+  registry.register(
+    definePermissionGroup({
+      name: "invoice_reader",
+      label: "Invoice Reader",
+      grant: { invoice: { data: { read: "all" } } },
+    }),
+  );
+  registry.register(
+    definePermissionGroup({
+      name: "order_reader",
+      label: "Order Reader",
+      grant: { order: { data: { read: "all" } } },
+    }),
+  );
+  return registry;
+}
+
+const READER: Actor = { type: "human", id: "invoice_reader_1", groups: ["invoice_reader"] };
+const STRANGER: Actor = { type: "human", id: "order_reader_1", groups: ["order_reader"] };
+
+/** Build the REAL server with the REAL cap-permission middleware + onchange route. */
+function buildApp(actor: Actor): { handle: (req: Request) => Promise<Response> } {
+  const entityRegistry = createEntityRegistry();
+  entityRegistry.register(invoiceEntity);
+  const store = new InMemoryStore();
+  const executor = createActionExecutor({ dataProvider: store });
+  const commandLayer = createCommandLayer({ executor });
+  commandLayer.use(createPermissionMiddlewareRegistration({ registry: invoiceRegistry() }));
+  const evaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+  const graphqlSchema = buildGraphQLSchema([invoiceEntity]);
+  return createServer(graphqlSchema, {
+    executor,
+    commandLayer,
+    entityRegistry,
+    onchangeEvaluator: evaluator,
+    resolveRequestActor: () => actor,
+  });
+}
+
+async function postOnchange(app: {
+  handle: (req: Request) => Promise<Response>;
+}): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await app.handle(
+    new Request(`${BASE}/api/entities/invoice/onchange`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ changedField: "qty", values: { qty: 3, unit_price: 10 } }),
+    }),
+  );
+  const body = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body };
+}
+
+describe("onchange authz spine — real route + real cap-permission (meta.onchange seam)", () => {
+  test("reader WITH grant.invoice.data.read: authorized → computed onchange result", async () => {
+    const { status, body } = await postOnchange(buildApp(READER));
+
+    // Past the REAL permission slot (the entity read grant matched the documented
+    // meta.onchange target) and the real evaluator ran: total = 3 * 10.
+    expect(status).toBe(200);
+    const updates = body.updates as Record<string, unknown> | undefined;
+    expect(updates?.total).toBe(30);
+  });
+
+  test("stranger WITHOUT invoice read: denied → canonical AUTHZ_DENIED (403)", async () => {
+    const { status, body } = await postOnchange(buildApp(STRANGER));
+
+    // The REAL permission engine default-denies an actor with no read access to
+    // `invoice` — the canonical, side-channel-free envelope, not an allow-all leak.
+    expect(status).toBe(403);
+    expect(body.success).toBe(false);
+    const error = body.error as { code?: string } | undefined;
+    expect(error?.code).toBe("AUTHZ_DENIED");
+  });
+});

--- a/addons/permission/cap-permission/__tests__/middleware.test.ts
+++ b/addons/permission/cap-permission/__tests__/middleware.test.ts
@@ -272,3 +272,112 @@ describe("permission middleware — meta.evolution target (skipActionSlots dispa
     expect(nextCalled).toBe(true);
   });
 });
+
+/**
+ * Meta-target permission resolution — `meta.onchange` (Spec 64 onchange route).
+ *
+ * The onchange route dispatches with `skipActionSlots: true`, NO `ctx.action`, and
+ * publishes `meta.onchange = { entity, changedField }`. `command-layer.ts`
+ * documents that the permission middleware should derive an entity-level READ
+ * check from this meta (not look up an action named "onchange"). These tests pin
+ * that the middleware HONOURS it: an actor with READ access to the entity is
+ * allowed, one without is denied, and a stray `meta.onchange` on a real action
+ * dispatch is ignored.
+ */
+describe("permission middleware — meta.onchange target (skipActionSlots dispatch)", () => {
+  /** An onchange-shaped dispatch: synthetic command, no action, meta read target. */
+  function onchangeCtx(actor: CommandContext["actor"]): CommandContext {
+    return {
+      command: "invoice.onchange",
+      input: {},
+      channel: "http",
+      actor,
+      meta: { onchange: { entity: "invoice", changedField: "amount" } },
+      // No `action` — non-action dispatch (skipActionSlots).
+    } as CommandContext;
+  }
+
+  /** A registry whose `invoice_reader` group grants READ access to `invoice`. */
+  function registryWithInvoiceRead(): PermissionRegistry {
+    const registry = new PermissionRegistry();
+    registry.register(
+      definePermissionGroup({
+        name: "invoice_reader",
+        label: "Invoice Reader",
+        grant: { invoice: { data: { read: "all" } } },
+      }),
+    );
+    // A group that exists but grants the WRONG entity, to prove default-deny.
+    registry.register(
+      definePermissionGroup({
+        name: "order_reader",
+        label: "Order Reader",
+        grant: { order: { data: { read: "all" } } },
+      }),
+    );
+    return registry;
+  }
+
+  it("authorizes onchange when the actor can READ the entity (grant.invoice.data.read)", async () => {
+    const middleware = createPermissionMiddleware({ registry: registryWithInvoiceRead() });
+    const ctx = onchangeCtx({ type: "human", id: "reader_1", groups: ["invoice_reader"] });
+    let nextCalled = false;
+
+    await middleware(ctx, async () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+  });
+
+  it("denies onchange when the actor has no read access to the entity", async () => {
+    const middleware = createPermissionMiddleware({ registry: registryWithInvoiceRead() });
+    // Has read on `order`, NOT `invoice` → default-deny for the invoice onchange.
+    const ctx = onchangeCtx({ type: "human", id: "reader_2", groups: ["order_reader"] });
+
+    await expect(middleware(ctx, async () => {})).rejects.toThrow(AuthorizationError);
+  });
+
+  it("denies onchange when an explicit data.read: none shadows an allow (deny wins)", async () => {
+    const registry = new PermissionRegistry();
+    registry.register(
+      definePermissionGroup({
+        name: "invoice_reader",
+        grant: { invoice: { data: { read: "all" } } },
+      }),
+    );
+    registry.register(
+      definePermissionGroup({
+        name: "invoice_blocked",
+        grant: { invoice: { data: { read: "none" } } },
+      }),
+    );
+    const middleware = createPermissionMiddleware({ registry });
+    const ctx = onchangeCtx({
+      type: "human",
+      id: "reader_3",
+      groups: ["invoice_reader", "invoice_blocked"],
+    });
+
+    await expect(middleware(ctx, async () => {})).rejects.toThrow(AuthorizationError);
+  });
+
+  it("ignores a stray meta.onchange on a real ACTION dispatch (target stays the action)", async () => {
+    // Defensive: the read-target branch is scoped to non-action dispatches. A real
+    // action carrying meta.onchange must still authorize against its action target.
+    const registry = createTestRegistry();
+    const middleware = createPermissionMiddleware({ registry });
+    const ctx = createTestContext({
+      meta: { onchange: { entity: "invoice", changedField: "amount" } },
+    });
+    let nextCalled = false;
+
+    await middleware(ctx, async () => {
+      nextCalled = true;
+    });
+
+    // `editors` grants the `submit_request` ACTION target — the onchange meta was
+    // ignored because `ctx.action` is present.
+    expect(nextCalled).toBe(true);
+  });
+});

--- a/addons/permission/cap-permission/src/middleware/permission-middleware.ts
+++ b/addons/permission/cap-permission/src/middleware/permission-middleware.ts
@@ -148,15 +148,16 @@ export function createPermissionMiddleware(
     // A `read` meta target (the onchange route, Spec 64) is authorized by
     // entity-level READ data access — NOT an action grant. Decide it up front and
     // return: the actor may run the onchange computation iff it can read the entity
-    // (`grant.<entity>.data.read` resolves to anything other than "none").
+    // (`grant.<entity>.data.read` resolves to anything other than "none"). Honour a
+    // custom `resolveCapability` here too (mirroring the action path) so a legacy
+    // `permissions[capability][entity]` grant whose capability differs from the
+    // entity name still resolves; default to the entity name (the canonical
+    // `grant[entity]` source is capability-agnostic, so it is unaffected either way).
     if (metaTarget?.kind === "read") {
-      const read = resolveDataAccess(
-        registry,
-        actor,
-        metaTarget.capability,
-        metaTarget.entity,
-        "read",
-      );
+      const readCapability = resolveCapability
+        ? resolveCapability(command, ctx)
+        : metaTarget.capability;
+      const read = resolveDataAccess(registry, actor, readCapability, metaTarget.entity, "read");
       if (read === "none") {
         throw new AuthorizationError({
           code: "authz.action.denied",
@@ -164,7 +165,7 @@ export function createPermissionMiddleware(
           requiredGroups: actor.groups.length > 0 ? undefined : ["(any)"],
           details: {
             action: command,
-            capability: metaTarget.capability,
+            capability: readCapability,
             entity: metaTarget.entity,
           },
         });

--- a/addons/permission/cap-permission/src/middleware/permission-middleware.ts
+++ b/addons/permission/cap-permission/src/middleware/permission-middleware.ts
@@ -64,11 +64,15 @@ export interface PermissionMiddlewareOptions {
 /** TTL for permission decision cache entries: 10 minutes (spec §4) */
 const PERM_CACHE_TTL_MS = 10 * 60 * 1000;
 
-/** The permission target (capability + action) a grant is matched against. */
-interface PermissionTarget {
-  capability: string;
-  action: string;
-}
+/**
+ * The authoritative permission target a NON-ACTION dispatch publishes in `ctx.meta`.
+ * Two kinds, matching the two documented conventions:
+ *  - `action` — gate on an action grant (`grant.<capability>.actions.<action>`).
+ *  - `read`   — gate on entity-level READ data access (`grant.<entity>.data.read`).
+ */
+type MetaTarget =
+  | { kind: "action"; capability: string; action: string }
+  | { kind: "read"; capability: string; entity: string };
 
 /**
  * Resolve the authoritative permission target for a NON-ACTION dispatch that
@@ -77,20 +81,27 @@ interface PermissionTarget {
  * `command-layer.ts` documents this contract: a `skipActionSlots` dispatch (the
  * onchange / evolution routes) bypasses the ActionExecutor entirely, so there is
  * no `ctx.action` to derive a target from. Its synthetic `command` name exists
- * only for metrics/tracing — the authoritative target is published in `ctx.meta`
- * (`meta.evolution = { operation }`). Gate on that target so a NATURAL grant
- * (`grant.evolution.actions.<operation>`) authorizes it, instead of the synthetic
- * command name which no group would ever grant (→ silent default-deny / admin-only).
+ * only for metrics/tracing — the authoritative target is published in `ctx.meta`:
+ *  - `meta.evolution = { operation }` → an ACTION grant target. Gate on a natural
+ *    grant (`grant.evolution.actions.<operation>`) instead of the synthetic command
+ *    name no group would ever grant (→ silent default-deny / admin-only).
+ *  - `meta.onchange = { entity }` (Spec 64) → an entity-level READ check. The
+ *    onchange route computes form fields for an entity; authorize it as "may this
+ *    actor READ this entity" (`grant.<entity>.data.read`), NOT as an action.
  *
  * Returns `null` when no recognised meta target is present, leaving the caller on
  * its normal action-based resolution. Only consulted for non-action dispatches
  * (`ctx.action` absent), so a real action's authorization is never affected.
  */
-function resolveMetaTarget(ctx: CommandContext): PermissionTarget | null {
+function resolveMetaTarget(ctx: CommandContext): MetaTarget | null {
   const meta = ctx.meta as Record<string, unknown> | undefined;
   const evolution = meta?.evolution as { operation?: unknown } | undefined;
   if (evolution && typeof evolution.operation === "string" && evolution.operation.length > 0) {
-    return { capability: "evolution", action: evolution.operation };
+    return { kind: "action", capability: "evolution", action: evolution.operation };
+  }
+  const onchange = meta?.onchange as { entity?: unknown } | undefined;
+  if (onchange && typeof onchange.entity === "string" && onchange.entity.length > 0) {
+    return { kind: "read", capability: onchange.entity, entity: onchange.entity };
   }
   return null;
 }
@@ -133,6 +144,36 @@ export function createPermissionMiddleware(
     // contract first; otherwise fall back to the action-based resolution. Scoping
     // the meta lookup to `!action` guarantees a real action's target is unchanged.
     const metaTarget = action ? null : resolveMetaTarget(ctx);
+
+    // A `read` meta target (the onchange route, Spec 64) is authorized by
+    // entity-level READ data access — NOT an action grant. Decide it up front and
+    // return: the actor may run the onchange computation iff it can read the entity
+    // (`grant.<entity>.data.read` resolves to anything other than "none").
+    if (metaTarget?.kind === "read") {
+      const read = resolveDataAccess(
+        registry,
+        actor,
+        metaTarget.capability,
+        metaTarget.entity,
+        "read",
+      );
+      if (read === "none") {
+        throw new AuthorizationError({
+          code: "authz.action.denied",
+          message: `Permission denied: no read access to entity "${metaTarget.entity}"`,
+          requiredGroups: actor.groups.length > 0 ? undefined : ["(any)"],
+          details: {
+            action: command,
+            capability: metaTarget.capability,
+            entity: metaTarget.entity,
+          },
+        });
+      }
+      await next();
+      return;
+    }
+
+    // From here `metaTarget` is an `action` target or null.
     const capabilityName = metaTarget
       ? metaTarget.capability
       : resolveCapability


### PR DESCRIPTION
## Complete the meta-target authorization contract — wire the `meta.onchange` half (companion to #527)

#527 fixed the `meta.evolution` half of a **documented-but-unimplemented** authorization contract. This wires the **`meta.onchange` half** — the identical seam, same root cause.

`command-layer.ts` documents that a `skipActionSlots` dispatch (no `ctx.action`) publishes its authoritative permission target in `ctx.meta`. The onchange route (`POST /api/entities/:name/onchange`, Spec 64) faithfully sets `ctx.meta.onchange = { entity, changedField }` and documents that the middleware should derive an **entity-level READ check** from it. But `cap-permission` ignored it and gated on the synthetic command name `"<entity>.onchange"` — which no group grants → silent **default-deny / admin-only**. Producer fills the meta, consumer ignores it; each had green tests, the integration was dead (same pattern as #527).

### Fix
- **cap-permission:** `resolveMetaTarget` is now a tagged union:
  - `{ kind: "action" }` — evolution (`grant.evolution.actions.<op>`), unchanged from #527.
  - `{ kind: "read" }` — onchange. Authorized by an **entity-level READ data-access check** (`grant.<entity>.data.read` resolves to anything other than `none`; an explicit `none` still wins), decided up front and returned — **not** an action grant.
  - Still scoped to non-action dispatches (`ctx.action` absent), so a real action's target is never affected. **No bypass:** `meta.onchange` is server-set by the route; a forged value can't appear on an action dispatch (those carry `ctx.action` → meta path skipped), and without entity read access it still default-denies.
- **cap-permission unit tests (4):** read grant allows · no-read denies · explicit `data.read: none` shadows an allow (deny wins) · stray `meta.onchange` on a real action dispatch is ignored.
- **adapter-server `onchange-authz-spine.test.ts` (e2e seam closer):** the REAL onchange route through `createServer` behind the REAL cap-permission middleware + a REAL read grant. A reader gets the computed onchange result (`total = 3 * 10`); a stranger gets the canonical `AUTHZ_DENIED` (403). The sibling `onchange-api.test.ts` only ever used a **stub** permission middleware — this is the first proof the real `cap-permission` honours `meta.onchange` end-to-end (producer + consumer agree on the signal).

### Behavior note
This is strictly more correct, not a loosening: actors who legitimately have entity read access (and could already read the entity via GraphQL) can now run its onchange computation; everyone else is denied exactly as before. The `meta.evolution`/`meta.onchange` contract is now fully implemented.

### Verification
- `bun run check` · `bun run typecheck` · full `bun run test` — all green (no regression from the shared-middleware change; existing `onchange-api.test.ts` stub-based tests unaffected).

### Review note
CLI cross-model review unavailable this run (codex usage-limited until Jun 11; gemini CLI `ECONNRESET`). Relying on the PR bots for the external cross-model pass + a self-adversarial review of the read-target branch and `!action` scoping. Please scrutinise the read-access gate semantics.

Completes the meta-target contract surfaced by the #527 spine work. Spec 64 (onchange).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
