### PR TITLE
fix(adapter-ui): resolve relation/object cell values in list views

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/auto-list-columns.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/auto-list-columns.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the auto-list column cell rendering of relation-resolver fields.
+ *
+ * Relation columns (e.g. `department`) have no entry in `schema.fields`, so
+ * the cell renderer falls through to the schemaless path. The row value is an
+ * expanded object (`{ id, name }` from `department { id name }`), which used
+ * to be rendered via `String(value)` → "[object Object]". It must now resolve
+ * the human-readable label exactly like the detail view does, or fall back to
+ * an em-dash placeholder.
+ *
+ * The test setup is logic-only (no DOM): we invoke the ColumnDef `cell`
+ * function directly with a minimal CellContext and inspect the ReactNode it
+ * returns (plain string for resolved labels, a <span> element for the
+ * placeholder).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EntityDefinition } from "@linchkit/core/types";
+import type { ColumnDef } from "@tanstack/react-table";
+import { buildColumns } from "../src/components/auto-list/columns";
+
+type DataRow = Record<string, unknown>;
+
+/** Minimal schema: `department` is intentionally NOT among the fields. */
+const schema = {
+  name: "purchase_request",
+  label: "Purchase Request",
+  fields: {
+    title: { type: "string", label: "Title" },
+  },
+} as unknown as EntityDefinition;
+
+function buildTestColumns(): ColumnDef<DataRow>[] {
+  return buildColumns({
+    fields: [{ field: "title" }, { field: "department" }],
+    schema,
+    rowActions: [],
+  });
+}
+
+/** Invoke a column's cell renderer with a minimal CellContext stand-in. */
+function renderCell(col: ColumnDef<DataRow>, value: unknown, original: DataRow = {}): unknown {
+  const cell = col.cell as (ctx: {
+    getValue: () => unknown;
+    row: { original: DataRow };
+  }) => unknown;
+  expect(typeof cell).toBe("function");
+  return cell({ getValue: () => value, row: { original } });
+}
+
+/** Extract the rendered children of a React element-shaped result. */
+function elementChildren(result: unknown): unknown {
+  return (result as { props: { children?: unknown } }).props.children;
+}
+
+describe("buildColumns relation cell rendering", () => {
+  const departmentCol = buildTestColumns()[1];
+  if (!departmentCol) throw new Error("department column missing");
+
+  test("resolves an expanded relation object to its display name", () => {
+    const result = renderCell(departmentCol, { id: "d1", name: "Engineering" }, { id: "r1" });
+    expect(result).toBe("Engineering");
+  });
+
+  test("resolves an array relation to a joined label list", () => {
+    const result = renderCell(departmentCol, [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ]);
+    expect(result).toBe("Alpha, Beta");
+  });
+
+  test("resolves a translatable display field instead of stringifying it", () => {
+    const result = renderCell(departmentCol, {
+      id: "d1",
+      name: { en: "Engineering", "zh-CN": "工程部" },
+    });
+    // Locale comes from i18next.language (uninitialized in tests → en/first fallback).
+    expect(result).toBe("Engineering");
+  });
+
+  test("renders a placeholder for null / undefined values", () => {
+    for (const value of [null, undefined, ""]) {
+      const result = renderCell(departmentCol, value);
+      expect(elementChildren(result)).toBe("—");
+    }
+  });
+
+  test("renders a placeholder (not String(object)) for unresolvable objects", () => {
+    const result = renderCell(departmentCol, { nested: { deep: 1 } });
+    expect(elementChildren(result)).toBe("—");
+  });
+
+  test('never renders the literal "[object Object]"', () => {
+    const inputs: unknown[] = [
+      { id: "d1", name: "Engineering" },
+      { id: "d1" },
+      { nested: { deep: 1 } },
+      [{ id: "a" }, {}],
+      {},
+    ];
+    for (const value of inputs) {
+      const result = renderCell(departmentCol, value);
+      if (typeof result === "string") {
+        expect(result).not.toContain("[object Object]");
+      }
+    }
+  });
+
+  test("still stringifies scalar values for schemaless columns", () => {
+    expect(renderCell(departmentCol, "Finance")).toBe("Finance");
+    expect(renderCell(departmentCol, 42)).toBe("42");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/relation-utils.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/relation-utils.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the shared relation display-label helpers.
+ *
+ * `resolveDisplayLabel` is the chokepoint that prevents the entity list from
+ * rendering "[object Object]" for relation-resolver columns (e.g.
+ * `department { id name }`): it applies the same title-field resolution the
+ * detail-view relation widgets use (getRecordLabel / ref-widget).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getRecordLabel, resolveDisplayLabel } from "../src/components/widgets/relation-utils";
+
+describe("getRecordLabel", () => {
+  test("uses the explicit title field when present", () => {
+    expect(getRecordLabel({ id: "d1", code: "ENG", name: "Engineering" }, "code")).toBe("ENG");
+  });
+
+  test("guesses a common title field when none is given", () => {
+    expect(getRecordLabel({ id: "d1", name: "Engineering" }, undefined)).toBe("Engineering");
+  });
+
+  test("falls back to the record id when no title candidate exists", () => {
+    expect(getRecordLabel({ id: "d1", budget: 100 }, undefined)).toBe("d1");
+  });
+});
+
+describe("resolveDisplayLabel", () => {
+  test("resolves a relation envelope to its name (the live list-view bug)", () => {
+    // The list query fetches `department { id name }` → the cell value is
+    // this object; the detail view shows "Engineering" for the same field.
+    expect(resolveDisplayLabel({ id: "d1", name: "Engineering" })).toBe("Engineering");
+  });
+
+  test("prefers the configured titleField over guessed candidates", () => {
+    const value = { id: "d1", code: "ENG", name: "Engineering" };
+    expect(resolveDisplayLabel(value, { titleField: "code" })).toBe("ENG");
+  });
+
+  test("ignores a titleField that is absent from the record", () => {
+    const value = { id: "d1", name: "Engineering" };
+    expect(resolveDisplayLabel(value, { titleField: "code" })).toBe("Engineering");
+  });
+
+  test("resolves a translatable title field by locale", () => {
+    const value = { id: "d1", name: { en: "Engineering", "zh-CN": "工程部" } };
+    expect(resolveDisplayLabel(value, { locale: "zh-CN" })).toBe("工程部");
+    expect(resolveDisplayLabel(value, { locale: "en" })).toBe("Engineering");
+  });
+
+  test("resolves a bare translatable locale map", () => {
+    const value = { en: "Hello", "zh-CN": "你好" };
+    expect(resolveDisplayLabel(value, { locale: "zh-CN" })).toBe("你好");
+    // Base-language fallback: "zh" matches "zh-CN".
+    expect(resolveDisplayLabel(value, { locale: "zh" })).toBe("你好");
+    // Unknown locale falls back to English.
+    expect(resolveDisplayLabel(value, { locale: "fr" })).toBe("Hello");
+  });
+
+  test("falls back to the first locale entry when no en value exists", () => {
+    expect(resolveDisplayLabel({ "zh-CN": "你好" }, { locale: "fr" })).toBe("你好");
+  });
+
+  test("joins labels for arrays of related records", () => {
+    const value = [
+      { id: "a", name: "Alpha" },
+      { id: "b", name: "Beta" },
+    ];
+    expect(resolveDisplayLabel(value)).toBe("Alpha, Beta");
+  });
+
+  test("falls back to the record id when no title candidate resolves", () => {
+    expect(resolveDisplayLabel({ id: "d1", budget: 100 })).toBe("d1");
+    expect(resolveDisplayLabel({ id: "d1", name: null })).toBe("d1");
+  });
+
+  test("returns null for unresolvable values instead of String(object)", () => {
+    expect(resolveDisplayLabel(null)).toBeNull();
+    expect(resolveDisplayLabel(undefined)).toBeNull();
+    expect(resolveDisplayLabel({ nested: { deep: 1 } })).toBeNull();
+    expect(resolveDisplayLabel([])).toBeNull();
+    expect(resolveDisplayLabel({})).toBeNull();
+  });
+
+  test("stringifies primitives", () => {
+    expect(resolveDisplayLabel("plain")).toBe("plain");
+    expect(resolveDisplayLabel(42)).toBe("42");
+    expect(resolveDisplayLabel(false)).toBe("false");
+  });
+
+  test('never produces "[object Object]" for any object-shaped input', () => {
+    const inputs: unknown[] = [
+      { id: "d1", name: "Engineering" },
+      { id: "d1" },
+      { nested: { deep: 1 } },
+      [{ id: "a" }, { foo: "bar" }],
+      { en: "Hi" },
+      {},
+    ];
+    for (const input of inputs) {
+      const label = resolveDisplayLabel(input);
+      expect(label ?? "").not.toContain("[object Object]");
+    }
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/relation-utils.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/relation-utils.test.ts
@@ -102,3 +102,21 @@ describe("resolveDisplayLabel", () => {
     }
   });
 });
+
+describe("resolveTranslatableMap false positives (review follow-up)", () => {
+  test("an arbitrary all-string object without locale-shaped keys returns null", () => {
+    expect(resolveDisplayLabel({ code: "ENG", name1: "Engineering" })).toBeNull();
+  });
+
+  test("an id-less object with non-locale keys is not rendered as a locale map", () => {
+    expect(
+      resolveDisplayLabel({ department_code: "ENG", description: "Engineering team" }),
+    ).toBeNull();
+  });
+
+  test("genuine locale maps still resolve after the key-shape guard", () => {
+    expect(resolveDisplayLabel({ en: "Engineering", "zh-CN": "工程部" }, { locale: "zh-CN" })).toBe(
+      "工程部",
+    );
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/columns.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/columns.tsx
@@ -26,6 +26,7 @@ import type React from "react";
 import { type EditingCell, isFieldTypeEditable } from "../../hooks/use-inline-edit";
 import type { FieldOverlayRecord, OverlayFieldType } from "../../lib/overlay-types";
 import { FieldDisplay } from "../field-renderer";
+import { resolveDisplayLabel } from "../widgets/relation-utils";
 import { InlineEditCell } from "./inline-edit-cell";
 import { StatusBadge } from "./status-badge";
 
@@ -136,7 +137,9 @@ export function buildColumns(opts: BuildColumnsOptions): ColumnDef<DataRow>[] {
         if (fieldDef) {
           return <FieldDisplay field={vf} value={value} fieldDef={fieldDef} />;
         }
-        return String(value ?? "");
+        // No schema field definition — typically a relation resolver field
+        // (e.g. `department { id name }`), whose value is an object or array.
+        return formatSchemalessCellValue(value);
       },
       enableSorting: vf.sortable ?? false,
       size: typeof vf.width === "number" ? vf.width : undefined,
@@ -296,6 +299,29 @@ function resolveOverlayColumnLabel(overlay: FieldOverlayRecord): string {
 }
 
 /**
+ * Format a cell value for a column that has no schema field definition
+ * (typically a relation-generated resolver field such as `department`).
+ *
+ * Objects and arrays are resolved to a human-readable label using the same
+ * title-field logic the detail-view relation widgets use; unresolvable
+ * values fall back to a muted em-dash. This must never render the
+ * `String(object)` form "[object Object]".
+ */
+function formatSchemalessCellValue(value: unknown): React.ReactNode {
+  if (value === null || value === undefined || value === "") {
+    return <span className="text-muted-foreground">&mdash;</span>;
+  }
+  if (typeof value !== "object") {
+    return String(value);
+  }
+  const label = resolveDisplayLabel(value, { locale: i18next.language });
+  if (label !== null && label !== "") {
+    return label;
+  }
+  return <span className="text-muted-foreground">&mdash;</span>;
+}
+
+/**
  * Format an overlay cell value for display based on field type.
  */
 function formatOverlayCellValue(value: unknown, fieldType: OverlayFieldType): React.ReactNode {
@@ -318,7 +344,9 @@ function formatOverlayCellValue(value: unknown, fieldType: OverlayFieldType): Re
         </span>
       );
     default:
-      return String(value);
+      // Guard against object-shaped values sneaking into scalar overlay
+      // columns — never render "[object Object]".
+      return formatSchemalessCellValue(value);
   }
 }
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/relation-utils.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/relation-utils.ts
@@ -39,10 +39,16 @@ export interface ResolveDisplayLabelOptions {
  * to a single string for the given locale. Returns null when the object is
  * not a pure string-valued locale map.
  */
+/** Keys that plausibly are BCP-47-ish locale codes ("en", "zh-CN", "pt-BR"). */
+const LOCALE_KEY_RE = /^[a-z]{2,3}(?:-[A-Za-z0-9]+)?$/;
+
 function resolveTranslatableMap(map: Record<string, unknown>, locale?: string): string | null {
   const keys = Object.keys(map);
   if (keys.length === 0) return null;
-  if (!keys.every((key) => typeof map[key] === "string")) return null;
+  // Every key must LOOK like a locale code, not merely map to a string —
+  // otherwise arbitrary all-string objects ({ code: "ENG", name: "..." })
+  // would be misread as locale maps and render a meaningless first value.
+  if (!keys.every((key) => LOCALE_KEY_RE.test(key) && typeof map[key] === "string")) return null;
   const values = map as Record<string, string>;
   if (locale) {
     const exact = values[locale];

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/relation-utils.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/relation-utils.ts
@@ -25,3 +25,75 @@ export function getRecordLabel(record: RelatedRecord, titleField: string | undef
   const guessed = guessTitleField(record);
   return String(record[guessed] ?? record.id);
 }
+
+/** Options for `resolveDisplayLabel`. */
+export interface ResolveDisplayLabelOptions {
+  /** Preferred title field (e.g. schema `presentation.titleField`). */
+  titleField?: string;
+  /** Active UI locale, used to resolve translatable locale maps. */
+  locale?: string;
+}
+
+/**
+ * Resolve a translatable locale map (e.g. `{ en: "...", "zh-CN": "..." }`)
+ * to a single string for the given locale. Returns null when the object is
+ * not a pure string-valued locale map.
+ */
+function resolveTranslatableMap(map: Record<string, unknown>, locale?: string): string | null {
+  const keys = Object.keys(map);
+  if (keys.length === 0) return null;
+  if (!keys.every((key) => typeof map[key] === "string")) return null;
+  const values = map as Record<string, string>;
+  if (locale) {
+    const exact = values[locale];
+    if (exact !== undefined) return exact;
+    // Fall back to a base-language match (e.g. "zh" matches "zh-CN").
+    const base = locale.split("-")[0];
+    if (base) {
+      const baseMatch = keys.find((key) => key === base || key.startsWith(`${base}-`));
+      if (baseMatch !== undefined) return values[baseMatch] ?? null;
+    }
+  }
+  if (values.en !== undefined) return values.en;
+  const first = keys[0];
+  return first !== undefined ? (values[first] ?? null) : null;
+}
+
+/**
+ * Resolve a human-readable label for an arbitrary field value.
+ *
+ * Handles, in order:
+ * - primitives → `String(value)`
+ * - arrays → comma-joined labels of resolvable items
+ * - related-record envelopes (`{ id, name/title/... }`) → same title-field
+ *   resolution the detail-view relation widgets use (`getRecordLabel`)
+ * - translatable locale maps (`{ en, "zh-CN", ... }`) → locale-aware pick
+ *
+ * Returns null when no meaningful label can be derived — never the
+ * `String(object)` form "[object Object]" — so callers can render their own
+ * placeholder.
+ */
+export function resolveDisplayLabel(
+  value: unknown,
+  opts: ResolveDisplayLabelOptions = {},
+): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "object") return String(value);
+  if (Array.isArray(value)) {
+    const labels = value
+      .map((item) => resolveDisplayLabel(item, opts))
+      .filter((label): label is string => label !== null && label !== "");
+    return labels.length > 0 ? labels.join(", ") : null;
+  }
+  const record = value as Record<string, unknown>;
+  if ("id" in record) {
+    const related = record as RelatedRecord;
+    const titleField =
+      opts.titleField && opts.titleField in related ? opts.titleField : guessTitleField(related);
+    // The title value may itself be a translatable map — resolve recursively.
+    const label = resolveDisplayLabel(related[titleField], { locale: opts.locale });
+    if (label !== null && label !== "") return label;
+    return related.id !== null && related.id !== undefined ? String(related.id) : null;
+  }
+  return resolveTranslatableMap(record, opts.locale);
+}


### PR DESCRIPTION
## Summary

Found by live browser testing: the entity list view rendered **"[object Object]"** for the `department` column on every row, while the record detail view rendered the same field correctly as "Engineering".

Root cause: `entity-list.tsx`'s query deliberately expands relation-resolver columns with subfield selection (`department { id name }`), so the row value is a relation envelope `{ id, name }`. But relation-resolver fields have no `schema.fields` entry, so `buildColumns` (auto-list/columns.tsx) fell through to the bare `String(value ?? "")` fallback.

## Fix (generic, not department-specific)

- **`widgets/relation-utils.ts`**: new exported `resolveDisplayLabel(value, { titleField?, locale? })` — a shared chokepoint built on the detail view's existing `getRecordLabel` semantics. Relation envelopes resolve via title-field candidates (`name`/`title`/`label`/`displayName`/`display_name`), recursing so translatable titles (`{ en, "zh-CN" }`) resolve per-locale; bare locale maps resolve locale → base language (`zh` matches `zh-CN`) → `en` → first entry; arrays comma-join item labels; opaque objects return `null` — never `String(object)`.
- **`auto-list/columns.tsx`**: the schemaless cell fallback (and the overlay-column `default:` branch) now formats through `formatSchemalessCellValue` — scalars pass through, objects resolve via the helper, unresolvable values render a muted em-dash. `[object Object]` is unreachable.

## Tests

Two new test files exercising the real `buildColumns` cell functions: the live bug case (`{id, name:"Engineering"}` → "Engineering"), translatable titles and locale maps with fallbacks, arrays, id fallback, em-dash placeholders for null/empty/opaque, scalar passthrough, and a "never contains [object Object]" sweep. Full `bun run test` green (adapter-ui 513 pass); `bun run check` + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)