### PR TITLE
fix(adapter-ui): dispatch bound Actions from transition pills and kanban drops

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
@@ -14,10 +14,11 @@
  * action-proposal-card.test.ts), so `executeHeaderAction` is exercised through
  * its injected `HeaderActionApi` (same injection style as
  * field-lock-bypass.test.ts). The raw `transitionRecord` client (still the
- * path for transitions invoked WITHOUT a bound action — transition pills,
- * kanban drags) is unchanged by this fix and deliberately NOT covered here:
- * a `globalThis.fetch` swap passes in isolation but breaks under the batched
- * CI run (known skew — inject dependencies instead of mocking globals).
+ * path for transitions invoked WITHOUT a bound action) is unchanged by this
+ * fix and deliberately NOT covered here: a `globalThis.fetch` swap passes in
+ * isolation but breaks under the batched CI run (known skew — inject
+ * dependencies instead of mocking globals). Transition pills and kanban
+ * drags dispatch through the same pattern — see transition-dispatch.test.ts.
  */
 
 import { describe, expect, test } from "bun:test";

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/transition-dispatch.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/transition-dispatch.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the shared transition dispatch (lib/transition-dispatch.ts).
+ *
+ * Regression coverage for the state-transition bypass bug on the transition
+ * pills (transition-buttons.tsx) and kanban drag-to-column (auto-kanban.tsx)
+ * surfaces: both used to call the generic `transitionRecord` GraphQL mutation
+ * unconditionally — a bare status update that skipped the bound Action, so
+ * `setFields` stamps were never written and flows triggered on the action
+ * never fired. Same bug class fixed for header buttons in PR #536
+ * (entity-form-actions.test.ts).
+ *
+ * Dispatch must run the bound Action via `executeAction` when the transition
+ * declares one; `transitionRecord` remains valid ONLY when no action is
+ * bound. Exercised through the injected `TransitionDispatchApi` — never via
+ * `globalThis.fetch` mocks (known batched-CI skew).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Transition } from "@linchkit/core/types";
+import {
+  executeTransition,
+  resolveBoundAction,
+  type TransitionDispatchApi,
+} from "../src/lib/transition-dispatch";
+
+// ── Injected-API capture helper ─────────────────────────────
+
+interface ApiCalls {
+  executeAction: { actionName: string; input: Record<string, unknown> }[];
+  transitionRecord: { schema: string; id: string; to: string; fields: string[] }[];
+  queryRecord: { schema: string; id: string; fields: string[] }[];
+}
+
+function makeApi(opts: {
+  actionSuccess?: boolean;
+  actionErrorMessage?: string;
+  record?: Record<string, unknown> | null;
+  queryThrows?: boolean;
+  transitionResult?: Record<string, unknown>;
+}): { api: TransitionDispatchApi; calls: ApiCalls } {
+  const calls: ApiCalls = { executeAction: [], transitionRecord: [], queryRecord: [] };
+  const api: TransitionDispatchApi = {
+    executeAction: async (actionName, input) => {
+      calls.executeAction.push({ actionName, input });
+      const success = opts.actionSuccess ?? true;
+      return success
+        ? { success: true }
+        : { success: false, error: { message: opts.actionErrorMessage } };
+    },
+    transitionRecord: async (schema, id, to, fields) => {
+      calls.transitionRecord.push({ schema, id, to, fields });
+      return opts.transitionResult ?? { id, status: to };
+    },
+    queryRecord: async (schema, id, fields) => {
+      calls.queryRecord.push({ schema, id, fields });
+      if (opts.queryThrows) throw new Error("network down");
+      return opts.record ?? null;
+    },
+  };
+  return { api, calls };
+}
+
+const BASE = {
+  entityName: "purchase_request",
+  recordId: "rec-1",
+  to: "pending",
+  recordFields: ["id", "status", "submitted_at"],
+};
+
+// ── executeTransition — bound action path ───────────────────
+
+describe("executeTransition — transition with a bound Action", () => {
+  test("runs the bound Action via executeAction, NEVER the generic transition mutation", async () => {
+    const fresh = { id: "rec-1", status: "pending", submitted_at: "2026-06-10T00:00:00Z" };
+    const { api, calls } = makeApi({ record: fresh });
+
+    const outcome = await executeTransition({
+      ...BASE,
+      boundAction: "submit_purchase_request",
+      api,
+    });
+
+    // The Action itself executes — server performs the declarative
+    // stateTransition, stamps setFields, fires rules/flows.
+    expect(calls.executeAction).toHaveLength(1);
+    expect(calls.executeAction[0]).toEqual({
+      actionName: "submit_purchase_request",
+      input: { id: "rec-1" },
+    });
+    expect(calls.transitionRecord).toHaveLength(0);
+    expect(outcome).toEqual({ kind: "success", updated: fresh });
+  });
+
+  test("re-queries the fresh record after the action so callers refresh in place", async () => {
+    const { api, calls } = makeApi({ record: { id: "rec-1", status: "pending" } });
+
+    await executeTransition({ ...BASE, boundAction: "submit_purchase_request", api });
+
+    expect(calls.queryRecord).toHaveLength(1);
+    expect(calls.queryRecord[0]).toEqual({
+      schema: "purchase_request",
+      id: "rec-1",
+      fields: ["id", "status", "submitted_at"],
+    });
+  });
+
+  test("action failure reports failed with the server message and skips the re-query", async () => {
+    const { api, calls } = makeApi({
+      actionSuccess: false,
+      actionErrorMessage: "guard rejected",
+    });
+
+    const outcome = await executeTransition({
+      ...BASE,
+      boundAction: "submit_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "failed", message: "guard rejected" });
+    expect(calls.queryRecord).toHaveLength(0);
+    expect(calls.transitionRecord).toHaveLength(0);
+  });
+
+  test("re-query failure still reports success with updated: null (caller falls back to full refetch)", async () => {
+    const { api } = makeApi({ queryThrows: true });
+
+    const outcome = await executeTransition({
+      ...BASE,
+      boundAction: "submit_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "success", updated: null });
+  });
+});
+
+// ── executeTransition — raw fallback path ───────────────────
+
+describe("executeTransition — transition WITHOUT a bound Action", () => {
+  test("falls back to the generic transition mutation and returns its record", async () => {
+    const mutationResult = { id: "rec-1", status: "pending" };
+    const { api, calls } = makeApi({ transitionResult: mutationResult });
+
+    const outcome = await executeTransition({ ...BASE, boundAction: undefined, api });
+
+    expect(calls.transitionRecord).toHaveLength(1);
+    expect(calls.transitionRecord[0]).toEqual({
+      schema: "purchase_request",
+      id: "rec-1",
+      to: "pending",
+      fields: ["id", "status", "submitted_at"],
+    });
+    expect(calls.executeAction).toHaveLength(0);
+    expect(calls.queryRecord).toHaveLength(0);
+    expect(outcome).toEqual({ kind: "success", updated: mutationResult });
+  });
+});
+
+// ── resolveBoundAction (kanban edge resolution) ─────────────
+
+describe("resolveBoundAction", () => {
+  const transitions: Transition[] = [
+    { from: "draft", to: "pending", action: "submit_purchase_request" },
+    { from: ["pending", "draft"], to: "cancelled", action: "cancel_purchase_request" },
+    { from: "pending", to: "approved", action: "" },
+  ];
+
+  test("resolves the action bound to a single-from edge", () => {
+    expect(resolveBoundAction(transitions, "draft", "pending")).toBe("submit_purchase_request");
+  });
+
+  test("resolves the action bound to an array-from edge", () => {
+    expect(resolveBoundAction(transitions, "pending", "cancelled")).toBe("cancel_purchase_request");
+    expect(resolveBoundAction(transitions, "draft", "cancelled")).toBe("cancel_purchase_request");
+  });
+
+  test("returns undefined when no edge matches (raw fallback)", () => {
+    expect(resolveBoundAction(transitions, "approved", "draft")).toBeUndefined();
+  });
+
+  test("returns undefined when the edge declares an empty action name (raw fallback)", () => {
+    expect(resolveBoundAction(transitions, "pending", "approved")).toBeUndefined();
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/transition-dispatch.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/transition-dispatch.test.ts
@@ -181,4 +181,9 @@ describe("resolveBoundAction", () => {
   test("returns undefined when the edge declares an empty action name (raw fallback)", () => {
     expect(resolveBoundAction(transitions, "pending", "approved")).toBeUndefined();
   });
+
+  test("returns undefined for missing transitions (incomplete state definition)", () => {
+    expect(resolveBoundAction(undefined, "draft", "pending")).toBeUndefined();
+    expect(resolveBoundAction(null, "draft", "pending")).toBeUndefined();
+  });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-kanban/auto-kanban.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-kanban/auto-kanban.tsx
@@ -2,7 +2,10 @@
  * AutoKanban — Kanban board view for entities with state fields.
  *
  * Groups records by state field value into draggable columns.
- * Drag-and-drop between columns triggers state transitions via GraphQL.
+ * Drag-and-drop between columns runs the transition's bound Action (server
+ * performs the declarative transition, setFields stamps, rules/flows); the
+ * generic transition mutation is used only when the transition edge has no
+ * bound action — see lib/transition-dispatch.ts.
  * Uses native HTML drag-and-drop API (no external library).
  */
 
@@ -13,8 +16,9 @@ import { Clock, GripVertical, Inbox, Loader2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEntityLabel } from "../../i18n/use-entity-label";
-import { transitionRecord } from "../../lib/api";
+import { executeAction, queryRecord, transitionRecord } from "../../lib/api";
 import { getStateBadgeClass, resolveStateColor } from "../../lib/state-colors";
+import { executeTransition, resolveBoundAction } from "../../lib/transition-dispatch";
 
 // ── Types ────────────────────────────────────────────────
 
@@ -338,11 +342,24 @@ export function AutoKanban({
         return;
       }
 
-      // Execute transition
+      // Execute transition — through the bound Action when the state machine
+      // declares one for this edge (declarative stateTransition + setFields +
+      // rules/flows happen server-side); raw transition mutation otherwise.
       setTransitioningId(recordId);
       try {
         const fields = queryFields ?? ["id", stateField];
-        await transitionRecord(schema.name, recordId, toState, fields);
+        const outcome = await executeTransition({
+          entityName: schema.name,
+          recordId,
+          to: toState,
+          boundAction: resolveBoundAction(stateDefinition.transitions, fromState, toState),
+          recordFields: fields,
+          api: { executeAction, transitionRecord, queryRecord },
+        });
+        if (outcome.kind === "failed") {
+          toast.error(outcome.message ?? t("toast.transitionFailed", "Status change failed"));
+          return;
+        }
         toast.success(t("toast.transitionSuccess", "Status changed successfully"));
         onTransitioned?.();
       } catch (err) {
@@ -353,7 +370,16 @@ export function AutoKanban({
         setTransitioningId(null);
       }
     },
-    [dragState, isValidDrop, schema.name, stateField, queryFields, onTransitioned, t],
+    [
+      dragState,
+      isValidDrop,
+      schema.name,
+      stateField,
+      stateDefinition.transitions,
+      queryFields,
+      onTransitioned,
+      t,
+    ],
   );
 
   // End drag when leaving the board area

--- a/addons/adapter-ui/cap-adapter-ui/src/components/transition-buttons.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/transition-buttons.tsx
@@ -39,7 +39,9 @@ interface TransitionButtonsProps {
   /** State machine definitions for label resolution */
   states?: StateDefinition[];
   /** Callback after successful transition */
-  onTransitioned?: (updatedRecord: Record<string, unknown>) => void;
+  /** Fresh record after the transition; undefined when the re-query failed
+   * (the transition itself succeeded — fall back to a full refetch). */
+  onTransitioned?: (updatedRecord?: Record<string, unknown>) => void;
 }
 
 export function TransitionButtons({
@@ -114,9 +116,10 @@ export function TransitionButtons({
         return;
       }
       toast.success(t("toast.transitionSuccess", "Status changed successfully"));
-      // updated: null → bound-action re-query failed; skip the in-place
-      // record refresh but still refresh the available transitions.
-      if (outcome.updated) onTransitioned?.(outcome.updated);
+      // updated: null → bound-action re-query failed, but the transition
+      // itself succeeded server-side — notify the parent without a record
+      // so it can fall back to a full refetch instead of going stale.
+      onTransitioned?.(outcome.updated ?? undefined);
       // Refresh available transitions after successful transition
       await fetchTransitions();
     } catch (_err) {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/transition-buttons.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/transition-buttons.tsx
@@ -3,7 +3,10 @@
  *
  * Fetches available transitions from the GraphQL API and displays them
  * as action buttons. Buttons are disabled with tooltip when the actor
- * lacks permission. Clicking an allowed button triggers the transition mutation.
+ * lacks permission. Clicking an allowed button runs the transition's bound
+ * Action (server performs the declarative transition, setFields stamps,
+ * rules/flows); the generic transition mutation is used only when the
+ * transition has no bound action — see lib/transition-dispatch.ts.
  */
 
 import type { StateDefinition, StateMeta } from "@linchkit/core/types";
@@ -19,7 +22,14 @@ import {
 import { ArrowRight, Loader2, Lock } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { type AvailableTransition, queryAvailableTransitions, transitionRecord } from "../lib/api";
+import {
+  type AvailableTransition,
+  executeAction,
+  queryAvailableTransitions,
+  queryRecord,
+  transitionRecord,
+} from "../lib/api";
+import { executeTransition } from "../lib/transition-dispatch";
 
 interface TransitionButtonsProps {
   entityName: string;
@@ -85,12 +95,28 @@ export function TransitionButtons({
     return stateValue;
   }
 
-  async function handleTransition(to: string) {
-    setTransitioning(to);
+  async function handleTransition(transition: AvailableTransition) {
+    setTransitioning(transition.to);
     try {
-      const updated = await transitionRecord(entityName, recordId, to, recordFields);
+      // Dispatch through the bound Action when present (declarative
+      // stateTransition + setFields + rules/flows happen server-side);
+      // raw transition mutation only when no action is bound.
+      const outcome = await executeTransition({
+        entityName,
+        recordId,
+        to: transition.to,
+        boundAction: transition.action || undefined,
+        recordFields,
+        api: { executeAction, transitionRecord, queryRecord },
+      });
+      if (outcome.kind === "failed") {
+        toast.error(outcome.message ?? t("toast.transitionFailed", "Status change failed"));
+        return;
+      }
       toast.success(t("toast.transitionSuccess", "Status changed successfully"));
-      onTransitioned?.(updated as Record<string, unknown>);
+      // updated: null → bound-action re-query failed; skip the in-place
+      // record refresh but still refresh the available transitions.
+      if (outcome.updated) onTransitioned?.(outcome.updated);
       // Refresh available transitions after successful transition
       await fetchTransitions();
     } catch (_err) {
@@ -113,7 +139,7 @@ export function TransitionButtons({
               size="sm"
               variant="outline"
               disabled={isDisabled}
-              onClick={() => handleTransition(tr.to)}
+              onClick={() => handleTransition(tr)}
             >
               {transitioning === tr.to ? (
                 <Loader2 className="mr-1.5 size-3.5 animate-spin" />

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
@@ -49,10 +49,12 @@ export type TransitionDispatchOutcome =
  * (empty action name) — callers then fall back to the raw transition mutation.
  */
 export function resolveBoundAction(
-  transitions: readonly Transition[],
+  transitions: readonly Transition[] | undefined | null,
   fromState: string,
   toState: string,
 ): string | undefined {
+  // Incomplete state definitions may carry no transitions at all.
+  if (!transitions) return undefined;
   for (const tr of transitions) {
     const fromArr = Array.isArray(tr.from) ? tr.from : [tr.from];
     if (fromArr.includes(fromState) && tr.to === toState) {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared state-transition dispatch for UI surfaces (transition pills, kanban
+ * drag-to-column).
+ *
+ * A transition with a bound Action MUST run through the Action itself: the
+ * server-side action performs the declarative `stateTransition`, stamps
+ * `setFields`, and fires rules/flows (e.g. `submit_purchase_request` stamps
+ * `submitted_at` and triggers the approval Flow). Routing it through the
+ * generic `transitionRecord` mutation bypasses all of that — it degrades to a
+ * bare status update. The generic mutation remains valid ONLY when no action
+ * is bound to the transition.
+ *
+ * Same fix pattern as `executeHeaderAction` in pages/entity-form-actions.ts
+ * (header buttons are keyed by action name; these surfaces are keyed by
+ * target state, hence the bound-action resolution + raw fallback here).
+ * Dependencies are injected (`TransitionDispatchApi`) so tests exercise the
+ * dispatch without mocking globals.
+ */
+
+import type { Transition } from "@linchkit/core/types";
+
+/** Minimal API surface consumed by executeTransition — injectable in tests. */
+export interface TransitionDispatchApi {
+  executeAction: (
+    actionName: string,
+    input: Record<string, unknown>,
+  ) => Promise<{ success: boolean; error?: { message?: string } }>;
+  transitionRecord: (
+    schema: string,
+    id: string,
+    to: string,
+    fields: string[],
+  ) => Promise<Record<string, unknown>>;
+  queryRecord: (
+    schema: string,
+    id: string,
+    fields: string[],
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+/** Structured outcome; callers map it to toasts/refreshes. */
+export type TransitionDispatchOutcome =
+  | { kind: "success"; updated: Record<string, unknown> | null }
+  | { kind: "failed"; message?: string };
+
+/**
+ * Resolve the Action bound to a state-machine transition edge (from → to).
+ * Returns undefined when no edge matches or the edge declares no action
+ * (empty action name) — callers then fall back to the raw transition mutation.
+ */
+export function resolveBoundAction(
+  transitions: readonly Transition[],
+  fromState: string,
+  toState: string,
+): string | undefined {
+  for (const tr of transitions) {
+    const fromArr = Array.isArray(tr.from) ? tr.from : [tr.from];
+    if (fromArr.includes(fromState) && tr.to === toState) {
+      return tr.action || undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Execute a state transition: through its bound Action when one exists,
+ * through the generic transition mutation otherwise.
+ *
+ * After a successful bound-action run the fresh record is re-queried (status,
+ * `setFields` stamps, derived fields); `updated: null` means the re-query
+ * failed and the caller should fall back to a full refetch. Network/GraphQL
+ * errors from the raw transition path propagate to the caller (same contract
+ * as calling `transitionRecord` directly).
+ */
+export async function executeTransition(opts: {
+  entityName: string;
+  recordId: string;
+  to: string;
+  /** Action bound to this transition; undefined → raw transition mutation. */
+  boundAction: string | undefined;
+  recordFields: string[];
+  api: TransitionDispatchApi;
+}): Promise<TransitionDispatchOutcome> {
+  const { entityName, recordId, to, boundAction, recordFields, api } = opts;
+
+  if (!boundAction) {
+    // No bound action — the generic transition mutation is the correct path.
+    const updated = await api.transitionRecord(entityName, recordId, to, recordFields);
+    return { kind: "success", updated };
+  }
+
+  const result = await api.executeAction(boundAction, { id: recordId });
+  if (!result.success) {
+    return { kind: "failed", message: result.error?.message };
+  }
+
+  // Bound action succeeded — re-query the record so the caller can refresh
+  // local state in place.
+  let updated: Record<string, unknown> | null = null;
+  try {
+    updated = await api.queryRecord(entityName, recordId, recordFields);
+  } catch {
+    updated = null;
+  }
+  return { kind: "success", updated };
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -61,8 +61,9 @@ export type HeaderActionOutcome =
  * approval Flow). Routing it through the generic `transitionRecord` mutation
  * bypasses all of that — it degrades to a bare status update. The generic
  * transition mutation remains valid ONLY for raw transitions invoked without
- * a bound action (e.g. transition pills / kanban drags); no such path exists
- * in this dispatcher because it is keyed by action name.
+ * a bound action (transition pills / kanban drags dispatch the same way via
+ * lib/transition-dispatch.ts); no such path exists in this dispatcher
+ * because it is keyed by action name.
  *
  * After a successful transition-bound action the fresh record is re-queried
  * so the form can update local state in place; `updated: null` means the


### PR DESCRIPTION
## Summary
- Live-testing wave follow-up (flagged in #536): the **transition pills** (`transition-buttons.tsx`) and **kanban drag-to-column** (`auto-kanban.tsx`) surfaces called `transitionRecord` (raw status update) even when the state machine declared a bound Action — so declarative effects (`setFields` stamps, Flow triggers like purchase-approval) never fired from those surfaces. Core contract (`packages/core/src/types/state.ts`): transitions must be bound to Actions.
- New shared DI dispatcher `src/lib/transition-dispatch.ts`: `executeTransition` runs `executeAction(name, {id})` when the transition has a bound action (then re-queries the fresh record; falls back to full refetch when the re-query fails) and uses `transitionRecord` only for unbound transitions. `resolveBoundAction` maps a from/to edge to its declared action (string-or-array `from`, empty action treated as unbound).
- Both surfaces now dispatch through it; header buttons keep using the #536 `executeHeaderAction` path (comment-only touch-ups there).

## Evidence
Same bug class as #536, verified at file:line before fixing: pills discarded the non-optional `AvailableTransition.action`; kanban used `stateDefinition.transitions` only for validity and ignored the declared action.

## Testing
- 9 new dependency-injected tests (`transition-dispatch.test.ts`): bound→executeAction (never transitionRecord), re-query behavior, action failure surfaces server message, unbound fallback exact args, resolveBoundAction edge cases. No globalThis.fetch mocks.
- Full suite green (batched runner), typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)