### PR TITLE
fix(core): keep the browser-safe client barrel free of Node built-ins

### DIFF
--- a/.changeset/core-barrel-browser-safe.md
+++ b/.changeset/core-barrel-browser-safe.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/core": patch
+---
+
+fix: keep the browser-safe client barrel free of Node built-ins — `release-compatibility.ts` (re-exported by `exports/client/migration.ts`) no longer imports `node:fs/promises` / `node:path` at module top level. The two filesystem entry points (`checkReleaseCompatibility`, `analyzeFile`) load them lazily, and `crossPlatformBasename` is a pure string implementation. Importing `@linchkit/core` in the browser previously threw "Module fs/promises has been externalized" and blanked the UI.

--- a/packages/core/src/migration/release-compatibility.ts
+++ b/packages/core/src/migration/release-compatibility.ts
@@ -11,8 +11,10 @@
  *   breaking — simultaneous incompatible changes; cannot blue-green deploy
  */
 
-import { readdir, readFile } from "node:fs/promises";
-import { join, posix as posixPath, win32 as win32Path } from "node:path";
+// NO top-level node:fs / node:path imports: this module is re-exported by the
+// browser-safe client barrel (exports/client/migration.ts) for its pure SQL
+// analysis, so Node built-ins are loaded lazily inside the two filesystem
+// entry points (checkReleaseCompatibility / analyzeFile) instead.
 import { splitStatements } from "./sql-splitter";
 
 export { splitStatements } from "./sql-splitter";
@@ -25,7 +27,11 @@ export { splitStatements } from "./sql-splitter";
  * Exported for unit tests.
  */
 export function crossPlatformBasename(filePath: string): string {
-  return filePath.includes("\\") ? win32Path.basename(filePath) : posixPath.basename(filePath);
+  // Pure string implementation (no node:path — see module doc): the last
+  // segment after either separator. Migration filenames never contain a
+  // literal backslash, so treating both separators uniformly is safe.
+  const idx = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+  return idx === -1 ? filePath : filePath.slice(idx + 1);
 }
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -334,6 +340,8 @@ export function analyzeMigrationSql(sql: string, fileName = "<inline>"): Migrati
 export async function checkReleaseCompatibility(
   migrationsDir: string,
 ): Promise<ReleaseCompatibilityResult> {
+  const { readdir, readFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
   let files: string[];
   try {
     const entries = await readdir(migrationsDir);
@@ -363,6 +371,7 @@ export async function checkReleaseCompatibility(
 
 /** Analyze a specific migration file by path. */
 export async function analyzeFile(filePath: string): Promise<MigrationAnalysis> {
+  const { readFile } = await import("node:fs/promises");
   const sql = await readFile(filePath, "utf-8");
   const name = crossPlatformBasename(filePath);
   return analyzeMigrationSql(sql, name);


### PR DESCRIPTION
## Summary

Found by live UI testing this session: `bun run dev:ui` rendered a **blank page** — importing `@linchkit/core` (the documented browser-safe entry) in the browser threw `Module "fs/promises" has been externalized for browser compatibility` and killed the bundle.

Root cause: `exports/client/migration.ts` re-exports **value** bindings (`checkReleaseCompatibility`, `analyzeFile`, pure SQL analyzers) from `migration/release-compatibility.ts`, whose top-level `node:fs/promises` / `node:path` imports get evaluated when the client barrel loads. Splitting the barrel wouldn't help — re-exporting anything from the module evaluates the whole module — so the module itself must stay Node-free at top level:

- `checkReleaseCompatibility` / `analyzeFile` now lazily `await import("node:fs/promises")` (+ `node:path`) inside the function bodies — both were already async; behavior unchanged for CLI/server callers (`packages/cli/src/commands/release-check.ts`).
- `crossPlatformBasename` reimplemented as a pure string op (last segment after either separator). Migration filenames never contain a literal backslash, so uniform separator handling is safe; all 4 existing unit cases pass unchanged.
- Module doc comment records the constraint so the next top-level fs import doesn't silently regress browser support.

## Verification

- Live: rebuilt `packages/core` dist → UI loads, Workspace/entity/evolution pages render, full purchase-request submit→approve flow driven in the browser.
- `bun run test` green; `bun run check` + `bun run typecheck` clean.

## Changeset

Patch bump for `@linchkit/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)