### PR TITLE
feat(adapter-server): wire EvolutionRuntime into the dev-server boot path

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-server-http-boot.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-server-http-boot.test.ts
@@ -35,6 +35,7 @@ import type {
   CapabilityDefinition,
   EntityDefinition,
   RelationDefinition,
+  Sensor,
   StateDefinition,
 } from "@linchkit/core";
 import { defineCapability, defineRelation } from "@linchkit/core";
@@ -311,5 +312,79 @@ describe("dev-server HTTP boot (in-process, DB-free, port-free)", () => {
     expect(body.error?.message ?? "").not.toContain("Ontology registry is not available");
     expect(res.status).toBe(200);
     expect(body.outcome).toBe("no_match");
+  });
+
+  it("wires the Evolution runtime into POST /api/evolution/run-cycle", async () => {
+    // Regression guard: `dev.ts`/`createDevApp` never built an EvolutionRuntime
+    // (only the `linch dev` boot path did), so `POST /api/evolution/run-cycle`
+    // answered 501 "Evolution runtime is not configured — on-demand cycle
+    // execution is unavailable" on `bun run dev:server`.
+    //
+    // A synthetic detection-style sensor is contributed via `extensions.sensors`
+    // — the same channel the purchase demo uses — so this also proves the
+    // sensors a capability registers actually reach the SignalBus and RUN
+    // during the on-demand cycle, with the dispatch query injected (routing
+    // `execution_log` reads to the in-memory ExecutionLogger, DB-free).
+    // No AI is involved: the cycle's translator registry is structural.
+    let sensorRuns = 0;
+    let sawDispatchQuery = false;
+    const smokeSensor: Sensor = {
+      name: "smoke_cycle_sensor",
+      source: "server",
+      async detect(ctx) {
+        sensorRuns += 1;
+        // The runtime's queryFactory must inject a dispatch query; reading the
+        // execution_log proves it routes to the ExecutionLogger without a DB.
+        const rows = await ctx.query?.("execution_log");
+        sawDispatchQuery = Array.isArray(rows);
+        // Quiet observation: no deviation surfaced, so the cycle completes
+        // without needing awareness promotion thresholds tuned for a test.
+        return {
+          sensor: "smoke_cycle_sensor",
+          source: "server",
+          timestamp: ctx.timestamp,
+          value: 0,
+          baseline: 0,
+          deviation: 0,
+          confidence: 1,
+          context: {},
+        };
+      },
+    };
+    const capSmokeSensor: CapabilityDefinition = defineCapability({
+      name: "cap-smoke-sensor",
+      label: "Smoke Sensor",
+      description: "Synthetic capability contributing one detection-style sensor (Spec 55 §3.3)",
+      type: "standard",
+      category: "business",
+      version: "0.1.0",
+      extensions: { sensors: [smokeSensor] },
+    });
+
+    const app = createDevApp([...configuredCapabilities(), capSmokeSensor], {
+      cors: false,
+    }).app;
+    const res = await app.handle(
+      new Request("http://local.test/api/evolution/run-cycle", { method: "POST" }),
+    );
+
+    const body = (await res.json()) as {
+      success?: boolean;
+      data?: { created: number; deduped: number; total: number; createdIds: string[] };
+      error?: { message?: string };
+    };
+    // Before the fix: 501 + "Evolution runtime is not configured — on-demand
+    // cycle execution is unavailable." With the runtime wired, the cycle runs
+    // end-to-end (sense → insight → proposal translation → draft persistence)
+    // and returns the draft-persistence summary.
+    expect(body.error?.message ?? "").not.toContain("Evolution runtime is not configured");
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(typeof body.data?.created).toBe("number");
+    expect(typeof body.data?.total).toBe("number");
+    // The capability-contributed sensor actually ran inside the cycle, with
+    // the dispatch query injected.
+    expect(sensorRuns).toBe(1);
+    expect(sawDispatchQuery).toBe(true);
   });
 });

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -18,8 +18,24 @@
  * so the boot smoke test and the real dev server share one wiring path.
  */
 
-import type { CapabilityDefinition, OntologyRegistry } from "@linchkit/core";
+import type {
+  CapabilityDefinition,
+  ImpactDataProvider,
+  OntologyRegistry,
+  PendingProposalStore,
+  ProposalDefinition,
+  Sensor,
+} from "@linchkit/core";
 import {
+  createDedupAnalyzer,
+  createDefaultInsightTranslatorRegistry,
+  createImpactAnalyzer,
+  createPreAnalysisPipeline,
+} from "@linchkit/core";
+import type { EvolutionRuntime } from "@linchkit/core/server";
+import {
+  createDispatchQuery,
+  createEvolutionRuntime,
   createFlowRegistry,
   createOntologyRegistry,
   createRelationRegistry,
@@ -61,6 +77,7 @@ export interface CreateDevAppOptions
         | "dataProvider"
         | "onchangeEvaluator"
         | "ontologyRegistry"
+        | "evolutionRuntime"
       >
     > {}
 
@@ -110,6 +127,122 @@ export function buildDevOntologyRegistry(
   });
 }
 
+/** Options for {@link buildDevEvolutionRuntime}. */
+export interface BuildDevEvolutionRuntimeOptions {
+  /**
+   * Capabilities to scan for detection-style sensor contributions
+   * (`cap.extensions.sensors`, Spec 55 §3.3). The assembled contributions
+   * bucket does not collect sensors, so the raw capability list is taken here
+   * — mirroring the CLI's collect-capabilities.ts.
+   */
+  capabilities: CapabilityDefinition[];
+  /** Assembled dev schema providing the dataProvider + executionLogger. */
+  assembled: Pick<AssembledDevSchema, "runtime">;
+  /** The unified semantic layer built by {@link buildDevOntologyRegistry}. */
+  ontologyRegistry: OntologyRegistry;
+}
+
+/**
+ * Build the Evolution runtime (Spec 55) for the dev-server boot path.
+ *
+ * Mirrors the `linch dev` boot path's `createEvolutionRuntime({...})` call
+ * (packages/cli/src/commands/dev-wiring.ts) so the on-demand cycle endpoint
+ * (`POST /api/evolution/run-cycle`) works on `bun run dev:server` too.
+ * Without it, the Evolution page's "Run Evolution Cycle" button answers 501
+ * "Evolution runtime is not configured".
+ *
+ * The dispatch query routes `execution_log` reads to the ExecutionLogger and
+ * all other schemas to the DataProvider; the runtime also receives the
+ * ontology + the default structural translator registry so surfaced insights
+ * translate into proposals (Spec 55 §7), plus a pre-analysis pipeline so every
+ * proposal arrives with a reviewer envelope (dedup + impact) attached.
+ *
+ * SAFETY (Spec 55, non-negotiable): this produces proposals as DATA only.
+ * The run-cycle endpoint persists them as governance `draft`s — no graduation
+ * is wired here: no ProposalFileWriter, no GitCommitter, no cadence scheduler.
+ * The cycle runs ON-DEMAND only.
+ */
+export function buildDevEvolutionRuntime(
+  options: BuildDevEvolutionRuntimeOptions,
+): EvolutionRuntime {
+  const { capabilities, assembled, ontologyRegistry } = options;
+  const { dataProvider, executionLogger } = assembled.runtime;
+
+  // Collect detection-style sensors contributed via `extensions.sensors` —
+  // the same extraction the CLI's collect-capabilities.ts performs. The
+  // dev-server's extractCapabilities does not surface sensors, so they are
+  // collected from the raw capability list here.
+  const sensors: Sensor[] = [];
+  for (const cap of capabilities) {
+    if (cap.extensions?.sensors) sensors.push(...cap.extensions.sensors);
+  }
+
+  // Real impact provider: the impact analyzer's narrow ImpactDataProvider
+  // contract (countRecords / sampleRecordIds) maps directly onto the
+  // DataProvider already in scope, so dev proposals get true first-order
+  // record counts instead of stubbed zeros.
+  const impactDataProvider: ImpactDataProvider = {
+    async countRecords(entity, filter) {
+      return dataProvider.count(entity, filter);
+    },
+    async sampleRecordIds(entity, limit, filter) {
+      // Guard against NaN/Infinity/fractional limits: Math.max(0, NaN) is NaN,
+      // which would slip past a `=== 0` check and reach the query/slice.
+      const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 0;
+      if (safeLimit === 0) return [];
+      // Push the limit into the query so the provider fetches only the sample
+      // rows. Both DrizzleDataProvider and InMemoryStore honor the `limit`
+      // filter key, so this avoids scanning + materializing a whole table just
+      // to return a handful of ids. The post-fetch slice stays as a defensive
+      // cap in case a provider ignores the hint.
+      const rows = await dataProvider.query(entity, {
+        ...(filter ?? {}),
+        limit: safeLimit,
+      });
+      return rows
+        .slice(0, safeLimit)
+        .map((row) =>
+          row && typeof row === "object" && "id" in row
+            ? String((row as { id?: unknown }).id ?? "")
+            : "",
+        )
+        .filter((id) => id.length > 0);
+    },
+  };
+
+  // Empty pending-proposal store: the dedup analyzer needs a pending set to
+  // compare against, but on this path the run-cycle ENDPOINT already dedups
+  // against the shared governance ProposalEngine when persisting drafts
+  // (persistCycleProposalsAsDrafts). The analyzer-level store stays empty —
+  // same shape as the CLI boot path (dev-wiring.ts) — so the pipeline still
+  // executes and reports an empty similar list.
+  const pendingProposalStore: PendingProposalStore = {
+    async listPending(): Promise<ProposalDefinition[]> {
+      return [];
+    },
+  };
+
+  const proposalPreAnalysisPipeline = createPreAnalysisPipeline({
+    analyzers: [
+      createDedupAnalyzer({ store: pendingProposalStore }),
+      createImpactAnalyzer({ dataProvider: impactDataProvider }),
+    ],
+  });
+
+  return createEvolutionRuntime({
+    sensors,
+    // Build a fresh dispatch query per cycle, scoped to that cycle's tenant
+    // (#500) — a per-tenant on-demand cycle reads only its own data.
+    queryFactory: (tenantId) => createDispatchQuery({ dataProvider, executionLogger, tenantId }),
+    ontology: ontologyRegistry,
+    translatorRegistry: createDefaultInsightTranslatorRegistry(),
+    // Capability label stamped onto every translated proposal — identifies
+    // the dev-server boot path as the origin (the CLI path uses "linch-dev").
+    proposalCapability: "dev-server",
+    proposalPreAnalysisPipeline,
+  });
+}
+
 /** Result of {@link createDevApp}: the Elysia app plus the assembled schema. */
 export interface DevApp {
   /**
@@ -149,6 +282,15 @@ export function createDevApp(
   // boot path, so ontology-dependent routes work on the in-process app too.
   const ontologyRegistry = buildDevOntologyRegistry(assembled);
 
+  // Evolution runtime (Spec 55) — same construction as dev.ts and the
+  // `linch dev` boot path, so `POST /api/evolution/run-cycle` works on the
+  // in-process app too. On-demand only; proposals stay DATA-only drafts.
+  const evolutionRuntime = buildDevEvolutionRuntime({
+    capabilities,
+    assembled,
+    ontologyRegistry,
+  });
+
   // Forward caller-supplied ServerOptions first, then the fields this factory
   // derives from the assembled runtime — which always win (and are excluded
   // from CreateDevAppOptions so callers cannot override them). This mirrors
@@ -180,6 +322,7 @@ export function createDevApp(
     dataProvider: runtime.dataProvider,
     onchangeEvaluator,
     ontologyRegistry,
+    evolutionRuntime,
   });
 
   return { app, assembled };

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -174,7 +174,9 @@ export function buildDevEvolutionRuntime(
   // collected from the raw capability list here.
   const sensors: Sensor[] = [];
   for (const cap of capabilities) {
-    if (cap.extensions?.sensors) sensors.push(...cap.extensions.sensors);
+    // Array.isArray guard: capability configs are user-authored and may
+    // bypass strict typing at runtime (e.g. a plain object by mistake).
+    if (Array.isArray(cap.extensions?.sensors)) sensors.push(...cap.extensions.sensors);
   }
 
   // Real impact provider: the impact analyzer's narrow ImpactDataProvider
@@ -199,10 +201,13 @@ export function buildDevEvolutionRuntime(
         ...(filter ?? {}),
         limit: safeLimit,
       });
+      // A failing or stubbed provider may return a non-array despite the
+      // typed contract; treat that as "no sample" rather than throwing.
+      if (!Array.isArray(rows)) return [];
       return rows
         .slice(0, safeLimit)
         .map((row) =>
-          row && typeof row === "object" && "id" in row
+          row && typeof row === "object" && !Array.isArray(row) && "id" in row
             ? String((row as { id?: unknown }).id ?? "")
             : "",
         )

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -10,7 +10,7 @@ import { resolve } from "node:path";
 import { consoleLogger } from "@linchkit/core/server";
 import { assembleDevSchema } from "./assemble-schema";
 import { loadConfig } from "./config-loader";
-import { buildDevOntologyRegistry } from "./dev-app";
+import { buildDevEvolutionRuntime, buildDevOntologyRegistry } from "./dev-app";
 import { createServer } from "./server";
 
 // ── Resolve project root ────────────────────────────────
@@ -115,6 +115,21 @@ const allActions = assembled.allActions;
 const ontologyRegistry = buildDevOntologyRegistry(assembled);
 consoleLogger.info(`OntologyRegistry built (${ontologyRegistry.listEntities().length} schemas)`);
 
+// Evolution runtime (Spec 55) — mirrors the `linch dev` boot path
+// (dev-wiring.ts). Without it, POST /api/evolution/run-cycle answers 501
+// "Evolution runtime is not configured" and the Evolution page's
+// "Run Evolution Cycle" button dead-ends. SAFETY: proposals from the live
+// cycle stay DATA-only drafts — no graduation, no file writes, no scheduler.
+const evolutionRuntime = buildDevEvolutionRuntime({
+  capabilities: config.capabilities ?? [],
+  assembled,
+  ontologyRegistry,
+});
+consoleLogger.info(
+  `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered ` +
+    "(insight→proposal translator + pre-analysis pipeline wired)",
+);
+
 const port = config.server?.port ?? 3001;
 const host = config.server?.host ?? "0.0.0.0";
 
@@ -140,6 +155,7 @@ const server = createServer(graphqlSchema, {
   dataProvider: runtime.dataProvider,
   onchangeEvaluator,
   ontologyRegistry,
+  evolutionRuntime,
 });
 
 server.listen(port);


### PR DESCRIPTION
## Summary

The last dev-server wiring gap from this session's live testing: the Evolution page's **"Run Evolution Cycle"** button answered *"Evolution runtime is not configured — on-demand cycle execution is unavailable"* on `bun run dev:server`. `ServerOptions.evolutionRuntime` (server.ts:228) existed but neither dev entry supplied it — only the `linch dev` CLI path (dev-wiring.ts, #485) did. Companion to #535 (ontology + aiConfig wiring), same shared-helper pattern.

### Wiring (mirrors dev-wiring.ts faithfully)

- **`buildDevEvolutionRuntime({ capabilities, assembled, ontologyRegistry })`** in `dev-app.ts`, shared by both entries:
  - `sensors` from `cap.extensions.sensors` (the purchase demo contributes `purchaseRejectionPattern`) — the dev assembly doesn't surface sensors, so the helper replicates the CLI's collect-capabilities extraction.
  - `queryFactory: (tenantId) => createDispatchQuery({ dataProvider, executionLogger, tenantId })` — per-tenant scoping per the #500 discipline; `execution_log` reads route to the ExecutionLogger.
  - `ontology` from `buildDevOntologyRegistry`; `translatorRegistry: createDefaultInsightTranslatorRegistry()` so insights translate into proposals.
  - Real pre-analysis pipeline: dedup analyzer (empty pending store — same as the CLI path; the run-cycle endpoint already dedups against the governance ProposalEngine on persist) + impact analyzer mapped onto the in-scope DataProvider, including the CLI's NaN/fractional-limit guard verbatim.
  - `proposalCapability: "dev-server"` — verified label-only (stamped onto translated proposals; no store keys on it); distinguishes dev-server-origin drafts from the CLI's `"linch-dev"`.
- `dev.ts` builds + passes it and logs `Evolution runtime ready: N sensor(s) registered` at boot.

### Safety invariants (Spec 55 — unchanged)

On-demand endpoint only: **no** ProposalFileWriter, **no** GitCommitter, **no** cadence scheduler. Cycle proposals stay DATA-only governance `draft`s via the endpoint's draft-only persistence.

## Tests

New boot test: a synthetic detection-sensor capability → `POST /api/evolution/run-cycle` via `app.handle()` returns 200 with cycle counters, the sensor ran exactly once, and the dispatch query routed `execution_log` reads through the logger (DB-free, no AI involved — the cycle path never gates on aiService). Full `bun run test` green (adapter-server 787 pass); `bun run check` + `bun run typecheck` clean.

With this, every button on the Evolution admin page is live on `bun run dev:server`: NL→draft rule (#535), dry-run outcomes (#529/#530), and now the on-demand evolution cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed evolution run-cycle endpoint configuration, resolving 501 errors that previously occurred when attempting to execute evolution operations in the development environment.

* **New Features**
  * Evolution runtime is now fully wired into the development server with complete sensor integration, enabling the execution of detection sensors and evolution-based workflows through the run-cycle endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->