### PR TITLE
feat(cap-dry-run): microVM runner tier + OS-enforced memory limit (Spec 70 P5b)

### DIFF
--- a/.changeset/dry-run-microvm-runner-tier.md
+++ b/.changeset/dry-run-microvm-runner-tier.md
@@ -1,0 +1,30 @@
+---
+"@linchkit/cap-dry-run": minor
+---
+
+Spec 70 P5: microVM runner tier + OS-enforced resource limits for the execution
+dry-run sandbox.
+
+- New `createDryRunner({ runner: "subprocess" | "microvm" })` factory (default
+  `"subprocess"`; `createSubprocessDryRunner` stays exported as a back-compat
+  alias). The launcher (harness files + args) is IDENTICAL across tiers — only
+  the spawn wrapper differs, per Spec 70 §4.
+- `"microvm"` tier: runs the launcher behind a gVisor KERNEL boundary via the
+  production runsc integration — `docker run --runtime=runsc --network=none
+  --read-only --cap-drop=ALL --pids-limit --memory=<limit>` with the per-run
+  temp dir as the only writable bind (mounted at the same absolute path so the
+  result file round-trips). Detection requires `docker` + `runsc` on PATH and a
+  `runsc` runtime in the daemon's runtime table (`docker info` probe, memoized).
+  When configured and unavailable it FAILS CLOSED (`infra_error`, nothing runs)
+  — it never silently degrades to the subprocess tier. Timeout/OOM reaping also
+  `docker kill`s the named container (killing the attached client alone would
+  leave it running).
+- OS-enforced memory cap for the subprocess tier on Linux: when `prlimit` is
+  available the spawn is wrapped `prlimit --data=<memoryBytes> -- <sandbox
+  argv>` (outermost, so the rlimit inherits into the sandboxed bun).
+  `RLIMIT_DATA` over `RLIMIT_AS` because JS engines reserve multi-GiB virtual
+  address space at startup; the cross-platform RSS-polling guard stays as
+  defense in depth and keeps the precise `oom` classification.
+- New injectable seams for host-independent tests: `spawn` (records argv,
+  runs nothing) and `microvmProbe`; everything stays argv-array based — no
+  shell interpolation anywhere.

--- a/addons/dry-run/cap-dry-run/README.md
+++ b/addons/dry-run/cap-dry-run/README.md
@@ -23,7 +23,9 @@ dir, then cleans up. Layered defense:
   handler that reads a host file and prints it cannot surface its contents in the outcome.
 - **Credential reads blocked** — common secret dirs are denied (`sandbox-exec` deny-read
   of `~/.ssh`/`~/.aws`/… ; `bwrap` hides `/home` + `/root`). A full deny-default read
-  sandbox is impractical for a runtime, so airtight read-isolation is the P5 microVM tier.
+  sandbox is impractical for a runtime, so airtight read-isolation is the microvm
+  runner tier (see *Runner tiers* below — the container sees only the image + the
+  per-run temp dir).
 - **Minimal env** — no secrets (no `DATABASE_URL`/keys); `HOME`/`TMPDIR` point at the
   throwaway dir.
 - **Shimmed `@linchkit/core`** — `define*()` resolves to a fake; the real DB/provider
@@ -36,10 +38,18 @@ dir, then cleans up. Layered defense:
 - **Hard timeout** — the child runs as a process-group leader (`detached`), so past
   `limits.timeoutMs` the whole group is killed → `timeout`, reaping any subprocess the
   handler spawned.
-- **Memory guard (best-effort)** — the child's RSS is sampled against `limits.memoryBytes`;
-  a runaway allocation is killed → `oom`. This sees the handler's process directly on
-  `sandbox-exec`/trusted-container; under `bwrap` the launcher is sampled, so a precise,
-  descendant-inclusive cap is the P5 cgroup/microVM tier (the timeout still backstops).
+- **Memory cap** — two layers (Spec 70 P5):
+  - *OS-enforced (Linux)*: when `prlimit` is available, the spawn is prefixed with
+    `prlimit --data=<memoryBytes> --` OUTSIDE the sandbox wrapper — the rlimit inherits
+    across exec into the sandboxed bun and every descendant. `RLIMIT_DATA` was chosen
+    over `RLIMIT_AS` (a JS engine reserves multi-GiB virtual address space at startup,
+    so an `--as` cap would stop the child from launching) and over a `sh -c 'ulimit …'`
+    wrapper (no shell ever touches the argv). On the microvm tier the cgroup
+    `--memory` flag is the OS-enforced cap instead.
+  - *RSS-polling guard (all platforms, defense in depth)*: the child process tree's RSS
+    is sampled against `limits.memoryBytes`; a runaway allocation is killed → `oom`.
+    macOS has no rlimit-style RSS enforcement (`sandbox-exec` cannot cap memory), so
+    there the poll is the only memory bound (the timeout still backstops).
 
 With network denied, captured output discarded, an empty env, and a shimmed core, a
 file read cannot be exfiltrated and the DB cannot be reached. File **writes** are confined to the temp
@@ -51,16 +61,40 @@ so the harness snapshots the intrinsics it relies on (`JSON.stringify`, `Object.
 randomly named result path from `argv`, neutralises the exit functions, and writes the
 verdict with the snapshots — a top-level forge attempt (fake `passed` + early exit, or
 mutating those globals) cannot win. Airtight verdict integrity against a determined
-same-realm adversary, a precise descendant-inclusive memory cap, and a kernel-level
-boundary (gVisor/Firecracker microVM) are the Spec 70 P5 hardening tier. The dry-run is
+same-realm adversary is the kernel-boundary (microvm) tier's job. The dry-run is
 warn-only and human-gated, so its signal is advisory in P3.
+
+## Runner tiers (Spec 70 §4)
+
+`createDryRunner({ runner })` selects the isolation tier; the launcher (harness files
+and args) is IDENTICAL in both — only the spawn wrapper differs:
+
+- **`"subprocess"`** (default) — the hardened OS-sandboxed Bun child described above,
+  plus the Linux `prlimit --data` rlimit when available. Wrapper ordering (outermost →
+  innermost): `prlimit` → sandbox (`bwrap`/`sandbox-exec`/bare-in-trusted-container) →
+  `bun` harness.
+- **`"microvm"`** — the escalation tier for hostile multi-tenant deployments: the same
+  launcher runs behind a gVisor KERNEL boundary via the production runsc integration,
+  `docker run --runtime=runsc --network=none --read-only --cap-drop=ALL
+  --memory=<limits.memoryBytes> -v <tempDir>:<tempDir> <image> bun …`. Requires `docker`
+  AND `runsc` on PATH, and the daemon must list a `runsc` runtime (probed via
+  `docker info`). The per-run temp dir is the only writable bind, mounted at the same
+  absolute path so the result file round-trips; `microvmImage` (default `oven/bun:1`)
+  supplies the in-container `bun`. A direct `runsc do` is deliberately NOT supported:
+  it overlays the host root, discarding the harness's result file with the sandbox.
+
+  **Fail closed, never fall back:** when `runner: "microvm"` is configured and no
+  usable mechanism exists, the runner reports `infra_error`
+  ("microvm runner unavailable … failing closed; no untrusted code was run") — it
+  NEVER silently degrades to the subprocess tier, which would report a weaker
+  boundary as the stronger one.
 
 ## Usage
 
 ```ts
-import { createSubprocessDryRunner } from "@linchkit/cap-dry-run";
+import { createDryRunner } from "@linchkit/cap-dry-run";
 
-const runner = createSubprocessDryRunner();
+const runner = createDryRunner(); // or { runner: "microvm" } on a gVisor host
 const outcome = await runner.dryRun({
   source,            // AI-materialized TypeScript (a defineAction module)
   target: "action",
@@ -72,6 +106,9 @@ const outcome = await runner.dryRun({
 // outcome.status ∈ passed | threw | timeout | oom | forbidden_side_effect |
 //                  malformed_output | infra_error
 ```
+
+`createSubprocessDryRunner` remains exported as a back-compat alias of
+`createDryRunner` (same options, including `runner`).
 
 A P3 follow-up wires this provider into the async materialize path to stamp the
 durable `dryRunStatus` that validation Phase 5 reads (Spec 70 §5).

--- a/addons/dry-run/cap-dry-run/__tests__/runner-tier.test.ts
+++ b/addons/dry-run/cap-dry-run/__tests__/runner-tier.test.ts
@@ -1,0 +1,333 @@
+/**
+ * cap-dry-run — runner tier + OS resource limits (Spec 70 P5b).
+ *
+ * Host-independent: every test injects a fake `SandboxEnv` (and a recording fake
+ * spawn), so no real gVisor/docker/bwrap/prlimit is needed and NOTHING is ever
+ * actually executed. Covers:
+ *
+ *   - `runner: "microvm"` with no usable mechanism → FAIL CLOSED, zero spawns
+ *     (never a silent fallback to the subprocess tier).
+ *   - `runner: "microvm"` with a (fake) usable mechanism → the spawn argv is the
+ *     docker+runsc wrapper around the IDENTICAL harness args (parity with the
+ *     subprocess tier), plus the cgroup memory cap.
+ *   - The default tier stays `"subprocess"`.
+ *   - Linux OS memory-limit wrapper (`prlimit --data`) prefixes the sandboxed argv
+ *     when available, and is absent (RSS-guard-only) otherwise.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { basename } from "node:path";
+import {
+  buildMemoryLimitArgv,
+  buildMicrovmArgv,
+  createDryRunner,
+  createSubprocessDryRunner,
+  type DryRunSpawn,
+  detectMemoryLimitWrapper,
+  detectMicrovmStrategy,
+  isMicrovmStrategyUsable,
+  type SandboxEnv,
+} from "../src/index";
+
+const MEMORY_BYTES = 256 * 1024 * 1024;
+
+function job(overrides: { changeName?: string; tenantId?: string } = {}) {
+  return {
+    source: 'export const x = { name: "dry_run_probe", handler: async () => ({}) };',
+    target: "action" as const,
+    changeName: overrides.changeName ?? "dry_run_probe",
+    input: {},
+    inputCaseId: "case-0",
+    ...(overrides.tenantId ? { tenantId: overrides.tenantId } : {}),
+    limits: { timeoutMs: 5_000, memoryBytes: MEMORY_BYTES },
+  };
+}
+
+const mkEnv = (over: Partial<SandboxEnv>): SandboxEnv => ({
+  which: () => null,
+  getEnv: () => undefined,
+  platform: "linux",
+  ...over,
+});
+
+/** docker + runsc both on PATH (the microvm mechanism is detectable). */
+const MICROVM_ENV = mkEnv({
+  which: (b) =>
+    b === "docker" ? "/usr/bin/docker" : b === "runsc" ? "/usr/local/bin/runsc" : null,
+});
+
+/** A recording spawn that runs NOTHING: every argv is captured, the fake child
+ * exits 0 immediately. The runner then finds no result file → `infra_error`,
+ * which these tests ignore — they assert on the recorded argv only. */
+function recordingSpawn(record: string[][]): DryRunSpawn {
+  return (argv) => {
+    record.push([...argv]);
+    return {
+      // A pid far outside any real range: `process.kill(-pid)` throws ESRCH and the
+      // runner falls back to this fake's no-op kill.
+      pid: 2 ** 30 + record.length,
+      exited: Promise.resolve(0),
+      kill: () => {},
+    };
+  };
+}
+
+describe("microvm strategy detection (pure, injected env)", () => {
+  test("requires BOTH docker and runsc on PATH", () => {
+    expect(detectMicrovmStrategy(MICROVM_ENV)).toBe("docker-runsc");
+    expect(
+      detectMicrovmStrategy(mkEnv({ which: (b) => (b === "docker" ? "/usr/bin/docker" : null) })),
+    ).toBeNull();
+    expect(
+      detectMicrovmStrategy(mkEnv({ which: (b) => (b === "runsc" ? "/usr/bin/runsc" : null) })),
+    ).toBeNull();
+    expect(detectMicrovmStrategy(mkEnv({}))).toBeNull();
+  });
+
+  test("usability requires the daemon to list a runsc runtime", () => {
+    expect(
+      isMicrovmStrategyUsable("docker-runsc", () => ({
+        exitCode: 0,
+        stdout: '{"runc":{"path":"runc"},"runsc":{"path":"/usr/local/bin/runsc"}}',
+      })),
+    ).toBe(true);
+    // Daemon up but no runsc runtime registered → not usable.
+    expect(
+      isMicrovmStrategyUsable("docker-runsc", () => ({
+        exitCode: 0,
+        stdout: '{"runc":{"path":"runc"}}',
+      })),
+    ).toBe(false);
+    // Daemon down / no permission → not usable.
+    expect(isMicrovmStrategyUsable("docker-runsc", () => ({ exitCode: 1, stdout: "" }))).toBe(
+      false,
+    );
+    expect(
+      isMicrovmStrategyUsable("docker-runsc", () => {
+        throw new Error("docker: command not found");
+      }),
+    ).toBe(false);
+  });
+
+  test("buildMicrovmArgv wraps the harness args behind docker+runsc with a cgroup cap", () => {
+    const argv = buildMicrovmArgv({
+      strategy: "docker-runsc",
+      childArgv: ["/host/bin/bun", "--preload", "/d/p.ts", "/d/r.ts"],
+      tempDir: "/d",
+      memoryBytes: MEMORY_BYTES,
+      containerName: "linchkit-dryrun-x",
+      image: "oven/bun:1",
+    });
+    expect(argv[0]).toBe("docker");
+    expect(argv).toContain("--runtime=runsc");
+    expect(argv).toContain("--network=none");
+    expect(argv).toContain("--read-only");
+    expect(argv).toContain(`--memory=${MEMORY_BYTES}`);
+    expect(argv).toContain("--cap-drop=ALL");
+    // The per-run temp dir is bind-mounted at the SAME absolute path…
+    expect(argv).toContain("/d:/d");
+    // …and the host bun path is replaced by the image's `bun` running the IDENTICAL
+    // harness args.
+    expect(argv.slice(argv.indexOf("oven/bun:1") + 1)).toEqual([
+      "bun",
+      "--preload",
+      "/d/p.ts",
+      "/d/r.ts",
+    ]);
+  });
+});
+
+describe("OS memory-limit wrapper detection (pure, injected env)", () => {
+  test("linux + prlimit on PATH → prlimit; otherwise guard-only (null)", () => {
+    expect(
+      detectMemoryLimitWrapper(
+        mkEnv({ which: (b) => (b === "prlimit" ? "/usr/bin/prlimit" : null) }),
+      ),
+    ).toBe("prlimit");
+    expect(detectMemoryLimitWrapper(mkEnv({}))).toBeNull();
+    // Not Linux → never an rlimit wrapper, even if a `prlimit` binary exists.
+    expect(
+      detectMemoryLimitWrapper(
+        mkEnv({ platform: "darwin", which: (b) => (b === "prlimit" ? "/x/prlimit" : null) }),
+      ),
+    ).toBeNull();
+  });
+
+  test("buildMemoryLimitArgv prefixes prlimit --data OUTSIDE the sandboxed argv", () => {
+    expect(
+      buildMemoryLimitArgv({
+        wrapper: "prlimit",
+        memoryBytes: MEMORY_BYTES,
+        argv: ["bwrap", "--unshare-net", "--", "/bin/bun", "x.ts"],
+      }),
+    ).toEqual([
+      "prlimit",
+      `--data=${MEMORY_BYTES}`,
+      "--",
+      "bwrap",
+      "--unshare-net",
+      "--",
+      "/bin/bun",
+      "x.ts",
+    ]);
+  });
+});
+
+describe("createDryRunner — microvm tier fails closed (nothing spawned)", () => {
+  test("microvm configured + runsc absent → infra_error, zero spawns, no fallback", async () => {
+    const record: string[][] = [];
+    const runner = createDryRunner({
+      runner: "microvm",
+      // docker present, runsc absent — the subprocess tier WOULD be available here
+      // (bwrap on PATH), proving the fail-closed path never silently degrades.
+      sandboxEnv: mkEnv({
+        which: (b) => (b === "docker" || b === "bwrap" ? `/usr/bin/${b}` : null),
+      }),
+      spawn: recordingSpawn(record),
+    });
+    const outcome = await runner.dryRun(job());
+    expect(outcome.status).toBe("infra_error");
+    expect(outcome.error ?? "").toContain("microvm runner unavailable");
+    expect(outcome.error ?? "").toContain("failing closed");
+    expect(record).toHaveLength(0);
+  });
+
+  test("microvm configured + runsc present but daemon has no runsc runtime → fail closed", async () => {
+    const record: string[][] = [];
+    const runner = createDryRunner({
+      runner: "microvm",
+      sandboxEnv: MICROVM_ENV,
+      microvmProbe: () => false,
+      spawn: recordingSpawn(record),
+    });
+    const outcome = await runner.dryRun(job());
+    expect(outcome.status).toBe("infra_error");
+    expect(outcome.error ?? "").toContain("microvm runner unavailable");
+    expect(record).toHaveLength(0);
+  });
+
+  test("default runner stays subprocess: no-sandbox env reports the SANDBOX message", async () => {
+    const runner = createDryRunner({
+      sandboxEnv: mkEnv({ platform: "darwin" }),
+      spawn: recordingSpawn([]),
+    });
+    const outcome = await runner.dryRun(job());
+    expect(outcome.status).toBe("infra_error");
+    expect(outcome.error ?? "").toContain("No OS sandbox available");
+    expect(outcome.error ?? "").not.toContain("microvm");
+  });
+
+  test("createSubprocessDryRunner remains exported and accepts the runner option", async () => {
+    const record: string[][] = [];
+    const runner = createSubprocessDryRunner({
+      runner: "microvm",
+      sandboxEnv: mkEnv({}),
+      spawn: recordingSpawn(record),
+    });
+    const outcome = await runner.dryRun(job());
+    expect(outcome.status).toBe("infra_error");
+    expect(outcome.error ?? "").toContain("microvm runner unavailable");
+    expect(record).toHaveLength(0);
+  });
+});
+
+describe("createDryRunner — microvm tier spawn argv + subprocess parity", () => {
+  test("usable microvm → docker+runsc wrapper, identical harness args, container reaped", async () => {
+    const microvmRecord: string[][] = [];
+    const microvmRunner = createDryRunner({
+      runner: "microvm",
+      sandboxEnv: MICROVM_ENV,
+      microvmProbe: () => true,
+      spawn: recordingSpawn(microvmRecord),
+    });
+    const microvmOutcome = await microvmRunner.dryRun(job({ tenantId: "t-1" }));
+    // The fake child writes no result file → infra (NOT a fail-closed message); the
+    // assertions below are about the recorded argv.
+    expect(microvmOutcome.status).toBe("infra_error");
+    expect(microvmOutcome.error ?? "").not.toContain("unavailable");
+
+    // Subprocess tier reference run (trusted-container → bare harness argv).
+    const subRecord: string[][] = [];
+    const subRunner = createDryRunner({
+      sandboxEnv: mkEnv({
+        getEnv: (k) => (k === "LINCHKIT_DRYRUN_TRUST_CONTAINER" ? "1" : undefined),
+      }),
+      spawn: recordingSpawn(subRecord),
+    });
+    await subRunner.dryRun(job({ tenantId: "t-1" }));
+
+    expect(microvmRecord.length).toBeGreaterThanOrEqual(1);
+    const argv = microvmRecord[0] as string[];
+    // argv[0] is resolved to the fake env's absolute docker path.
+    expect(argv[0]).toBe("/usr/bin/docker");
+    expect(argv[1]).toBe("run");
+    expect(argv).toContain("--runtime=runsc");
+    expect(argv).toContain("--network=none");
+    expect(argv).toContain("--read-only");
+    expect(argv).toContain(`--memory=${MEMORY_BYTES}`);
+    // The per-run temp dir is bind-mounted at the same absolute path.
+    expect(argv.some((a) => /linchkit-dryrun-.+:.+linchkit-dryrun-/.test(a))).toBe(true);
+
+    // PARITY: the in-container command is the IDENTICAL launcher the subprocess tier
+    // runs — same arg count, same flags, same harness filenames, same change/tenant.
+    const imageIdx = argv.indexOf("oven/bun:1");
+    expect(imageIdx).toBeGreaterThan(0);
+    const tail = argv.slice(imageIdx + 1);
+    const sub = subRecord[0] as string[];
+    expect(tail).toHaveLength(sub.length);
+    expect(tail[0]).toBe("bun"); // image-provided bun replaces the host bun path
+    expect(tail[1]).toBe("--preload");
+    expect(sub[1]).toBe("--preload");
+    // Harness files have identical names (temp dirs differ per run).
+    for (const i of [2, 3, 4, 8]) {
+      expect(basename(tail[i] as string)).toBe(basename(sub[i] as string));
+    }
+    expect(basename(tail[5] as string)).toStartWith("__dryrun_result_");
+    expect(basename(sub[5] as string)).toStartWith("__dryrun_result_");
+    expect(tail[6]).toBe("dry_run_probe");
+    expect(sub[6]).toBe("dry_run_probe");
+    expect(tail[7]).toBe("t-1");
+    expect(sub[7]).toBe("t-1");
+
+    // Reap: the runner `docker kill`s the named container (killing the attached
+    // client alone would leave it running).
+    const nameIdx = argv.indexOf("--name");
+    const containerName = argv[nameIdx + 1] as string;
+    expect(containerName).toStartWith("linchkit-dryrun-");
+    expect(microvmRecord.some((a) => a[1] === "kill" && a[2] === containerName)).toBe(true);
+  });
+});
+
+describe("createDryRunner — Linux OS memory-limit wrapper (subprocess tier)", () => {
+  test("prlimit available → argv is prlimit --data -- bwrap …", async () => {
+    const record: string[][] = [];
+    const runner = createDryRunner({
+      sandboxEnv: mkEnv({
+        which: (b) => (b === "bwrap" || b === "prlimit" ? `/usr/bin/${b}` : null),
+      }),
+      spawn: recordingSpawn(record),
+    });
+    await runner.dryRun(job());
+    expect(record).toHaveLength(1);
+    const argv = record[0] as string[];
+    expect(argv[0]).toBe("/usr/bin/prlimit");
+    expect(argv[1]).toBe(`--data=${MEMORY_BYTES}`);
+    expect(argv[2]).toBe("--");
+    expect(argv[3]).toBe("bwrap");
+    expect(argv).toContain("--unshare-net");
+  });
+
+  test("prlimit absent → sandbox argv unchanged (RSS guard remains the only cap)", async () => {
+    const record: string[][] = [];
+    const runner = createDryRunner({
+      sandboxEnv: mkEnv({ which: (b) => (b === "bwrap" ? "/usr/bin/bwrap" : null) }),
+      spawn: recordingSpawn(record),
+    });
+    await runner.dryRun(job());
+    expect(record).toHaveLength(1);
+    const argv = record[0] as string[];
+    expect(argv[0]).toBe("/usr/bin/bwrap");
+    expect(argv).not.toContain("prlimit");
+    expect(argv).toContain("--unshare-net");
+  });
+});

--- a/addons/dry-run/cap-dry-run/src/index.ts
+++ b/addons/dry-run/cap-dry-run/src/index.ts
@@ -8,18 +8,36 @@
  * Core stays execution-free: it declares the seam (Spec 70 P2); this capability
  * supplies the implementation. The runner FAILS CLOSED (reports `infra_error`,
  * runs nothing) on any host where no OS sandbox can deny network egress.
+ *
+ * Spec 70 P5 adds the escalation tier: `createDryRunner({ runner: "microvm" })`
+ * runs the IDENTICAL launcher inside a gVisor kernel boundary
+ * (`docker run --runtime=runsc`), and the subprocess tier gains an OS-enforced
+ * memory rlimit on Linux (`prlimit --data`). A configured microvm tier with no
+ * usable mechanism fails closed — it never degrades to the subprocess tier.
  */
 
 export {
+  buildMemoryLimitArgv,
+  buildMicrovmArgv,
   buildSandboxArgv,
   buildSandboxExecProfile,
   defaultSandboxEnv,
+  detectMemoryLimitWrapper,
+  detectMicrovmStrategy,
   detectSandboxStrategy,
+  isMicrovmStrategyUsable,
   isSandboxStrategyUsable,
+  type MemoryLimitWrapper,
+  type MicrovmStrategy,
   type SandboxEnv,
   type SandboxStrategy,
 } from "./sandbox";
 export {
+  createDryRunner,
   createSubprocessDryRunner,
+  type DryRunnerOptions,
+  type DryRunnerTier,
+  type DryRunSpawn,
+  type SpawnedDryRunChild,
   type SubprocessDryRunnerOptions,
 } from "./subprocess-dry-runner";

--- a/addons/dry-run/cap-dry-run/src/sandbox.ts
+++ b/addons/dry-run/cap-dry-run/src/sandbox.ts
@@ -319,8 +319,9 @@ export function buildMicrovmArgv(args: {
     "--cap-drop=ALL",
     "--security-opt=no-new-privileges",
     "--pids-limit=128",
-    `--memory=${memoryBytes}`,
-    `--memory-swap=${memoryBytes}`,
+    // Floored: a fractional byte count would fail Docker's CLI size parsing.
+    `--memory=${Math.floor(memoryBytes)}`,
+    `--memory-swap=${Math.floor(memoryBytes)}`,
     "-v",
     `${tempDir}:${tempDir}`,
     "-w",
@@ -384,5 +385,6 @@ export function buildMemoryLimitArgv(args: {
   memoryBytes: number;
   argv: readonly string[];
 }): string[] {
-  return ["prlimit", `--data=${args.memoryBytes}`, "--", ...args.argv];
+  // Floored: prlimit rejects fractional limit values.
+  return ["prlimit", `--data=${Math.floor(args.memoryBytes)}`, "--", ...args.argv];
 }

--- a/addons/dry-run/cap-dry-run/src/sandbox.ts
+++ b/addons/dry-run/cap-dry-run/src/sandbox.ts
@@ -223,3 +223,166 @@ export function buildSandboxArgv(args: {
       return [...childArgv];
   }
 }
+
+// ── microVM runner tier (Spec 70 §4 escalation tier, P5) ──────────────────────
+
+/**
+ * Mechanisms that give the dry-run a KERNEL boundary (gVisor). The one mechanism we
+ * trust is the production gVisor integration: a container engine driving the `runsc`
+ * OCI runtime (`docker run --runtime=runsc`). A direct `runsc do` is deliberately NOT
+ * a strategy: it overlays the host root filesystem, so the harness's result-file write
+ * is discarded with the sandbox and every run would report `infra_error`; turning the
+ * overlay off would leave the host filesystem writable — worse than the subprocess tier.
+ */
+export type MicrovmStrategy = "docker-runsc";
+
+/**
+ * Detect a usable microVM mechanism. Requires BOTH `docker` (the engine that builds
+ * the OCI sandbox with mounts) and `runsc` (gVisor) on PATH; whether the Docker daemon
+ * actually has the runsc runtime registered is verified separately by
+ * {@link isMicrovmStrategyUsable}. Returns `null` when absent — the caller MUST then
+ * fail closed (a configured microvm tier NEVER silently degrades to the subprocess
+ * tier; that would report a weaker boundary as the stronger one).
+ */
+export function detectMicrovmStrategy(
+  env: SandboxEnv = defaultSandboxEnv(),
+): MicrovmStrategy | null {
+  if (env.which("docker") && env.which("runsc")) return "docker-runsc";
+  return null;
+}
+
+/**
+ * Verify the detected microVM mechanism is actually USABLE: `runsc` being on PATH does
+ * not mean the Docker daemon has it registered as a runtime. We ask the daemon for its
+ * runtime table and require a `runsc` entry; any failure (daemon down, no permission,
+ * no runsc runtime) → not usable → the caller fails closed. `run` is injectable for
+ * host-independent tests.
+ */
+export function isMicrovmStrategyUsable(
+  _strategy: MicrovmStrategy,
+  run: (argv: string[]) => { exitCode: number | null; stdout?: string } = (argv) => {
+    const res = Bun.spawnSync(argv);
+    return { exitCode: res.exitCode, stdout: new TextDecoder().decode(res.stdout) };
+  },
+): boolean {
+  try {
+    const res = run(["docker", "info", "--format", "{{json .Runtimes}}"]);
+    return res.exitCode === 0 && (res.stdout ?? "").includes('"runsc"');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wrap the child harness command so it runs inside a gVisor microVM via
+ * `docker run --runtime=runsc`. The launcher interface is unchanged (Spec 70 §4):
+ * the IDENTICAL harness args run, only the spawn wrapper differs.
+ *
+ *   - `--network=none` — egress denial (parity with sandbox-exec/bwrap), now behind
+ *     a kernel boundary.
+ *   - `--read-only` + a single writable bind of the per-run temp dir at the SAME
+ *     absolute path — parity with the bwrap read-only root, and it lets the parent
+ *     read the harness's result file after exit.
+ *   - `--memory`/`--memory-swap` — the OS-ENFORCED memory cap for this tier (cgroup,
+ *     enforced by the engine; the host-side RSS poll stays as defense in depth).
+ *   - `--cap-drop=ALL --security-opt=no-new-privileges --pids-limit` — least privilege
+ *     and a fork-bomb bound.
+ *   - `childArgv[0]` (the HOST bun path) is replaced by the image's `bun`: the host
+ *     binary does not exist inside the container, while every other harness arg is an
+ *     absolute path under the bind-mounted temp dir, identical inside and out.
+ *   - `--name` gives the parent a handle to `docker kill` on timeout/OOM reap —
+ *     killing the attached `docker run` client does NOT stop the container.
+ *
+ * Everything is built as an argv array (never shell-interpolated); the only embedded
+ * paths are the runner-owned `mkdtemp` dir, never the untrusted source.
+ */
+export function buildMicrovmArgv(args: {
+  strategy: MicrovmStrategy;
+  childArgv: readonly string[];
+  tempDir: string;
+  memoryBytes: number;
+  containerName: string;
+  image: string;
+}): string[] {
+  const { childArgv, tempDir, memoryBytes, containerName, image } = args;
+  const harnessArgs = childArgv.slice(1);
+  return [
+    "docker",
+    "run",
+    "--rm",
+    "-i",
+    "--name",
+    containerName,
+    "--runtime=runsc",
+    "--network=none",
+    "--read-only",
+    "--cap-drop=ALL",
+    "--security-opt=no-new-privileges",
+    "--pids-limit=128",
+    `--memory=${memoryBytes}`,
+    `--memory-swap=${memoryBytes}`,
+    "-v",
+    `${tempDir}:${tempDir}`,
+    "-w",
+    tempDir,
+    "-e",
+    `HOME=${tempDir}`,
+    "-e",
+    `TMPDIR=${tempDir}`,
+    image,
+    "bun",
+    ...harnessArgs,
+  ];
+}
+
+// ── OS-enforced memory limit (subprocess tier) ────────────────────────────────
+
+/** The one OS memory-limit mechanism the subprocess tier uses (see below). */
+export type MemoryLimitWrapper = "prlimit";
+
+/**
+ * Detect an OS-enforced memory-limit wrapper for the subprocess tier. Linux only:
+ * `prlimit(1)` (util-linux) applies an rlimit to the command it execs, and rlimits
+ * inherit across exec/fork — wrapping the OUTERMOST command caps every descendant,
+ * including the bun that runs the untrusted handler inside bwrap.
+ *
+ * macOS has no equivalent (`sandbox-exec` cannot enforce memory and there is no
+ * prlimit), so there the RSS-polling guard remains the only memory bound — returning
+ * `null` here means "guard-only", which is hardening lost, NOT a security failure
+ * (egress denial is the boundary), so the caller does NOT fail closed.
+ */
+export function detectMemoryLimitWrapper(
+  env: SandboxEnv = defaultSandboxEnv(),
+): MemoryLimitWrapper | null {
+  if (env.platform !== "linux") return null;
+  return env.which("prlimit") ? "prlimit" : null;
+}
+
+/**
+ * Prefix the (already sandbox-wrapped) argv with the OS memory limit.
+ *
+ * Mechanism choice — `prlimit --data=<bytes>` (RLIMIT_DATA), deliberately NOT
+ * `--as` (RLIMIT_AS) and NOT a `sh -c 'ulimit -v …'` wrapper:
+ *   - RLIMIT_AS caps VIRTUAL address space, and a modern JS engine reserves multi-GiB
+ *     PROT_NONE regions at startup — an `--as` cap at the dry-run budget would stop
+ *     the child from even launching.
+ *   - RLIMIT_DATA (Linux ≥ 4.7) covers brk + writable private anonymous mappings —
+ *     the memory a runaway allocation actually commits — while ignoring those
+ *     untouched reservations.
+ *   - A `sh -c` wrapper would put the harness argv through a shell; argv arrays only.
+ *
+ * When the OS limit fires, the child's allocation fails (the run surfaces as `threw`
+ * or, if bun aborts, `infra_error`); the RSS-polling guard stays active on all
+ * platforms as defense in depth and still provides the precise `oom` classification.
+ *
+ * Ordering: the limit wraps OUTSIDE the sandbox (`prlimit -- bwrap -- bun …`) —
+ * rlimits inherit into the sandboxed child, and this keeps the limit binary outside
+ * the confined filesystem view.
+ */
+export function buildMemoryLimitArgv(args: {
+  wrapper: MemoryLimitWrapper;
+  memoryBytes: number;
+  argv: readonly string[];
+}): string[] {
+  return ["prlimit", `--data=${args.memoryBytes}`, "--", ...args.argv];
+}

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -315,7 +315,7 @@ export function createDryRunner(options: DryRunnerOptions = {}): ExecutionDryRun
             const dockerBin = sandboxEnv.which("docker") ?? "docker";
             spawnChild([dockerBin, "kill", containerName], {
               cwd: options.tmpRoot ?? tmpdir(),
-              env: { PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin" },
+              env: { PATH: sandboxEnv.getEnv("PATH") ?? "/usr/bin:/bin:/usr/local/bin" },
               stdin: new Blob([]),
             }).exited.catch(() => {});
           } catch {
@@ -414,12 +414,13 @@ export function createDryRunner(options: DryRunnerOptions = {}): ExecutionDryRun
         // DATABASE_URL / API keys / tokens). HOME + TMPDIR point at the throwaway dir.
         // The microvm tier additionally passes DOCKER_HOST through so the client can
         // reach a non-default daemon socket (it carries no secret material).
+        const dockerHost = sandboxEnv.getEnv("DOCKER_HOST");
         const env: Record<string, string> = {
-          PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
+          PATH: sandboxEnv.getEnv("PATH") ?? "/usr/bin:/bin:/usr/local/bin",
           HOME: dir,
           TMPDIR: dir,
-          LANG: process.env.LANG ?? "C",
-          ...(microvm && process.env.DOCKER_HOST ? { DOCKER_HOST: process.env.DOCKER_HOST } : {}),
+          LANG: sandboxEnv.getEnv("LANG") ?? "C",
+          ...(microvm && dockerHost ? { DOCKER_HOST: dockerHost } : {}),
         };
 
         // The default spawn is `detached` (process-group leader, POSIX `setsid`), so we

--- a/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
+++ b/addons/dry-run/cap-dry-run/src/subprocess-dry-runner.ts
@@ -33,17 +33,25 @@ import {
   SOURCE_FILENAME,
 } from "./child-harness";
 import {
+  buildMemoryLimitArgv,
+  buildMicrovmArgv,
   buildSandboxArgv,
   buildSandboxExecProfile,
   defaultSandboxEnv,
+  detectMemoryLimitWrapper,
+  detectMicrovmStrategy,
   detectSandboxStrategy,
+  isMicrovmStrategyUsable,
   isSandboxStrategyUsable,
+  type MicrovmStrategy,
   type SandboxEnv,
   type SandboxStrategy,
 } from "./sandbox";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_MEMORY_BYTES = 256 * 1024 * 1024;
+/** Default image for the microvm tier — bun must exist inside the container. */
+const DEFAULT_MICROVM_IMAGE = "oven/bun:1";
 /** How often the memory guard samples the process tree's RSS. */
 const MEM_POLL_MS = 250;
 
@@ -107,7 +115,39 @@ interface ChildResult {
   __nonce?: string;
 }
 
+/** Runner tiers (Spec 70 §4): the hardened OS-process default, or the gVisor
+ * kernel-boundary escalation tier. The launcher (harness files + argv) is IDENTICAL;
+ * only the spawn wrapper differs. */
+export type DryRunnerTier = "subprocess" | "microvm";
+
+/** The subset of `Bun.spawn`'s subprocess handle the runner relies on. */
+export interface SpawnedDryRunChild {
+  pid: number;
+  exited: Promise<number>;
+  kill(signal?: number): void;
+}
+
+/** Spawn seam: the runner always passes a fully built argv array (never a shell
+ * string); the default implementation is a detached, output-discarding `Bun.spawn`.
+ * Injectable so tests can record the exact argv without running anything. */
+export type DryRunSpawn = (
+  argv: string[],
+  options: { cwd: string; env: Record<string, string>; stdin: Blob },
+) => SpawnedDryRunChild;
+
+const defaultSpawn: DryRunSpawn = (argv, options) =>
+  // `detached` → process-group leader (whole-tree reaping); stdout/stderr DISCARDED
+  // (captured untrusted output would be an exfiltration channel — see dryRun()).
+  Bun.spawn(argv, { ...options, stdout: "ignore", stderr: "ignore", detached: true });
+
 export interface SubprocessDryRunnerOptions {
+  /**
+   * Which isolation tier wraps the spawn (default `"subprocess"`). A configured
+   * `"microvm"` tier with no usable gVisor mechanism on the host FAILS CLOSED
+   * (`infra_error`, nothing runs) — it never silently degrades to the subprocess
+   * tier, which would report a weaker boundary as the stronger one.
+   */
+  runner?: DryRunnerTier;
   /** Default resource bounds when a job omits them. */
   defaultLimits?: { timeoutMs: number; memoryBytes: number };
   /** Override the sandbox/platform probe (tests). */
@@ -116,7 +156,16 @@ export interface SubprocessDryRunnerOptions {
   tmpRoot?: string;
   /** Absolute path to the Bun executable for the child (defaults to this process's). */
   bunPath?: string;
+  /** Container image for the microvm tier; must provide `bun` (default `oven/bun:1`). */
+  microvmImage?: string;
+  /** Override the microvm usability probe (tests). */
+  microvmProbe?: (strategy: MicrovmStrategy) => boolean;
+  /** Override the spawn (tests record argv instead of running). */
+  spawn?: DryRunSpawn;
 }
+
+/** Preferred options alias now that the factory selects the runner tier. */
+export type DryRunnerOptions = SubprocessDryRunnerOptions;
 
 /** Build the `infra_error` outcome (warn-only; never blocks). */
 function infraOutcome(
@@ -146,13 +195,22 @@ function resolveBunPath(provided: string | undefined, env: SandboxEnv): string {
 }
 
 /**
- * Create a hardened-subprocess `ExecutionDryRunProvider`. Each `dryRun` call runs
- * in its own throwaway temp dir, sandboxed, and is fully cleaned up afterward.
+ * Create a hardened `ExecutionDryRunProvider`. Each `dryRun` call runs in its own
+ * throwaway temp dir, sandboxed, and is fully cleaned up afterward. The isolation
+ * tier is selected by `options.runner` (Spec 70 §4):
+ *
+ *   - `"subprocess"` (default) — OS-sandboxed Bun child (`sandbox-exec`/`bwrap`/
+ *     trusted container), plus an OS-enforced memory rlimit on Linux when
+ *     `prlimit` is available (`prlimit --data -- <sandbox argv>`).
+ *   - `"microvm"` — the IDENTICAL launcher inside a gVisor kernel boundary
+ *     (`docker run --runtime=runsc --network=none --read-only --memory=…`). No
+ *     usable mechanism → FAIL CLOSED, never a silent subprocess fallback.
  */
-export function createSubprocessDryRunner(
-  options: SubprocessDryRunnerOptions = {},
-): ExecutionDryRunProvider {
+export function createDryRunner(options: DryRunnerOptions = {}): ExecutionDryRunProvider {
   const sandboxEnv = options.sandboxEnv ?? defaultSandboxEnv();
+  const tier: DryRunnerTier = options.runner ?? "subprocess";
+  const spawnChild = options.spawn ?? defaultSpawn;
+  const microvmProbe = options.microvmProbe ?? isMicrovmStrategyUsable;
   // Resolve the Bun executable to an ABSOLUTE path. A relative/bare `bunPath`
   // (e.g. "bun") would make `dirname(bunPath)` in sandbox.ts resolve to "." and
   // bind the caller's CWD into the bwrap sandbox (leaking arbitrary files), so a
@@ -176,6 +234,19 @@ export function createSubprocessDryRunner(
     }
     return usable;
   };
+  // Same once-per-runner memo for the microvm mechanism (docker daemon runtime table).
+  const microvmUsableMemo = new Map<MicrovmStrategy, boolean>();
+  const microvmUsable = (strategy: MicrovmStrategy): boolean => {
+    let usable = microvmUsableMemo.get(strategy);
+    if (usable === undefined) {
+      usable = microvmProbe(strategy);
+      microvmUsableMemo.set(strategy, usable);
+    }
+    return usable;
+  };
+  // The OS memory-limit wrapper for the subprocess tier (Linux `prlimit`; `null` on
+  // platforms without one → the RSS-polling guard alone bounds memory there).
+  const memoryLimitWrapper = detectMemoryLimitWrapper(sandboxEnv);
 
   return {
     async dryRun(job): Promise<DryRunOutcome> {
@@ -188,20 +259,42 @@ export function createSubprocessDryRunner(
       // result forged by the untrusted code cannot carry it.
       const nonce = crypto.randomUUID();
 
-      // Fail closed when no OS sandbox can deny network egress on this host, or when
-      // the detected primitive is present but cannot actually apply a sandbox.
-      const strategy = detectSandboxStrategy(sandboxEnv);
-      if (!strategy) {
-        return infraOutcome(
-          base,
-          "No OS sandbox available to deny network egress on this host — failing closed (no untrusted code was run).",
-        );
-      }
-      if (!strategyUsable(strategy)) {
-        return infraOutcome(
-          base,
-          `The '${strategy}' sandbox is present but cannot apply a profile on this host — failing closed (no untrusted code was run).`,
-        );
+      // Resolve the isolation wrapper for the configured tier BEFORE anything is
+      // written or spawned. Each tier fails closed on its own terms; a configured
+      // microvm tier NEVER falls back to the subprocess tier (a stronger configured
+      // boundary silently degrading would misreport the isolation actually applied).
+      let strategy: SandboxStrategy | null = null;
+      let microvm: MicrovmStrategy | null = null;
+      if (tier === "microvm") {
+        microvm = detectMicrovmStrategy(sandboxEnv);
+        if (!microvm) {
+          return infraOutcome(
+            base,
+            "microvm runner unavailable (no gVisor `runsc` + container engine on this host) — failing closed; no untrusted code was run.",
+          );
+        }
+        if (!microvmUsable(microvm)) {
+          return infraOutcome(
+            base,
+            "microvm runner unavailable (`runsc` is present but the container engine has no runsc runtime registered) — failing closed; no untrusted code was run.",
+          );
+        }
+      } else {
+        // Fail closed when no OS sandbox can deny network egress on this host, or when
+        // the detected primitive is present but cannot actually apply a sandbox.
+        strategy = detectSandboxStrategy(sandboxEnv);
+        if (!strategy) {
+          return infraOutcome(
+            base,
+            "No OS sandbox available to deny network egress on this host — failing closed (no untrusted code was run).",
+          );
+        }
+        if (!strategyUsable(strategy)) {
+          return infraOutcome(
+            base,
+            `The '${strategy}' sandbox is present but cannot apply a profile on this host — failing closed (no untrusted code was run).`,
+          );
+        }
       }
 
       const dir = await mkdtemp(join(options.tmpRoot ?? tmpdir(), "linchkit-dryrun-"));
@@ -209,8 +302,26 @@ export function createSubprocessDryRunner(
       // Hoisted so `finally` can reap the child's process group on EVERY path — even a
       // handler that backgrounds a process and then returns normally leaves nothing
       // alive past the dry-run.
-      let proc: ReturnType<typeof Bun.spawn> | undefined;
+      let proc: SpawnedDryRunChild | undefined;
+      // microvm only: the per-run container name, so reaping can `docker kill` it —
+      // killing the attached `docker run` CLIENT does not stop the container.
+      const containerName =
+        tier === "microvm" ? `linchkit-dryrun-${crypto.randomUUID()}` : undefined;
       const reapGroup = (): void => {
+        if (containerName) {
+          // Fire-and-forget; an already-exited `--rm` container makes this a no-op
+          // error we ignore. Goes through the same spawn seam (argv array, no shell).
+          try {
+            const dockerBin = sandboxEnv.which("docker") ?? "docker";
+            spawnChild([dockerBin, "kill", containerName], {
+              cwd: options.tmpRoot ?? tmpdir(),
+              env: { PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin" },
+              stdin: new Blob([]),
+            }).exited.catch(() => {});
+          } catch {
+            /* best effort */
+          }
+        }
         if (!proc) return;
         try {
           // Negative pid targets the whole group (the child is its leader via
@@ -266,7 +377,34 @@ export function createSubprocessDryRunner(
           job.tenantId ?? "dry-run",
           metaPath,
         ];
-        const argv = buildSandboxArgv({ strategy, childArgv, tempDir: dir, profilePath });
+        // Wrapper ordering (outermost → innermost):
+        //   subprocess tier: [prlimit (linux, when present)] → sandbox (bwrap /
+        //     sandbox-exec / bare-in-trusted-container) → bun harness. The rlimit
+        //     inherits across exec into the sandboxed bun, and keeping it outermost
+        //     keeps the limit binary outside the confined filesystem view.
+        //   microvm tier: docker(runsc) → bun harness. The cgroup `--memory` flag IS
+        //     this tier's OS-enforced cap, so no prlimit; the kernel boundary
+        //     subsumes the OS sandbox wrappers.
+        // All layers are argv arrays — nothing is ever shell-interpolated.
+        let argv: string[];
+        if (microvm && containerName) {
+          argv = buildMicrovmArgv({
+            strategy: microvm,
+            childArgv,
+            tempDir: dir,
+            memoryBytes,
+            containerName,
+            image: options.microvmImage ?? DEFAULT_MICROVM_IMAGE,
+          });
+        } else if (strategy) {
+          argv = buildSandboxArgv({ strategy, childArgv, tempDir: dir, profilePath });
+          if (memoryLimitWrapper) {
+            argv = buildMemoryLimitArgv({ wrapper: memoryLimitWrapper, memoryBytes, argv });
+          }
+        } else {
+          // Unreachable: detection above either set a wrapper or failed closed.
+          return infraOutcome(base, "No isolation wrapper resolved — failing closed.");
+        }
         // Resolve the wrapper binary (argv[0]) to an absolute path so spawning does
         // not depend on the child's (minimal) PATH.
         const wrapperBin = argv[0];
@@ -274,29 +412,29 @@ export function createSubprocessDryRunner(
 
         // Minimal env: enough for bun to run, but NO secrets (no inherited
         // DATABASE_URL / API keys / tokens). HOME + TMPDIR point at the throwaway dir.
+        // The microvm tier additionally passes DOCKER_HOST through so the client can
+        // reach a non-default daemon socket (it carries no secret material).
         const env: Record<string, string> = {
           PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
           HOME: dir,
           TMPDIR: dir,
           LANG: process.env.LANG ?? "C",
+          ...(microvm && process.env.DOCKER_HOST ? { DOCKER_HOST: process.env.DOCKER_HOST } : {}),
         };
 
-        // `detached` makes the child a process-group leader (POSIX `setsid`), so we can
-        // kill the WHOLE group — reaping any subprocess the handler spawned, not just
-        // the sandbox command — and nothing outlives the dry-run.
+        // The default spawn is `detached` (process-group leader, POSIX `setsid`), so we
+        // can kill the WHOLE group — reaping any subprocess the handler spawned, not
+        // just the wrapper command — and nothing outlives the dry-run.
         //
         // stdout/stderr are DISCARDED, not captured: returning the untrusted child's
         // output would be an exfiltration channel (a handler that reads a host file and
         // prints it would surface its contents in the outcome). The verdict comes only
         // from the structured result file the harness writes. Discarding also means no
         // pipe a leaked descendant could hold open to defeat the timeout.
-        proc = Bun.spawn(argv, {
+        proc = spawnChild(argv, {
           cwd: dir,
           env,
           stdin: new Blob([nonce]),
-          stdout: "ignore",
-          stderr: "ignore",
-          detached: true,
         });
 
         // Race the child's exit against the hard timeout and a memory guard.
@@ -410,3 +548,9 @@ export function createSubprocessDryRunner(
     },
   };
 }
+
+/**
+ * Back-compat alias of {@link createDryRunner} — the original Spec 70 P3 export.
+ * Identical behaviour (including the optional `runner` tier selection).
+ */
+export const createSubprocessDryRunner = createDryRunner;


### PR DESCRIPTION
## Summary

Part 2 of #522 (Spec 70 P5) — the §4 escalation tier + hardened resource bounds for `@linchkit/cap-dry-run`. Companion to #530 (`strictExecutionDryRun` flag, disjoint files).

### Runner tier config

`createDryRunner({ runner: "subprocess" | "microvm" })` (default `"subprocess"`). The launcher — harness files, argv, limits, nonce protocol — is **identical** across tiers; only the spawn wrapper differs (Spec 70 §4 line "the launcher interface is unchanged"). `createSubprocessDryRunner` stays as a back-compat alias.

### microVM tier (gVisor kernel boundary)

- `docker run --runtime=runsc` with `--network=none`, `--read-only` + a single writable bind of the per-run temp dir (same absolute path inside/out), cgroup `--memory`/`--memory-swap` as this tier's OS-enforced cap, `--cap-drop=ALL`, `no-new-privileges`, `--pids-limit=128`, per-run `--name` so reaping can `docker kill` the container (killing the attached client alone does not stop it).
- **Fail closed, never degrade**: requires `docker` + `runsc` on PATH AND the daemon's runtime table to list `runsc` (probed via injectable seam, memoized per runner). Any miss → `infra_error`, zero spawns. A configured stronger tier silently falling back to subprocess would misreport the isolation actually applied.
- Direct `runsc do` deliberately rejected as a mechanism: it overlays the host root, so the harness's result-file write is discarded (every run would be `infra_error`); disabling the overlay would leave the host fs writable — weaker than the subprocess tier. Documented in `sandbox.ts`.

### OS-enforced memory limit (subprocess tier, Linux)

- `prlimit --data=<bytes> --` wraps **outside** the bwrap sandbox (rlimits inherit across exec; the limit binary stays outside the confined fs view).
- `RLIMIT_DATA` over `RLIMIT_AS`: JS engines reserve multi-GiB `PROT_NONE` address space at startup, so an `--as` cap at the dry-run budget would stop the child from even launching. No `sh -c 'ulimit …'` wrapper — argv arrays only, nothing shell-interpolated.
- The RSS-polling guard stays on all tiers/platforms as defense in depth and keeps the precise `oom` classification (macOS has no OS memory primitive under `sandbox-exec`).

### Tests

12 new host-independent tests (`__tests__/runner-tier.test.ts`, fake `SandboxEnv` + recording fake spawn — nothing executes): fail-closed paths spawn nothing, microvm argv shape + harness parity with the subprocess tier, prlimit presence/absence, default tier unchanged. 24 pre-existing real-sandbox smokes pass unchanged. Full `bun run test` green; `bun run check` + `bun run typecheck` clean.

### Honest caveat

The microvm spawn path is argv-verified only — it has never run against a live `runsc` daemon. `--memory` semantics under runsc and the `oven/bun:1` default image should be verified on a real gVisor host before relying on the tier in production (tracked in the commit message + README).

## Changeset

Minor bump for `@linchkit/cap-dry-run`.

Closes #522 together with #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)