### PR TITLE
fix(adapter-server): wire OntologyRegistry + aiConfig into the dev-server boot path

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-server-http-boot.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-server-http-boot.test.ts
@@ -31,6 +31,7 @@ import { describe, expect, it } from "bun:test";
 import { capChatter } from "@linchkit/cap-chatter";
 import type {
   ActionDefinition,
+  AIService,
   CapabilityDefinition,
   EntityDefinition,
   RelationDefinition,
@@ -264,5 +265,51 @@ describe("dev-server HTTP boot (in-process, DB-free, port-free)", () => {
     // State machine + relation contributed by the synthetic capability are bundled.
     expect(body.data.states.some((s) => s.name === "smoke_project_lifecycle")).toBe(true);
     expect(body.data.relations.some((r) => r.name === "smoke_project_to_milestones")).toBe(true);
+  });
+
+  it("wires the OntologyRegistry into ontology-dependent AI routes", async () => {
+    // Regression guard: `dev.ts`/`createDevApp` never built an OntologyRegistry
+    // (only the `linch dev` boot path did), so `POST /api/ai/resolve-schema-intent`
+    // answered 503 "Ontology registry is not available — …" on `bun run dev:server`.
+    //
+    // The route checks AI availability BEFORE the ontology gate, so a
+    // configured-but-deterministic AI stub is needed to reach (and prove past)
+    // that gate — no real LLM is called: the stub returns a canned `no_match`
+    // resolution, mirroring `ai-resolve-schema-intent.test.ts`'s fake service.
+    const stubAi = {
+      configured: true,
+      defaultProvider: "fake",
+      providerNames: ["fake"],
+      complete: async () => ({
+        content: JSON.stringify({
+          kind: "no_match",
+          explanation: "Deterministic stub — no rule drafted.",
+        }),
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        model: "fake-model",
+        provider: "fake",
+        duration: 1,
+      }),
+    } as unknown as AIService;
+
+    const app = createDevApp(configuredCapabilities(), { cors: false, aiService: stubAi }).app;
+    const res = await app.handle(
+      new Request("http://local.test/api/ai/resolve-schema-intent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "Block archiving projects that still have milestones" }),
+      }),
+    );
+
+    const body = (await res.json()) as {
+      outcome?: string;
+      error?: { message?: string };
+    };
+    // Before the fix: 503 + "Ontology registry is not available — schema intent
+    // resolution requires the unified Ontology layer." With the registry wired,
+    // the resolver runs end-to-end and returns a resolved outcome (200).
+    expect(body.error?.message ?? "").not.toContain("Ontology registry is not available");
+    expect(res.status).toBe(200);
+    expect(body.outcome).toBe("no_match");
   });
 });

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -104,6 +104,9 @@ export function buildDevOntologyRegistry(
     views: contributions.views,
     links: relationRegistry,
     flows: flowRegistry,
+    // Raw relation definitions feed the dependency graph / impact analysis
+    // (Spec 67); `links` above only serves relation lookups.
+    relationDefs: contributions.relations,
   });
 }
 

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -18,7 +18,12 @@
  * so the boot smoke test and the real dev server share one wiring path.
  */
 
-import type { CapabilityDefinition } from "@linchkit/core";
+import type { CapabilityDefinition, OntologyRegistry } from "@linchkit/core";
+import {
+  createFlowRegistry,
+  createOntologyRegistry,
+  createRelationRegistry,
+} from "@linchkit/core/server";
 import {
   type AssembleDevSchemaOptions,
   type AssembledDevSchema,
@@ -55,8 +60,52 @@ export interface CreateDevAppOptions
         | "eventBus"
         | "dataProvider"
         | "onchangeEvaluator"
+        | "ontologyRegistry"
       >
     > {}
+
+/**
+ * Build the unified OntologyRegistry over an assembled dev schema.
+ *
+ * Mirrors the `linch dev` boot path's `createOntologyRegistry({...})` call
+ * (packages/cli/src/commands/dev-wiring.ts) so the dev-server entry exposes
+ * the same semantic layer. Without it, ontology-dependent endpoints (e.g.
+ * `POST /api/ai/resolve-schema-intent`) answer 503 "Ontology registry is not
+ * available" and Phase 3 compatibility validation silently skips.
+ *
+ * Inputs reuse what the assembly already has in scope: the runtime's
+ * EntityRegistry + the executor's ActionRegistry, plus the flattened
+ * capability contributions (rules/states/views). Relation and flow registries
+ * are built here from the contributed definitions — registration mirrors the
+ * CLI's build-registries.ts, so an invalid relation fails loud at boot on
+ * both paths. `handlers`/`interfaces` registries are not assembled on this
+ * DB-free path; both deps are optional and omitted.
+ */
+export function buildDevOntologyRegistry(
+  assembled: Pick<AssembledDevSchema, "runtime" | "contributions">,
+): OntologyRegistry {
+  const { runtime, contributions } = assembled;
+
+  const relationRegistry = createRelationRegistry();
+  for (const relation of contributions.relations) {
+    relationRegistry.register(relation);
+  }
+
+  const flowRegistry = createFlowRegistry();
+  for (const flow of contributions.flows) {
+    flowRegistry.register(flow);
+  }
+
+  return createOntologyRegistry({
+    schemas: runtime.entityRegistry,
+    actions: runtime.executor.registry,
+    rules: contributions.rules,
+    states: contributions.states,
+    views: contributions.views,
+    links: relationRegistry,
+    flows: flowRegistry,
+  });
+}
 
 /** Result of {@link createDevApp}: the Elysia app plus the assembled schema. */
 export interface DevApp {
@@ -93,6 +142,10 @@ export function createDevApp(
   const assembled = assembleDevSchema(capabilities, { aiService });
   const { schema, runtime, contributions, onchangeEvaluator } = assembled;
 
+  // Unified semantic layer — same construction as dev.ts and the `linch dev`
+  // boot path, so ontology-dependent routes work on the in-process app too.
+  const ontologyRegistry = buildDevOntologyRegistry(assembled);
+
   // Forward caller-supplied ServerOptions first, then the fields this factory
   // derives from the assembled runtime — which always win (and are excluded
   // from CreateDevAppOptions so callers cannot override them). This mirrors
@@ -123,6 +176,7 @@ export function createDevApp(
     eventBus: runtime.eventBus,
     dataProvider: runtime.dataProvider,
     onchangeEvaluator,
+    ontologyRegistry,
   });
 
   return { app, assembled };

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -10,6 +10,7 @@ import { resolve } from "node:path";
 import { consoleLogger } from "@linchkit/core/server";
 import { assembleDevSchema } from "./assemble-schema";
 import { loadConfig } from "./config-loader";
+import { buildDevOntologyRegistry } from "./dev-app";
 import { createServer } from "./server";
 
 // ── Resolve project root ────────────────────────────────
@@ -107,6 +108,13 @@ if (runtime.dataProvider instanceof InMemoryStore) {
 const allEntities = assembled.allEntities;
 const allActions = assembled.allActions;
 
+// Unified semantic layer over the assembled registries — mirrors the
+// `linch dev` boot path (dev-wiring.ts). Without it, ontology-dependent
+// endpoints (e.g. POST /api/ai/resolve-schema-intent) answer 503 and Phase 3
+// compatibility validation silently skips.
+const ontologyRegistry = buildDevOntologyRegistry(assembled);
+consoleLogger.info(`OntologyRegistry built (${ontologyRegistry.listEntities().length} schemas)`);
+
 const port = config.server?.port ?? 3001;
 const host = config.server?.host ?? "0.0.0.0";
 
@@ -127,6 +135,7 @@ const server = createServer(graphqlSchema, {
   flows: [],
   dataProvider: runtime.dataProvider,
   onchangeEvaluator,
+  ontologyRegistry,
 });
 
 server.listen(port);

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -130,6 +130,10 @@ const server = createServer(graphqlSchema, {
   capabilities: config.capabilities,
   rules: capContributions.rules,
   aiService: runtime.ai,
+  // The assistant + model-resolving AI routes gate on BOTH aiService AND
+  // aiConfig (ai-api.ts) — without this the boot summary says "AI: zhipu"
+  // while POST /api/ai/assistant answers 503 "AI service is not configured".
+  aiConfig: config.ai,
   linchKitConfig: config,
   states: capContributions.states,
   flows: [],


### PR DESCRIPTION
## Summary

Found by live UI testing this session: on `bun run dev:server`, the Evolution page's NL→draft-rule box answers **503 "Ontology registry is not available — schema intent resolution requires the unified Ontology layer"**, and Phase 3 compatibility validation silently skips. The `linch dev` CLI path builds the registry (`dev-wiring.ts`, #485) — the adapter-server dev entry was left behind.

- **`dev-app.ts`**: new exported `buildDevOntologyRegistry(assembled)` — one shared construction so the two entries can't diverge again. Inputs mirror the CLI exactly: `schemas: runtime.entityRegistry`, `actions: runtime.executor.registry`, contributed `rules`/`states`/`views`, plus relation + flow registries populated from contributions (registration mirrors the CLI's `build-registries.ts`, so an invalid relation fails loud at boot on both paths). `createDevApp` passes it to `createServer` and adds it to the caller-override exclusion list.
- **`dev.ts`**: builds the same registry, passes `ontologyRegistry` into the existing `createServer(...)` call, logs `OntologyRegistry built (N schemas)` at boot (dev-wiring style).
- **Test**: new dev-server boot test — with a stubbed configured AI provider (canned `no_match`, no real LLM), `POST /api/ai/resolve-schema-intent` via `app.handle()` no longer returns the ontology-unavailable 503. Verified red→green by temporarily removing the option.

## Known parity gap (documented, optional deps)

`handlers` / `interfaces` ontology facets stay empty on this DB-free assembly path — `assemble-schema.ts` doesn't surface those registries. Both are optional in `OntologyRegistryDeps`; closing it would mean touching the assembly surface and is left as a follow-up if those facets matter here.

## Verification

`bun run test` green (adapter-server 781 pass / 0 fail); `bun run check` + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dev server now properly supports ontology-gated AI routes and schema intent resolution.
  * AI configuration is now correctly integrated into the dev server setup.

* **Tests**
  * Added regression test verifying AI route functionality with ontology gating works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->