### PR TITLE
fix(adapter-ui): isolate registry unit tests from the shared singletons

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/panel-registry.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/panel-registry.test.ts
@@ -1,84 +1,69 @@
+/**
+ * Panel-registry unit tests run against an ISOLATED instance from
+ * createRecordPanelRegistry() — never against the shared module singleton.
+ * Capability packages (cap-chatter-ui, …) register into the singleton at
+ * import time and assert on it; clearing it here raced those assertions under
+ * bun's batched test run (#539).
+ */
+
 import { beforeEach, describe, expect, test } from "bun:test";
-import { clearRecordPanels, getRecordPanels, registerRecordPanel } from "../src/lib/panel-registry";
+import {
+  createRecordPanelRegistry,
+  type RecordPanelRegistration,
+  type RecordPanelRegistry,
+} from "../src/lib/panel-registry";
+
+function makePanel(overrides: Partial<RecordPanelRegistration> = {}): RecordPanelRegistration {
+  return {
+    id: "test-panel",
+    capability: "cap-test",
+    slot: "record-detail-tab",
+    label: "Test",
+    component: () => Promise.resolve({ default: (() => null) as React.FC }),
+    ...overrides,
+  };
+}
+
+let registry: RecordPanelRegistry;
 
 beforeEach(() => {
-  clearRecordPanels();
+  registry = createRecordPanelRegistry();
 });
 
 describe("panel-registry", () => {
   test("registers and retrieves a panel", () => {
-    registerRecordPanel({
-      id: "chatter",
-      capability: "cap-chatter",
-      slot: "record-detail-tab",
-      label: "Chatter",
-      order: 100,
-      component: () => Promise.resolve({ default: (() => null) as React.FC }),
-    });
-    const panels = getRecordPanels();
+    registry.register(makePanel({ id: "chatter", capability: "cap-chatter", label: "Chatter" }));
+    const panels = registry.getAll();
     expect(panels).toHaveLength(1);
     expect(panels[0]?.id).toBe("chatter");
   });
 
   test("sorts by order", () => {
-    registerRecordPanel({
-      id: "b",
-      capability: "cap-b",
-      slot: "record-detail-tab",
-      label: "B",
-      order: 200,
-      component: () => Promise.resolve({ default: (() => null) as React.FC }),
-    });
-    registerRecordPanel({
-      id: "a",
-      capability: "cap-a",
-      slot: "record-detail-tab",
-      label: "A",
-      order: 50,
-      component: () => Promise.resolve({ default: (() => null) as React.FC }),
-    });
-    const panels = getRecordPanels();
+    registry.register(makePanel({ id: "b", capability: "cap-b", label: "B", order: 200 }));
+    registry.register(makePanel({ id: "a", capability: "cap-a", label: "A", order: 50 }));
+    const panels = registry.getAll();
     expect(panels[0]?.id).toBe("a");
     expect(panels[1]?.id).toBe("b");
   });
 
   test("default order is 100", () => {
-    registerRecordPanel({
-      id: "no-order",
-      capability: "cap-x",
-      slot: "record-detail-tab",
-      label: "X",
-      component: () => Promise.resolve({ default: (() => null) as React.FC }),
-    });
-    registerRecordPanel({
-      id: "high-order",
-      capability: "cap-y",
-      slot: "record-detail-tab",
-      label: "Y",
-      order: 200,
-      component: () => Promise.resolve({ default: (() => null) as React.FC }),
-    });
-    const panels = getRecordPanels();
+    registry.register(makePanel({ id: "no-order", capability: "cap-x", label: "X" }));
+    registry.register(makePanel({ id: "high-order", capability: "cap-y", label: "Y", order: 200 }));
+    const panels = registry.getAll();
     expect(panels[0]?.id).toBe("no-order");
     expect(panels[1]?.id).toBe("high-order");
   });
 
   test("rejects duplicate id", () => {
-    registerRecordPanel({
-      id: "dup",
-      capability: "cap-x",
-      slot: "record-detail-tab",
-      label: "X",
-      component: () => Promise.resolve({ default: (() => null) as React.FC }),
-    });
+    registry.register(makePanel({ id: "dup", capability: "cap-x", label: "X" }));
     expect(() =>
-      registerRecordPanel({
-        id: "dup",
-        capability: "cap-y",
-        slot: "record-detail-tab",
-        label: "Y",
-        component: () => Promise.resolve({ default: (() => null) as React.FC }),
-      }),
+      registry.register(makePanel({ id: "dup", capability: "cap-y", label: "Y" })),
     ).toThrow(/already registered/);
+  });
+
+  test("instances are isolated from each other and from the shared singleton", () => {
+    registry.register(makePanel({ id: "iso" }));
+    const other = createRecordPanelRegistry();
+    expect(other.getAll()).toHaveLength(0);
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/panel-registry.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/panel-registry.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
+import type React from "react";
 import {
   createRecordPanelRegistry,
   type RecordPanelRegistration,

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/route-registry.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/route-registry.test.ts
@@ -1,5 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { _clearAdminRoutes, getAdminRoutes, registerAdminRoute } from "../src/lib/route-registry";
+/**
+ * Route-registry unit tests run against an ISOLATED instance from
+ * createAdminRouteRegistry() — never against the shared module singleton.
+ * Capability packages (cap-adapter-mcp UI, …) register into the singleton at
+ * import time and assert on it; clearing it here raced those assertions under
+ * bun's batched test run (#539).
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { type AdminRouteRegistry, createAdminRouteRegistry } from "../src/lib/route-registry";
 
 // ── Helpers ─────────────────────────────────────────────
 
@@ -17,50 +25,48 @@ function makeRoute(overrides: Record<string, unknown> = {}) {
 // ── Tests ───────────────────────────────────────────────
 
 describe("Admin Route Registry", () => {
+  let registry: AdminRouteRegistry;
+
   beforeEach(() => {
-    _clearAdminRoutes();
+    registry = createAdminRouteRegistry();
   });
 
-  afterEach(() => {
-    _clearAdminRoutes();
+  it("register adds a route", () => {
+    registry.register(makeRoute());
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.getAll()[0]?.id).toBe("test-route");
   });
 
-  it("registerAdminRoute adds a route", () => {
-    registerAdminRoute(makeRoute());
-    expect(getAdminRoutes()).toHaveLength(1);
-    expect(getAdminRoutes()[0]?.id).toBe("test-route");
-  });
+  it("getAll returns sorted by order", () => {
+    registry.register(makeRoute({ id: "c", order: 300 }));
+    registry.register(makeRoute({ id: "a", order: 10 }));
+    registry.register(makeRoute({ id: "b", order: 50 }));
 
-  it("getAdminRoutes returns sorted by order", () => {
-    registerAdminRoute(makeRoute({ id: "c", order: 300 }));
-    registerAdminRoute(makeRoute({ id: "a", order: 10 }));
-    registerAdminRoute(makeRoute({ id: "b", order: 50 }));
-
-    const routes = getAdminRoutes();
+    const routes = registry.getAll();
     expect(routes.map((r) => r.id)).toEqual(["a", "b", "c"]);
   });
 
   it("throws on duplicate ID", () => {
-    registerAdminRoute(makeRoute({ id: "dup" }));
-    expect(() => registerAdminRoute(makeRoute({ id: "dup" }))).toThrow(
+    registry.register(makeRoute({ id: "dup" }));
+    expect(() => registry.register(makeRoute({ id: "dup" }))).toThrow(
       'Admin route "dup" is already registered',
     );
   });
 
-  it("getAdminRoutes returns a copy, not a reference", () => {
-    registerAdminRoute(makeRoute());
-    const a = getAdminRoutes();
-    const b = getAdminRoutes();
+  it("getAll returns a copy, not a reference", () => {
+    registry.register(makeRoute());
+    const a = registry.getAll();
+    const b = registry.getAll();
     expect(a).not.toBe(b);
     expect(a).toEqual(b);
   });
 
   it("default order is 100", () => {
-    registerAdminRoute(makeRoute({ id: "low", order: 50 }));
-    registerAdminRoute(makeRoute({ id: "default" })); // no order → 100
-    registerAdminRoute(makeRoute({ id: "high", order: 200 }));
+    registry.register(makeRoute({ id: "low", order: 50 }));
+    registry.register(makeRoute({ id: "default" })); // no order → 100
+    registry.register(makeRoute({ id: "high", order: 200 }));
 
-    const routes = getAdminRoutes();
+    const routes = registry.getAll();
     expect(routes.map((r) => r.id)).toEqual(["low", "default", "high"]);
   });
 
@@ -73,14 +79,20 @@ describe("Admin Route Registry", () => {
       icon: "Terminal",
       order: 42,
     });
-    registerAdminRoute(route);
+    registry.register(route);
 
-    const [result] = getAdminRoutes();
+    const [result] = registry.getAll();
     expect(result?.id).toBe("full");
     expect(result?.capability).toBe("cap-mcp");
     expect(result?.path).toBe("/admin/mcp");
     expect(result?.label).toBe("mcp.title");
     expect(result?.icon).toBe("Terminal");
     expect(result?.order).toBe(42);
+  });
+
+  it("instances are isolated from each other and from the shared singleton", () => {
+    registry.register(makeRoute({ id: "iso" }));
+    const other = createAdminRouteRegistry();
+    expect(other.getAll()).toHaveLength(0);
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/panel-registry.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/panel-registry.ts
@@ -38,22 +38,43 @@ export interface RecordPanelRegistration {
   }>;
 }
 
-const registry: RecordPanelRegistration[] = [];
+/** A record-panel registry instance (register + sorted read). */
+export interface RecordPanelRegistry {
+  register(panel: RecordPanelRegistration): void;
+  getAll(): RecordPanelRegistration[];
+}
+
+/**
+ * Create an isolated panel registry. Unit tests construct their own instance —
+ * NEVER clear the shared module singleton below: capability packages
+ * (cap-chatter-ui, …) register into it at import time and assert on it, and
+ * under bun's batched test run a shared-singleton clear races those
+ * import-time registrations (#539).
+ */
+export function createRecordPanelRegistry(): RecordPanelRegistry {
+  const items: RecordPanelRegistration[] = [];
+  return {
+    register(panel: RecordPanelRegistration): void {
+      if (items.some((p) => p.id === panel.id)) {
+        throw new Error(`Record panel "${panel.id}" is already registered`);
+      }
+      items.push(panel);
+    },
+    getAll(): RecordPanelRegistration[] {
+      return [...items].sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+    },
+  };
+}
+
+/** The shared app-wide registry capability packages register into on import. */
+const defaultRegistry = createRecordPanelRegistry();
 
 /** Register a record-detail panel. Called at import time by capability UI packages. */
 export function registerRecordPanel(panel: RecordPanelRegistration): void {
-  if (registry.some((p) => p.id === panel.id)) {
-    throw new Error(`Record panel "${panel.id}" is already registered`);
-  }
-  registry.push(panel);
+  defaultRegistry.register(panel);
 }
 
 /** Get all registered panels, sorted by order. */
 export function getRecordPanels(): RecordPanelRegistration[] {
-  return [...registry].sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
-}
-
-/** Clear all registrations (for testing only). */
-export function clearRecordPanels(): void {
-  registry.length = 0;
+  return defaultRegistry.getAll();
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/route-registry.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/route-registry.ts
@@ -26,16 +26,42 @@ export interface AdminRouteRegistration {
   children?: AdminRouteRegistration[];
 }
 
-const registry: AdminRouteRegistration[] = [];
+/** An admin-route registry instance (register + sorted read). */
+export interface AdminRouteRegistry {
+  register(route: AdminRouteRegistration): void;
+  getAll(): AdminRouteRegistration[];
+}
+
+/**
+ * Create an isolated admin-route registry. Unit tests construct their own
+ * instance — NEVER clear the shared module singleton below: capability
+ * packages (cap-adapter-mcp UI, …) register into it at import time and assert
+ * on it, and under bun's batched test run a shared-singleton clear races
+ * those import-time registrations (#539).
+ */
+export function createAdminRouteRegistry(): AdminRouteRegistry {
+  const items: AdminRouteRegistration[] = [];
+  return {
+    register(route: AdminRouteRegistration): void {
+      if (items.some((r) => r.id === route.id)) {
+        throw new Error(`Admin route "${route.id}" is already registered`);
+      }
+      items.push(route);
+    },
+    getAll(): AdminRouteRegistration[] {
+      return [...items].sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+    },
+  };
+}
+
+/** The shared app-wide registry capability packages register into on import. */
+const defaultRegistry = createAdminRouteRegistry();
 
 /**
  * Register an admin route. Throws if a route with the same ID is already registered.
  */
 export function registerAdminRoute(route: AdminRouteRegistration): void {
-  if (registry.some((r) => r.id === route.id)) {
-    throw new Error(`Admin route "${route.id}" is already registered`);
-  }
-  registry.push(route);
+  defaultRegistry.register(route);
 }
 
 /**
@@ -43,13 +69,5 @@ export function registerAdminRoute(route: AdminRouteRegistration): void {
  * Returns a shallow copy to prevent external mutation.
  */
 export function getAdminRoutes(): AdminRouteRegistration[] {
-  return [...registry].sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
-}
-
-/**
- * Clear all registered routes. Only for testing.
- * @internal
- */
-export function _clearAdminRoutes(): void {
-  registry.length = 0;
+  return defaultRegistry.getAll();
 }


### PR DESCRIPTION
## Summary

Closes #539 — the CI flake currently blocking #536 and #537.

`capChatterUi > registers the chatter record-detail panel on import` and `capMcpUi > registers the MCP admin route on import` fail deterministically in the CI addons batch (bun 1.3.14) on any PR that adds adapter-ui test files, while passing locally (bun 1.2.18). Mechanism: `panel-registry.test.ts` cleared the **shared module singleton** in `beforeEach`; capability packages register into that singleton at import time and assert on it. Bun 1.3.x evaluates test-file module graphs before execution, so the clear lands between the import-time registration and the assertion. Local 1.2.18 loads-and-runs file by file and never reproduces.

## Fix

- **Factories**: `createRecordPanelRegistry()` / `createAdminRouteRegistry()`; the shared singletons now delegate to a default instance. Public API (`registerRecordPanel`/`getRecordPanels`/`registerAdminRoute`/`getAdminRoutes`) unchanged.
- **Clear functions removed** (`clearRecordPanels`, `_clearAdminRoutes`): they were test-only with no src callers — removing them makes wiping the shared registries impossible by construction.
- Both registry unit test files now construct **isolated instances**; all prior cases preserved, +2 isolation tests.

## Verification

`bun test` over adapter-ui registry tests + the full cap-chatter / cap-adapter-mcp suites: 243 pass / 0 fail. Full `bun run test` green; `bun run check` + `bun run typecheck` clean.

Once merged, #536/#537 just need a CI re-run (their merge refs pick up main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)