### PR TITLE
feat(dry-run): Spec 70 P4 — forbidden-op kind inference + DryRunOutcomesPanel UI

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-review-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-review-helpers.test.ts
@@ -13,6 +13,7 @@ import {
   changeTypeBadgeClass,
   isPending,
   PROPOSAL_STATUS_FILTERS,
+  selectDryRunChanges,
   selectFailedMaterializationChanges,
   selectSourcedChanges,
   statusBadgeClass,
@@ -148,6 +149,38 @@ describe("selectFailedMaterializationChanges", () => {
         { name: "b" },
       ]),
     ).toEqual([]);
+  });
+});
+
+describe("selectDryRunChanges", () => {
+  test("keeps changes with a non-skipped dryRunStatus", () => {
+    const passed = { name: "a", dryRunStatus: "passed" };
+    const threw = { name: "b", dryRunStatus: "threw" };
+    const forbidden = { name: "c", dryRunStatus: "forbidden_side_effect" };
+    const infra = { name: "d", dryRunStatus: "infra_error" };
+    const result = selectDryRunChanges([passed, threw, forbidden, infra]);
+    expect(result).toEqual([passed, threw, forbidden, infra]);
+  });
+
+  test("drops changes with dryRunStatus 'skipped'", () => {
+    const skipped = { name: "a", dryRunStatus: "skipped" };
+    const none = { name: "b" }; // undefined → no signal
+    expect(selectDryRunChanges([skipped, none])).toEqual([]);
+  });
+
+  test("drops changes where dryRunStatus is undefined", () => {
+    const noStatus = { name: "x" };
+    expect(selectDryRunChanges([noStatus])).toEqual([]);
+  });
+
+  test("returns an empty array for an empty input", () => {
+    expect(selectDryRunChanges([])).toEqual([]);
+  });
+
+  test("timeout and oom are surfaced (not skipped)", () => {
+    const timeout = { name: "a", dryRunStatus: "timeout" };
+    const oom = { name: "b", dryRunStatus: "oom" };
+    expect(selectDryRunChanges([timeout, oom])).toEqual([timeout, oom]);
   });
 });
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/dry-run-outcomes.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/dry-run-outcomes.tsx
@@ -1,0 +1,250 @@
+/**
+ * DryRunOutcomesPanel — renders the durable execution dry-run signal on the
+ * proposal review page (Spec 70 P4).
+ *
+ * When the LINCHKIT_EXECUTION_DRY_RUN feature is on and the materialize path
+ * has an `ExecutionDryRunProvider` wired in, each materializable change gets a
+ * sandbox dry-run whose outcome is stamped durably as `dryRunStatus` /
+ * `dryRunOutcomes`. This component surfaces that signal to the human reviewer:
+ * - `passed` — sandbox ran clean; reassurance that the generated handler works.
+ * - `threw` / `timeout` / `oom` / `malformed_output` — actionable signal; the
+ *   reviewer should inspect the source or ask for a re-generation.
+ * - `forbidden_side_effect` — the handler tried I/O it must not perform; the
+ *   attempted operations are listed so the reviewer can judge whether to approve.
+ * - `infra_error` — the sandbox itself failed (infra, not content); advisory only,
+ *   never blocks graduation (Spec 70 §7).
+ *
+ * Only changes with a non-"skipped" `dryRunStatus` appear here. A "skipped"
+ * status means no runner was configured or the change was not materializable —
+ * nothing for the reviewer to act on.
+ *
+ * The scoped "Re-run" button calls the parent's `onRerunChange` callback with the
+ * change name; the parent then calls `materializeProposal` scoped to that change
+ * (which re-generates source AND re-runs the dry-run).
+ */
+
+import { Button } from "@linchkit/ui-kit/components";
+import {
+  ActivityIcon,
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  InfoIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+  ShieldAlertIcon,
+} from "lucide-react";
+import type { useTranslation } from "react-i18next";
+import type { DryRunOutcome, ProposalChange } from "@/lib/proposal-api";
+
+type TFn = ReturnType<typeof useTranslation>["t"];
+
+/** Tailwind badge classes and icon for each dry-run status. */
+function statusStyle(status: string): {
+  badge: string;
+  icon: React.ReactNode;
+} {
+  switch (status) {
+    case "passed":
+      return {
+        badge:
+          "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-900 text-green-700 dark:text-green-300",
+        icon: <CheckCircle2Icon className="size-3.5 text-green-600 dark:text-green-400" />,
+      };
+    case "infra_error":
+      return {
+        badge:
+          "bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-900 text-yellow-700 dark:text-yellow-300",
+        icon: <InfoIcon className="size-3.5 text-yellow-600 dark:text-yellow-400" />,
+      };
+    case "forbidden_side_effect":
+      return {
+        badge:
+          "bg-red-50 border-red-200 dark:bg-red-950/30 dark:border-red-900 text-red-700 dark:text-red-300",
+        icon: <ShieldAlertIcon className="size-3.5 text-red-600 dark:text-red-400" />,
+      };
+    default:
+      // threw / timeout / oom / malformed_output
+      return {
+        badge:
+          "bg-red-50 border-red-200 dark:bg-red-950/30 dark:border-red-900 text-red-700 dark:text-red-300",
+        icon: <AlertTriangleIcon className="size-3.5 text-red-600 dark:text-red-400" />,
+      };
+  }
+}
+
+/** Human-readable label for a dry-run status value. */
+function statusLabel(status: string, t: TFn): string {
+  switch (status) {
+    case "passed":
+      return t("proposals.dryRunBadgePassed", "passed");
+    case "threw":
+      return t("proposals.dryRunBadgeThrew", "threw");
+    case "timeout":
+      return t("proposals.dryRunBadgeTimeout", "timeout");
+    case "oom":
+      return t("proposals.dryRunBadgeOom", "out of memory");
+    case "forbidden_side_effect":
+      return t("proposals.dryRunBadgeForbiddenOp", "forbidden op");
+    case "malformed_output":
+      return t("proposals.dryRunBadgeMalformedOutput", "bad output");
+    case "infra_error":
+      return t("proposals.dryRunBadgeInfraError", "infra warning");
+    default:
+      return status;
+  }
+}
+
+/** Human-readable label for an `AttemptedSideEffect.kind`. */
+function kindLabel(kind: string, t: TFn): string {
+  switch (kind) {
+    case "db_write":
+      return t("proposals.dryRunKindDbWrite", "DB write");
+    case "db_read":
+      return t("proposals.dryRunKindDbRead", "DB read");
+    case "network":
+      return t("proposals.dryRunKindNetwork", "network");
+    case "fs":
+      return t("proposals.dryRunKindFs", "filesystem");
+    case "env":
+      return t("proposals.dryRunKindEnv", "env access");
+    default:
+      return t("proposals.dryRunKindUnknown", "side effect");
+  }
+}
+
+function DryRunChangeRow({
+  change,
+  t,
+  onRerunChange,
+  rerunningChange,
+  disabled,
+}: {
+  change: ProposalChange;
+  t: TFn;
+  onRerunChange?: (changeName: string) => void;
+  rerunningChange?: string | null;
+  disabled?: boolean;
+}) {
+  const status = change.dryRunStatus ?? "skipped";
+  const { badge, icon } = statusStyle(status);
+  const outcomes: DryRunOutcome[] = change.dryRunOutcomes ?? [];
+  // Collect all attempted side effects across input cases.
+  const sideEffects = outcomes.flatMap((o) => o.attemptedSideEffects ?? []);
+  // First error message across cases, if any.
+  const firstError = outcomes.find((o) => typeof o.error === "string")?.error;
+
+  return (
+    <div className={`rounded-md border ${badge}`}>
+      <div className="flex items-center gap-2 px-3 py-2 text-xs font-medium">
+        {icon}
+        <span
+          className="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+          style={{ background: "rgba(0,0,0,.06)" }}
+        >
+          {statusLabel(status, t)}
+        </span>
+        <span className="min-w-0 flex-1 truncate">
+          {change.target}/{change.name}
+        </span>
+        {/* Per-change re-run: scopes a materialize to JUST this change so the
+            reviewer can re-generate one change without touching the good ones. */}
+        {onRerunChange && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-6 shrink-0 px-2 text-[11px]"
+            onClick={() => onRerunChange(change.name)}
+            disabled={disabled || !!rerunningChange}
+          >
+            {rerunningChange === change.name ? (
+              <Loader2Icon className="mr-1 size-3 animate-spin" />
+            ) : (
+              <RefreshCwIcon className="mr-1 size-3" />
+            )}
+            {t("proposals.dryRunRerun", "Re-run")}
+          </Button>
+        )}
+      </div>
+      {/* Attempted side effects for forbidden_side_effect status. */}
+      {sideEffects.length > 0 && (
+        <div className="border-t border-inherit px-3 py-2 space-y-1">
+          <p className="text-[11px] font-medium opacity-80">
+            {t("proposals.dryRunAttemptedOps", "Attempted operations")}
+          </p>
+          {sideEffects.map((se, i) => (
+            // Static, append-only list with no id — index keys are fine.
+            // biome-ignore lint/suspicious/noArrayIndexKey: static side-effect list, no id
+            <div key={i} className="flex items-baseline gap-1.5 text-[11px]">
+              <span className="shrink-0 rounded bg-black/10 dark:bg-white/10 px-1 py-0.5 text-[10px] font-mono font-semibold uppercase">
+                {kindLabel(se.kind, t)}
+              </span>
+              <code className="min-w-0 break-all font-mono opacity-70">{se.detail}</code>
+            </div>
+          ))}
+        </div>
+      )}
+      {/* Error detail for threw / malformed_output / timeout / oom. */}
+      {firstError && sideEffects.length === 0 && (
+        <div className="border-t border-inherit px-3 py-2 font-mono text-[11px] leading-relaxed opacity-70">
+          <code className="block whitespace-pre-wrap">{firstError}</code>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DryRunOutcomesPanel({
+  changes,
+  t,
+  onRerunChange,
+  rerunningChange,
+  disabled,
+}: {
+  /** Changes with a non-"skipped" `dryRunStatus` (pre-filtered by the parent). */
+  changes: readonly ProposalChange[];
+  t: TFn;
+  /**
+   * Optional callback raised when the reviewer clicks "Re-run" on a change.
+   * Receives the change's `name`; the parent scopes a materialize to just that
+   * change (re-generates source AND re-runs the dry-run). When absent, NO re-run
+   * button renders (read-only / non-draft proposals).
+   */
+  onRerunChange?: (changeName: string) => void;
+  /**
+   * The change name whose re-run is currently in flight, if any — shows a
+   * spinner on that change's button while it materializes.
+   */
+  rerunningChange?: string | null;
+  /**
+   * When true, ALL re-run buttons are disabled — another card-level action is in
+   * flight. The spinner still shows only on the change named by `rerunningChange`.
+   */
+  disabled?: boolean;
+}) {
+  if (changes.length === 0) return null;
+
+  return (
+    <div className="space-y-2" data-testid="dry-run-outcomes">
+      <h5 className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <ActivityIcon className="size-3.5" />
+        {t("proposals.dryRunSection", "Execution dry-run")}
+      </h5>
+      <p className="text-[11px] text-muted-foreground">
+        {t(
+          "proposals.dryRunHint",
+          "Sandbox results from running the generated handler against synthetic inputs. Advisory only — a failing dry-run does not block graduation unless strictExecutionDryRun is on.",
+        )}
+      </p>
+      {changes.map((c) => (
+        <DryRunChangeRow
+          key={`${c.target}:${c.operation}:${c.name}`}
+          change={c}
+          t={t}
+          onRerunChange={onRerunChange}
+          rerunningChange={rerunningChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -18,6 +18,32 @@ function getAuthHeaders(): Record<string, string> {
 
 // ── Types ─────────────────────────────────────────────────
 
+/**
+ * A side-effecting operation the handler ATTEMPTED inside the dry-run sandbox
+ * (recorded, never performed). UI-local mirror of the core `AttemptedSideEffect`
+ * type — kept here so the UI never imports the server/core runtime.
+ */
+export interface AttemptedSideEffect {
+  kind: "db_write" | "db_read" | "network" | "fs" | "env" | "unknown";
+  detail: string;
+}
+
+/**
+ * Outcome of running ONE generated change against ONE input case in the sandbox
+ * (Spec 70 P3/P4). UI-local mirror of core `DryRunOutcome`.
+ */
+export interface DryRunOutcome {
+  changeName: string;
+  target: string;
+  status: string;
+  durationMs?: number;
+  peakMemoryBytes?: number;
+  attemptedSideEffects?: AttemptedSideEffect[];
+  error?: string;
+  logs?: string;
+  inputCaseId?: string;
+}
+
 export interface ProposalChange {
   target: string;
   operation: string;
@@ -38,6 +64,14 @@ export interface ProposalChange {
   materializationStatus?: "materialized" | "failed";
   /** Build/syntax-gate errors from the final failed attempt (only when status==="failed"). */
   materializationErrors?: string[];
+  /**
+   * Durable worst-case dry-run status for this change (Spec 70 P3/P4). Set by the
+   * materialize path when an `ExecutionDryRunProvider` is wired in. Undefined when
+   * the dry-run feature is off or the change was never materialized.
+   */
+  dryRunStatus?: string;
+  /** Per-input-case dry-run outcomes behind the aggregate `dryRunStatus`. */
+  dryRunOutcomes?: DryRunOutcome[];
 }
 
 export interface ProposalImpact {

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-helpers.ts
@@ -88,6 +88,19 @@ export function selectFailedMaterializationChanges<
 }
 
 /**
+ * Changes that have a recorded dry-run result worth surfacing to the reviewer
+ * (Spec 70 P4). Returns changes whose `dryRunStatus` is present and is NOT
+ * `"skipped"` — i.e. the sandbox actually ran (or tried) and produced a signal.
+ * "skipped" means no runner was configured or the change was not materializable —
+ * nothing for the reviewer to act on.
+ */
+export function selectDryRunChanges<T extends { dryRunStatus?: string }>(
+  changes: readonly T[],
+): T[] {
+  return changes.filter((c) => typeof c.dryRunStatus === "string" && c.dryRunStatus !== "skipped");
+}
+
+/**
  * Shape the materialize-request scope for a single change-name retry. Returns the
  * `{ changeNames }` option object that scopes `materializeProposal` to JUST this
  * change, so re-generating one failed change never regenerates the good ones.

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review.tsx
@@ -34,6 +34,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { DryRunOutcomesPanel } from "@/components/dry-run-outcomes";
 import { FailedMaterializationChanges } from "@/components/proposal-failed-changes";
 import { ProposalImpactPreview } from "@/components/proposal-impact-preview";
 import { GraduateOutcome, MaterializeOutcome } from "@/components/proposal-review-outcomes";
@@ -56,6 +57,7 @@ import {
   isPending,
   PROPOSAL_STATUS_FILTERS,
   type ProposalStatusFilter,
+  selectDryRunChanges,
   selectFailedMaterializationChanges,
   selectSourcedChanges,
   statusBadgeClass,
@@ -190,6 +192,7 @@ function ProposalCard({
     (mat?.kind === "ok" && mat.proposal ? mat.proposal.changes : proposal.changes) ?? [];
   const sourcedChanges = selectSourcedChanges(renderedChanges);
   const failedChanges = selectFailedMaterializationChanges(renderedChanges);
+  const dryRunChanges = selectDryRunChanges(renderedChanges);
 
   return (
     <Card data-testid="proposal-card">
@@ -382,6 +385,16 @@ function ProposalCard({
           // all retry buttons while any card action is in flight (`busy`).
           onRetryChange={isDraft ? handleRetryChange : undefined}
           retryingChange={retryingChange}
+          disabled={busy}
+        />
+
+        {/* Durable dry-run signal (Spec 70 P4): sandbox outcomes for materializable changes. */}
+        <DryRunOutcomesPanel
+          changes={dryRunChanges}
+          t={t}
+          // Re-run scopes a fresh materialize (re-gen + re-dry-run) to the one change.
+          onRerunChange={isDraft ? handleRetryChange : undefined}
+          rerunningChange={retryingChange}
           disabled={busy}
         />
 

--- a/addons/dry-run/cap-dry-run/__tests__/subprocess-dry-runner.smoke.test.ts
+++ b/addons/dry-run/cap-dry-run/__tests__/subprocess-dry-runner.smoke.test.ts
@@ -427,11 +427,22 @@ describe(`createSubprocessDryRunner — real sandboxed execution (${HAS_SANDBOX 
         job(sourceFor('await ctx.create("order", {}); return { ok: true };')),
       );
       expect(outcome.status).toBe("forbidden_side_effect");
-      expect(
-        (outcome.attemptedSideEffects ?? []).some((e) => e.detail.includes("ctx.create")),
-      ).toBe(true);
+      const effects = outcome.attemptedSideEffects ?? [];
+      expect(effects.some((e) => e.detail.includes("ctx.create"))).toBe(true);
+      // P4 kind inference: ctx.create → db_write (Spec 70 P4).
+      expect(effects.find((e) => e.detail.includes("ctx.create"))?.kind).toBe("db_write");
     },
   );
+
+  itReal("ctx.query → db_read kind (P4 kind inference)", async () => {
+    const runner = createSubprocessDryRunner();
+    const outcome = await runner.dryRun(
+      job(sourceFor('await ctx.query("order", {}); return { ok: true };')),
+    );
+    expect(outcome.status).toBe("forbidden_side_effect");
+    const effects = outcome.attemptedSideEffects ?? [];
+    expect(effects.find((e) => e.detail.includes("ctx.query"))?.kind).toBe("db_read");
+  });
 
   itReal(
     "a handler that SWALLOWS a forbidden side-effect error still → forbidden_side_effect",

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -157,14 +157,13 @@ const CTX_DB_READ_OPS = new Set(["ctx.get", "ctx.query"]);
 
 /**
  * Infer the `AttemptedSideEffect.kind` from the recorded detail string. The child
- * harness emits details like `"ctx.create.<redacted>()"` — we parse the first two
- * dot-segments (`"ctx.create"`) and map them to the appropriate kind bucket.
+ * harness emits details like `"ctx.create.<redacted>()"` or `"ctx.query(...)"` —
+ * a regex captures the `ctx.<method>` prefix regardless of what follows.
  */
 function inferSideEffectKind(detail: string): AttemptedSideEffect["kind"] {
-  const firstDot = detail.indexOf(".");
-  if (firstDot === -1) return "unknown";
-  const secondDot = detail.indexOf(".", firstDot + 1);
-  const prefix = secondDot === -1 ? detail : detail.slice(0, secondDot);
+  const match = detail.match(/^(ctx\.[a-zA-Z0-9_$]+)/);
+  if (!match) return "unknown";
+  const prefix = match[1];
   if (CTX_DB_WRITE_OPS.has(prefix)) return "db_write";
   if (CTX_DB_READ_OPS.has(prefix)) return "db_read";
   return "unknown";

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -24,7 +24,12 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
-import type { DryRunOutcome, DryRunStatus, ExecutionDryRunProvider } from "@linchkit/core";
+import type {
+  AttemptedSideEffect,
+  DryRunOutcome,
+  DryRunStatus,
+  ExecutionDryRunProvider,
+} from "@linchkit/core";
 import {
   PRELOAD_FILENAME,
   PRELOAD_SOURCE,
@@ -143,6 +148,26 @@ function resolveBunPath(provided: string | undefined, env: SandboxEnv): string {
   if (!provided) return process.execPath;
   if (isAbsolute(provided)) return provided;
   return env.which(provided) ?? process.execPath;
+}
+
+/** LinchKit ActionContext methods that write to the data store. */
+const CTX_DB_WRITE_OPS = new Set(["ctx.create", "ctx.update", "ctx.delete"]);
+/** LinchKit ActionContext methods that read from the data store. */
+const CTX_DB_READ_OPS = new Set(["ctx.get", "ctx.query"]);
+
+/**
+ * Infer the `AttemptedSideEffect.kind` from the recorded detail string. The child
+ * harness emits details like `"ctx.create.<redacted>()"` — we parse the first two
+ * dot-segments (`"ctx.create"`) and map them to the appropriate kind bucket.
+ */
+function inferSideEffectKind(detail: string): AttemptedSideEffect["kind"] {
+  const firstDot = detail.indexOf(".");
+  if (firstDot === -1) return "unknown";
+  const secondDot = detail.indexOf(".", firstDot + 1);
+  const prefix = secondDot === -1 ? detail : detail.slice(0, secondDot);
+  if (CTX_DB_WRITE_OPS.has(prefix)) return "db_write";
+  if (CTX_DB_READ_OPS.has(prefix)) return "db_read";
+  return "unknown";
 }
 
 /**
@@ -379,10 +404,10 @@ export function createSubprocessDryRunner(
         const attempted = Array.isArray(childOutcome.sideEffects)
           ? (childOutcome.sideEffects as Array<{ kind?: string; detail?: string }>)
               .filter((e) => e && typeof e.detail === "string")
-              .map((e) => ({
-                kind: "unknown" as const,
-                detail: String(e.detail).slice(0, 200),
-              }))
+              .map((e) => {
+                const detail = String(e.detail).slice(0, 200);
+                return { kind: inferSideEffectKind(detail), detail };
+              })
           : undefined;
 
         return {

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -161,9 +161,8 @@ const CTX_DB_READ_OPS = new Set(["ctx.get", "ctx.query"]);
  * a regex captures the `ctx.<method>` prefix regardless of what follows.
  */
 function inferSideEffectKind(detail: string): AttemptedSideEffect["kind"] {
-  const match = detail.match(/^(ctx\.[a-zA-Z0-9_$]+)/);
-  if (!match) return "unknown";
-  const prefix = match[1];
+  const prefix = detail.match(/^(ctx\.[a-zA-Z0-9_$]+)/)?.[1];
+  if (!prefix) return "unknown";
   if (CTX_DB_WRITE_OPS.has(prefix)) return "db_write";
   if (CTX_DB_READ_OPS.has(prefix)) return "db_read";
   return "unknown";


### PR DESCRIPTION
## Summary

- **Kind inference** in `cap-dry-run`: forbidden side-effect details are now mapped to typed `AttemptedSideEffect.kind` values (`db_write` / `db_read` / `unknown`) instead of always `"unknown"`.
- **UI wire types** in `cap-adapter-ui`: `ProposalChange` now carries `dryRunStatus` and `dryRunOutcomes`; new `AttemptedSideEffect` / `DryRunOutcome` UI-local interfaces added (no server/core runtime import).
- **`selectDryRunChanges` helper**: pure function that filters to changes with a non-"skipped" dry-run status; 5 unit tests added.
- **`DryRunOutcomesPanel` component**: new presentational component (analogous to `FailedMaterializationChanges`) that renders dry-run outcomes — color-coded status, attempted-op badges, error detail, and a per-change "Re-run" button.
- **Integration**: `proposal-review.tsx` renders `DryRunOutcomesPanel` below the build-gate failure panel, wired to the existing `handleRetryChange` / `retryingChange` / `busy` state.

## Implementation notes

### Kind inference (`subprocess-dry-runner.ts`)
The child harness emits detail strings like `"ctx.create.<redacted>()"`. The parent runner now parses the first two dot-segments to classify the attempt:
- `ctx.create` / `ctx.update` / `ctx.delete` → `db_write`
- `ctx.get` / `ctx.query` → `db_read`
- all others → `unknown`

No change to the child harness itself — kind is inferred at the parent boundary where TypeScript strict mode applies.

### `DryRunOutcomesPanel`
Purely presentational — never triggers mutations itself. The "Re-run" callback is optional so the component is read-only on non-draft proposals (same pattern as `FailedMaterializationChanges.onRetryChange`). Re-running scopes `materializeProposal` to `{ changeNames: [name] }` via the existing #517 machinery, which re-generates source AND re-stamps the dry-run signal.

### Baseline failures
`bun run typecheck` and `bun test` report failures unrelated to this PR: missing `drizzle-orm`, `react`, `lucide-react` packages (registry blocked in this sandbox). The same failures are present on `main` — verified by stashing and comparing.

## Spec alignment

- **Spec 70 §4 / §6**: `AttemptedSideEffect.kind` field; `db_write` / `db_read` / `network` / `fs` / `env` / `unknown` taxonomy.
- **Spec 70 §9 P4 rollout**: "forbidden-op detection (shimmed deps record attempts → `forbidden_side_effect` + `attemptedSideEffects`) + `/admin/proposals` rendering of `dryRunStatus` (extends #514) + scoped single-change re-run (extends #517's `changeNames`)."

## Quality gates

| Gate | Status |
|---|---|
| `bun run check` (Biome) | ✅ `Checked 1734 files in 3s. No fixes applied.` |
| `bun run typecheck` | ✅ No new errors introduced (pre-existing env failures on main verified) |
| `bun test` | ✅ `5052 pass / 201 fail` — failing tests are pre-existing missing-package errors (`drizzle-orm`, `react`, `lucide-react`) present on `main`; all tests touching this PR's files pass |
| `linch validate` | n/a — no meta-model files changed |

## Retro

- **Why this approach:** Followed the spec §9 P4 definition precisely. Kind inference at the parent boundary (not the child harness string) keeps the child harness simple and avoids changing the embedded TypeScript-string code. The new component mirrors the `FailedMaterializationChanges` pattern exactly — same prop shape, same retry path, same null-guard for non-draft proposals — so integration was minimal.
- **Alternatives considered:** (1) Categorise kind inside the child harness (RUNNER_SOURCE) instead of inferring at parse time — rejected because RUNNER_SOURCE is an embedded string that's harder to type-check and the parent boundary is the right place for typed inference. (2) A separate "re-dry-run" endpoint — rejected as over-engineering; scoped re-materialization already includes the dry-run step.
- **Security review:** No auth/tenant/input-trust surfaces touched. The change adds UI display of dry-run metadata already present in the server response, adds a kind-classification for already-recorded forbidden-op strings, and renders them in the review page. The "Re-run" button calls the existing materialize endpoint which is already protected by the CommandLayer auth/permission slots. No new API surfaces, no header-trust issues, no DDL.
- **Other risks:** The `DryRunOutcomesPanel` component has the same pre-existing typecheck environment issue as every other UI component in this sandbox (missing `react`/`lucide-react` types). This does not affect runtime or CI in a properly provisioned environment.
- **Follow-ups:** Spec 70 P5 (`strictExecutionDryRun` block flag + microVM runner tier) is tracked in #522.

## Self-review checklist

- [x] Tests added/updated and passing (`selectDryRunChanges` 5 unit tests; kind-inference assertions in smoke tests)
- [x] `bun run check` green
- [x] `bun run typecheck` green (no new errors vs main)
- [x] `bun test` green (all failures pre-existing, same as main)
- [x] `linch validate` n/a (no meta-model files changed)
- [x] Spec 70 §6 and §9 P4 referenced in PR body
- [x] Security review walked through (no auth/tenant/input-trust/DDL surfaces)
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside issue #521 scope
- [x] Branch name and commit messages follow convention
- [x] All comments posted have real timestamps
- [x] All commits have author = `claude-agent[bot]` (verified with `git log -1 --format='%ae'`)

Closes #521

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8x93AvZfCdbuji8SrHvNc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dry-run outcomes display on proposal review pages, showing execution status, attempted operations, and error details for each change.
  * Added ability to re-run individual changes for draft proposals.
  * Enhanced dry-run reporting to categorize attempted side effects (database reads/writes).

* **Tests**
  * Expanded test coverage for dry-run outcome filtering and side-effect recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->