### PR TITLE
fix(adapter-ui): normalize /health checks across all three server shapes

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/system-overview-health.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/system-overview-health.test.ts
@@ -50,3 +50,17 @@ describe("normalizeHealthChecks", () => {
     expect(normalizeHealthChecks(42)).toEqual([]);
   });
 });
+
+describe("normalizeHealthChecks hardening (review follow-up)", () => {
+  test("an unknown status string falls back to the ok-derived status", () => {
+    expect(normalizeHealthChecks({ db: { status: "weird", ok: false } })).toEqual([
+      { name: "db", status: "unhealthy", durationMs: 0 },
+    ]);
+  });
+
+  test("a primitive entry value yields a healthy default check", () => {
+    expect(normalizeHealthChecks({ process: true })).toEqual([
+      { name: "process", status: "healthy", durationMs: 0 },
+    ]);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/system-overview-health.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/system-overview-health.test.ts
@@ -1,0 +1,52 @@
+/**
+ * normalizeHealthChecks — the /health endpoint has three live shapes
+ * (adapter-server routes/health.ts); the System Overview page must render
+ * all of them without crashing ("health.checks.map is not a function" was
+ * thrown on the minimal object map).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { normalizeHealthChecks } from "../src/pages/system-overview";
+
+describe("normalizeHealthChecks", () => {
+  test("minimal object map (the live crash case) becomes one check per entry", () => {
+    const checks = normalizeHealthChecks({ process: { ok: true } });
+    expect(checks).toEqual([{ name: "process", status: "healthy", durationMs: 0 }]);
+  });
+
+  test("object map entry with ok=false maps to unhealthy", () => {
+    const checks = normalizeHealthChecks({ database: { ok: false, detail: "connect refused" } });
+    expect(checks).toEqual([
+      { name: "database", status: "unhealthy", message: "connect refused", durationMs: 0 },
+    ]);
+  });
+
+  test("probe-list array ({name, ok, detail}) maps ok to status and detail to message", () => {
+    const checks = normalizeHealthChecks([
+      { name: "database", ok: true },
+      { name: "memory", ok: false, detail: "rss high" },
+    ]);
+    expect(checks).toEqual([
+      { name: "database", status: "healthy", durationMs: 0 },
+      { name: "memory", status: "unhealthy", message: "rss high", durationMs: 0 },
+    ]);
+  });
+
+  test("rich registry array passes through status, message and durationMs", () => {
+    const rich = [{ name: "db", status: "degraded", message: "slow", durationMs: 42 }];
+    expect(normalizeHealthChecks(rich)).toEqual([
+      { name: "db", status: "degraded", message: "slow", durationMs: 42 },
+    ]);
+  });
+
+  test("array entries without a name get a positional fallback name", () => {
+    const checks = normalizeHealthChecks([{ ok: true }]);
+    expect(checks[0]?.name).toBe("check_0");
+  });
+
+  test("non-object inputs produce an empty list, never a crash", () => {
+    expect(normalizeHealthChecks(null)).toEqual([]);
+    expect(normalizeHealthChecks("healthy")).toEqual([]);
+    expect(normalizeHealthChecks(42)).toEqual([]);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
@@ -81,10 +81,12 @@ interface HealthResponse {
  * ("health.checks.map is not a function").
  */
 export function normalizeHealthChecks(raw: unknown): HealthCheck[] {
+  const VALID_STATUSES: ReadonlySet<string> = new Set(["healthy", "degraded", "unhealthy"]);
   const toCheck = (name: string, entry: unknown): HealthCheck => {
-    const obj = (entry ?? {}) as Record<string, unknown>;
-    const status =
-      typeof obj.status === "string"
+    const obj: Record<string, unknown> =
+      entry !== null && typeof entry === "object" ? (entry as Record<string, unknown>) : {};
+    const status: HealthCheck["status"] =
+      typeof obj.status === "string" && VALID_STATUSES.has(obj.status)
         ? (obj.status as HealthCheck["status"])
         : obj.ok === false
           ? "unhealthy"

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
@@ -71,6 +71,49 @@ interface HealthResponse {
   system?: SystemInfo;
 }
 
+/**
+ * Normalize the server's `/health` checks into the rich HealthCheck[] this
+ * page renders. The endpoint has three live shapes (routes/health.ts):
+ *   - rich registry: [{ name, status, durationMs, ... }]   → passthrough
+ *   - probe list:    [{ name, ok, detail? }]               → ok ⇒ status
+ *   - minimal map:   { process: { ok: true } }             → entries ⇒ checks
+ * Rendering `.map` directly on the raw value crashed on the minimal map
+ * ("health.checks.map is not a function").
+ */
+export function normalizeHealthChecks(raw: unknown): HealthCheck[] {
+  const toCheck = (name: string, entry: unknown): HealthCheck => {
+    const obj = (entry ?? {}) as Record<string, unknown>;
+    const status =
+      typeof obj.status === "string"
+        ? (obj.status as HealthCheck["status"])
+        : obj.ok === false
+          ? "unhealthy"
+          : "healthy";
+    return {
+      name,
+      status,
+      ...(typeof obj.message === "string"
+        ? { message: obj.message }
+        : typeof obj.detail === "string"
+          ? { message: obj.detail }
+          : {}),
+      durationMs: typeof obj.durationMs === "number" ? obj.durationMs : 0,
+    };
+  };
+  if (Array.isArray(raw)) {
+    return raw.map((entry, i) => {
+      const name = (entry as Record<string, unknown>)?.name;
+      return toCheck(typeof name === "string" ? name : `check_${i}`, entry);
+    });
+  }
+  if (raw && typeof raw === "object") {
+    return Object.entries(raw as Record<string, unknown>).map(([name, entry]) =>
+      toCheck(name, entry),
+    );
+  }
+  return [];
+}
+
 interface SettingsGeneral {
   version: string;
   uptime: number;
@@ -209,7 +252,10 @@ export function SystemOverviewPage() {
       const res = await fetch("/health");
       const data = await res.json().catch(() => null);
       if (data?.checks) {
-        setHealth(data as HealthResponse);
+        setHealth({
+          ...(data as Omit<HealthResponse, "checks">),
+          checks: normalizeHealthChecks(data.checks),
+        });
         setLastRefresh(new Date());
         return;
       }


### PR DESCRIPTION
## Summary

User-reported live crash on the System Overview page: **"health.checks.map is not a function"** (red error boundary).

The page renders `HealthCheck[]` (`{name, status, durationMs}`), but `routes/health.ts` emits three different shapes depending on configuration:

| Server state | `checks` shape |
|---|---|
| rich health registry | `[{ name, status, durationMs, ... }]` |
| probe list | `[{ name, ok, detail? }]` |
| minimal (dev server) | `{ process: { ok: true } }` ← **crashed the page** |

## Fix

`normalizeHealthChecks(raw)` converts any of the three into the rich array: object map → one check per entry, `ok=false` → `unhealthy`, `detail` → `message`, missing names get positional fallbacks, non-object inputs → `[]` (render nothing, never crash). `fetchHealth` normalizes before `setState`; the render path is unchanged.

Verified live: System Overview now renders "所有系统运行正常" with the Process check card on the dev server.

## Tests

6 unit tests covering every shape including the exact live crash case. Full `bun run test` green; `bun run check` + `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)