### PR TITLE
feat(core,adapter-server): strictExecutionDryRun opt-in flag — Phase 5 warn→block gate (Spec 70 P5a)

### DIFF
--- a/.changeset/strict-execution-dry-run-flag.md
+++ b/.changeset/strict-execution-dry-run-flag.md
@@ -1,0 +1,21 @@
+---
+"@linchkit/core": patch
+"@linchkit/cap-adapter-server": patch
+---
+
+feat(core,adapter-server): `strictExecutionDryRun` feature flag — opt-in gate that escalates execution dry-run findings from warnings to blocking validation errors (Spec 70 P5a, #522)
+
+`EnvironmentFeatureFlags.strictExecutionDryRun` exposes the existing Phase 5
+warn→block escalation as a configurable flag. Unlike `strictCompatibility` /
+`strictGeneratedContract` it is **opt-in everywhere — NOT derived from
+`isProduction`**: the dry-run depends on external sandbox infrastructure, so
+auto-blocking in prod on an un-configured or flaky sandbox would wedge
+graduation. It defaults to `false` in every environment and flips on only via
+the explicit `LINCHKIT_STRICT_EXECUTION_DRY_RUN=1` override (mirroring the
+materialize-path `LINCHKIT_EXECUTION_DRY_RUN=1` opt-in), once an operator has
+confirmed the sandbox is healthy. Infra failures (`infra_error`) remain
+warnings regardless of the flag.
+
+adapter-server threads the flag from `detectEnvironment().features` into the
+proposal-validation context next to the other strict flags, so submit-time
+Phase 5 honors it end-to-end.

--- a/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
@@ -188,6 +188,15 @@ export interface MountProposalAPIOptions {
    * prod/staging). Lock-step sibling of `strictCompatibility`.
    */
   strictGeneratedContract?: boolean;
+  /**
+   * Escalate Phase 5 execution dry-run CONTENT findings (Spec 70 §7) from WARN
+   * to BLOCK. Sourced from `detectEnvironment().features.strictExecutionDryRun`,
+   * which — unlike the two strict siblings above — is opt-in EVERYWHERE (never
+   * derived from `isProduction`): enabled only via
+   * `LINCHKIT_STRICT_EXECUTION_DRY_RUN=1` once the sandbox is confirmed healthy.
+   * Infra failures (`infra_error`) always stay warnings regardless of this flag.
+   */
+  strictExecutionDryRun?: boolean;
 }
 
 /**
@@ -212,14 +221,17 @@ export function mountProposalAPI(
     : (options ?? {});
   const executionLogger = opts.executionLogger;
 
-  // ValidationContext threaded into both submit sites so Phase 3 (compatibility)
-  // and Phase 4 (generated-source contract) can run. Built once; when ontology is
-  // absent Phase 3 returns "skipped" and when no change carries generated source
-  // Phase 4 returns "skipped" (both unchanged for existing callers).
+  // ValidationContext threaded into both submit sites so Phase 3 (compatibility),
+  // Phase 4 (generated-source contract) and Phase 5 (execution dry-run) can run.
+  // Built once; when ontology is absent Phase 3 returns "skipped", when no change
+  // carries generated source Phase 4 returns "skipped", and when no change carries
+  // a durable `dryRunStatus` Phase 5 returns "skipped" (all unchanged for existing
+  // callers).
   const validationContext: ValidationContext = {
     ontology: opts.ontology,
     strictCompatibility: opts.strictCompatibility,
     strictGeneratedContract: opts.strictGeneratedContract,
+    strictExecutionDryRun: opts.strictExecutionDryRun,
   };
 
   // Run initial pattern scan in background if execution logger is available

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -461,11 +461,14 @@ export function createServer(
   // detect breaking references (Phase 3, Spec 09 §4.5) and gate generated-source
   // contract findings (Phase 4, G5). strictCompatibility / strictGeneratedContract
   // block such proposals in prod/staging; dev/test stay warn-only.
+  // strictExecutionDryRun (Phase 5, Spec 70) is opt-in everywhere — it blocks
+  // only when LINCHKIT_STRICT_EXECUTION_DRY_RUN=1 is set explicitly.
   mountProposalAPI(app, {
     executionLogger,
     ontology: opts.ontologyRegistry,
     strictCompatibility: environment.features.strictCompatibility,
     strictGeneratedContract: environment.features.strictGeneratedContract,
+    strictExecutionDryRun: environment.features.strictExecutionDryRun,
   });
   // Manual, admin-triggered graduation: POST /api/proposals/:id/graduate writes
   // an approved proposal to disk and opens a PR (Spec 55 §7.6/§7.7). It NEVER

--- a/packages/core/__tests__/deployment.strict-execution-dry-run.test.ts
+++ b/packages/core/__tests__/deployment.strict-execution-dry-run.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Environment gating for the Phase 5 execution dry-run check (Spec 70 §7).
+ *
+ * `strictExecutionDryRun` controls whether Phase 5 execution dry-run CONTENT
+ * findings block proposal validation (vs warn-only). Unlike its strict
+ * siblings (`strictCompatibility` / `strictGeneratedContract`) it is OPT-IN
+ * EVERYWHERE — never derived from `isProduction` — because the dry-run depends
+ * on external sandbox infrastructure: auto-blocking in prod on an
+ * un-configured or flaky sandbox would wedge graduation. It flips on ONLY via
+ * the explicit `LINCHKIT_STRICT_EXECUTION_DRY_RUN=1` override.
+ *
+ * Kept in a focused module so the broad `deployment.test.ts` stays under the
+ * file-size policy (mirrors deployment.strict-generated-contract.test.ts).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { detectEnvironment } from "../src/deployment";
+
+const ENV_VAR = "LINCHKIT_STRICT_EXECUTION_DRY_RUN";
+
+describe("detectEnvironment — strictExecutionDryRun", () => {
+  let savedValue: string | undefined;
+
+  beforeEach(() => {
+    savedValue = process.env[ENV_VAR];
+    delete process.env[ENV_VAR];
+  });
+
+  afterEach(() => {
+    if (savedValue === undefined) {
+      delete process.env[ENV_VAR];
+    } else {
+      process.env[ENV_VAR] = savedValue;
+    }
+  });
+
+  it("defaults to false in development", () => {
+    const config = detectEnvironment("development");
+    expect(config.features.strictExecutionDryRun).toBe(false);
+  });
+
+  it("defaults to false in test", () => {
+    const config = detectEnvironment("test");
+    expect(config.features.strictExecutionDryRun).toBe(false);
+  });
+
+  it("defaults to false in PRODUCTION (opt-in everywhere — NOT derived from isProduction)", () => {
+    const config = detectEnvironment("production");
+    expect(config.isProduction).toBe(true);
+    expect(config.features.strictExecutionDryRun).toBe(false);
+    // Explicitly diverges from the prod-derived strict siblings.
+    expect(config.features.strictCompatibility).toBe(true);
+    expect(config.features.strictGeneratedContract).toBe(true);
+  });
+
+  it("defaults to false in staging (production-like)", () => {
+    const config = detectEnvironment("staging");
+    expect(config.isProduction).toBe(true);
+    expect(config.features.strictExecutionDryRun).toBe(false);
+  });
+
+  it("LINCHKIT_STRICT_EXECUTION_DRY_RUN=1 opts in (any environment)", () => {
+    process.env[ENV_VAR] = "1";
+    expect(detectEnvironment("development").features.strictExecutionDryRun).toBe(true);
+    expect(detectEnvironment("production").features.strictExecutionDryRun).toBe(true);
+  });
+
+  it('ignores non-"1" values (strict opt-in, fail-safe to warn-only)', () => {
+    process.env[ENV_VAR] = "true";
+    expect(detectEnvironment("production").features.strictExecutionDryRun).toBe(false);
+    process.env[ENV_VAR] = "0";
+    expect(detectEnvironment("production").features.strictExecutionDryRun).toBe(false);
+    process.env[ENV_VAR] = "";
+    expect(detectEnvironment("production").features.strictExecutionDryRun).toBe(false);
+  });
+});

--- a/packages/core/src/deployment/environment.ts
+++ b/packages/core/src/deployment/environment.ts
@@ -30,6 +30,16 @@ export interface EnvironmentFeatureFlags {
    * candidate code.
    */
   strictGeneratedContract: boolean;
+  /**
+   * Escalate proposal-validation Phase 5 execution dry-run CONTENT findings
+   * (Spec 70 §7) from WARN to BLOCK. Unlike its strict siblings this flag is
+   * **opt-in everywhere — NOT derived from `isProduction`**: the dry-run depends
+   * on external sandbox infrastructure, and auto-blocking in prod on an
+   * un-configured or flaky sandbox would wedge graduation. Default `false` in
+   * EVERY environment; enable explicitly via `LINCHKIT_STRICT_EXECUTION_DRY_RUN=1`
+   * only after an operator has confirmed the sandbox is healthy.
+   */
+  strictExecutionDryRun: boolean;
   /** Enable detailed error messages in responses (default: true in dev/test) */
   detailedErrors: boolean;
   /** Enable hot-reload / watch mode (default: true in dev) */
@@ -92,6 +102,17 @@ function normalizeEnvName(raw: string): EnvironmentName {
   }
 }
 
+/**
+ * Resolve the opt-in Phase 5 strict gate from the environment.
+ *
+ * Mirrors the materialize-path opt-in (`LINCHKIT_EXECUTION_DRY_RUN=1`): the
+ * strict gate is enabled ONLY when `LINCHKIT_STRICT_EXECUTION_DRY_RUN === "1"`,
+ * regardless of the detected environment (see `strictExecutionDryRun` doc).
+ */
+function resolveStrictExecutionDryRun(): boolean {
+  return process.env.LINCHKIT_STRICT_EXECUTION_DRY_RUN === "1";
+}
+
 /** Build full config with feature flags for a given environment */
 function buildConfig(name: EnvironmentName): EnvironmentConfig {
   const isProduction = name === "production" || name === "staging";
@@ -108,6 +129,8 @@ function buildConfig(name: EnvironmentName): EnvironmentConfig {
       strictValidation: isProduction,
       strictCompatibility: isProduction,
       strictGeneratedContract: isProduction,
+      // Opt-in everywhere (Spec 70 §7) — never derived from isProduction.
+      strictExecutionDryRun: resolveStrictExecutionDryRun(),
       detailedErrors: isDevelopment || isTest,
       hotReload: isDevelopment,
       requestLogging: isDevelopment,


### PR DESCRIPTION
## Summary

Part 1 of #522 (Spec 70 P5). Exposes the existing `validatePhase5` warn→block escalation as a configurable feature flag — until now the gate logic existed in core but **no configuration surface could turn it on**.

- **`EnvironmentFeatureFlags.strictExecutionDryRun`** (`packages/core/src/deployment/environment.ts`): escalates Phase 5 execution dry-run CONTENT findings from WARN to BLOCK. Per Spec 70 §7/§9 it is **opt-in everywhere — NOT derived from `isProduction`** (unlike `strictCompatibility` / `strictGeneratedContract`): the dry-run depends on external sandbox infrastructure, and auto-blocking prod graduation on an un-configured or flaky sandbox would wedge it. Defaults `false` in every environment; flips on only via `LINCHKIT_STRICT_EXECUTION_DRY_RUN=1` (mirrors the materialize-path `LINCHKIT_EXECUTION_DRY_RUN=1` opt-in precedent).
- **adapter-server wiring**: `server.ts` threads `environment.features.strictExecutionDryRun` into `mountProposalAPI` next to the other two strict flags; `proposal-api.ts` adds it to `MountProposalAPIOptions` and the submit-time `ValidationContext`, so Phase 5 honors it end-to-end.
- `infra_error` findings remain warnings regardless of the flag (sandbox infrastructure failure must never block graduation).

## Call-site audit

`proposal-api.ts` is the only site building a proposal `ValidationContext` from `environment.features` (repo-wide grep). CLI `exec.ts` / `dev-wiring.ts` / `runtime-context.ts` consume only `strictValidation` for ActionExecutor input validation and don't wire the other strict siblings either — left consistent.

## Tests

- New `packages/core/__tests__/deployment.strict-execution-dry-run.test.ts`: default `false` in dev/test/**production/staging** (explicit divergence from the prod-derived siblings), env-var `=1` opt-in flips it true in dev AND prod, non-`"1"` values (`"true"`, `"0"`, `""`) stay false.
- Full suite: `bun run test` green (core 3775 pass, adapter-server 780 pass); `bun run check` + `bun run typecheck` clean.

## Changeset

Patch bump for `@linchkit/core` + `@linchkit/cap-adapter-server`.

Part of #522 — the microVM runner tier + OS resource-limit wrapper (P5b) land in a separate PR (disjoint files, in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)