### PR TITLE
feat(e2e): real-browser smoke suite (puppeteer-core + bun test)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@restatedev/restate-sdk": "1.14.4",
+        "@restatedev/restate-sdk": "1.14.5",
         "@tanstack/react-table": "^8.21.3",
         "ai": "^6.0.134",
         "dataloader": "^2.2.3",
@@ -23,6 +23,7 @@
         "@changesets/cli": "^2.30.0",
         "bun-types": "latest",
         "drizzle-kit": "^0.31.10",
+        "puppeteer-core": "^25.1.0",
         "tsup": "^8.5.1",
       },
     },
@@ -97,13 +98,12 @@
         "@linchkit/cap-chatter": "workspace:*",
         "@linchkit/cap-dry-run": "workspace:*",
         "@linchkit/cap-permission": "workspace:*",
-        "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
         "@linchkit/cap-ai-provider": "^1.0.0",
         "@linchkit/cap-dry-run": "^0.1.0",
-        "@linchkit/core": "^0.2.0",
+        "@linchkit/core": ">=0.3.0 <0.4.0",
       },
     },
     "addons/adapter-ui/cap-adapter-ui": {
@@ -118,6 +118,7 @@
         "@linchkit/ui-kit": "workspace:*",
         "@tanstack/react-query": "^5.95.2",
         "@tanstack/react-router": "^1.168.2",
+        "@tanstack/react-table": "^8.21.3",
         "@tiptap/extension-link": "^3.20.5",
         "@tiptap/extension-placeholder": "^3.20.5",
         "@tiptap/pm": "^3.20.5",
@@ -329,7 +330,7 @@
       "name": "@linchkit/cap-flow-restate",
       "version": "1.0.0",
       "dependencies": {
-        "@restatedev/restate-sdk": "1.14.4",
+        "@restatedev/restate-sdk": "1.14.5",
       },
       "devDependencies": {
         "@linchkit/core": "workspace:*",
@@ -1098,6 +1099,8 @@
 
     "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
+    "@puppeteer/browsers": ["@puppeteer/browsers@3.0.4", "https://registry.npmmirror.com/@puppeteer/browsers/-/browsers-3.0.4.tgz", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^17.7.2" }, "peerDependencies": { "proxy-agent": ">=8.0.1" }, "optionalPeers": ["proxy-agent"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-HGM8iAmGTf+Y7t0373szVbTmt3d7vPkYL/1bpOkOFO0YUYLgSeuYBCzESklogNPvOBnZ/MRD5f07OkpqH1trtA=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "https://registry.npmmirror.com/@radix-ui/number/-/number-1.1.1.tgz", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "https://registry.npmmirror.com/@radix-ui/primitive/-/primitive-1.1.3.tgz", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
@@ -1224,9 +1227,9 @@
 
     "@repeaterjs/repeater": ["@repeaterjs/repeater@3.0.6", "https://registry.npmmirror.com/@repeaterjs/repeater/-/repeater-3.0.6.tgz", {}, "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="],
 
-    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.14.4", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.14.4" } }, "sha512-H3nqBlHvNwDgfYdAqTe7+fgvkRoNrOOKVKwPB2/ucDyLZUx15yr3FU5aKWQCuM0TVvkSE3bwYWvLIXoVUpEbtw=="],
+    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.14.5", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.14.5" } }, "sha512-RvuJU/Ji9MSgLkRBN1pLeGm/AdrpFl380SZZ0sPk/NWC9jpZyX2fntJx7NbIqfQ4PfoTm1/zPH8/gn7AQGuSaQ=="],
 
-    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.14.4", "", {}, "sha512-q1ukObKmcwRSznuOt73TST6kvh8mjQaWU9dmHhbWCbx2xddUsj4LiGD2MkuTfMhl42SFNCdbp6Lvew1Wy+7IlQ=="],
+    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.14.5", "", {}, "sha512-MvlRhyFhnNMDLFRz2t5TbhebIkIAI8oN2reRgoAj9OMADK0xn7mOuBbWHwGF+8MsFfBXmV1HrNqpAXltEeNzqg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.10", "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz", { "os": "android", "cpu": "arm64" }, "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg=="],
 
@@ -1634,6 +1637,8 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "chromium-bidi": ["chromium-bidi@16.0.1", "https://registry.npmmirror.com/chromium-bidi/-/chromium-bidi-16.0.1.tgz", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA=="],
+
     "citty": ["citty@0.2.1", "https://registry.npmmirror.com/citty/-/citty-0.2.1.tgz", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
@@ -1813,6 +1818,8 @@
     "detect-libc": ["detect-libc@2.1.2", "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "https://registry.npmmirror.com/detect-node-es/-/detect-node-es-1.1.0.tgz", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1624250", "https://registry.npmmirror.com/devtools-protocol/-/devtools-protocol-0.0.1624250.tgz", {}, "sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA=="],
 
     "diff": ["diff@8.0.3", "https://registry.npmmirror.com/diff/-/diff-8.0.3.tgz", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
@@ -2188,7 +2195,11 @@
 
     "minimist": ["minimist@1.2.8", "https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "mitt": ["mitt@3.0.1", "https://registry.npmmirror.com/mitt/-/mitt-3.0.1.tgz", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "modern-tar": ["modern-tar@0.7.6", "https://registry.npmmirror.com/modern-tar/-/modern-tar-0.7.6.tgz", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -2373,6 +2384,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "puppeteer-core": ["puppeteer-core@25.1.0", "https://registry.npmmirror.com/puppeteer-core/-/puppeteer-core-25.1.0.tgz", { "dependencies": { "@puppeteer/browsers": "3.0.4", "chromium-bidi": "16.0.1", "devtools-protocol": "0.0.1624250", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.2", "ws": "^8.21.0" } }, "sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ=="],
 
     "qs": ["qs@6.15.0", "https://registry.npmmirror.com/qs/-/qs-6.15.0.tgz", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
@@ -2618,6 +2631,8 @@
 
     "type-is": ["type-is@2.0.1", "https://registry.npmmirror.com/type-is/-/type-is-2.0.1.tgz", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "typed-query-selector": ["typed-query-selector@2.12.2", "https://registry.npmmirror.com/typed-query-selector/-/typed-query-selector-2.12.2.tgz", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
     "typescript": ["typescript@6.0.2", "https://registry.npmmirror.com/typescript/-/typescript-6.0.2.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
@@ -2676,15 +2691,19 @@
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "https://registry.npmmirror.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.2", "https://registry.npmmirror.com/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz", {}, "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA=="],
+
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
     "which": ["which@2.0.2", "https://registry.npmmirror.com/which/-/which-2.0.2.tgz", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrap-ansi": ["wrap-ansi@6.2.0", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "https://registry.npmmirror.com/ws/-/ws-8.21.0.tgz", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "https://registry.npmmirror.com/wsl-utils/-/wsl-utils-0.3.1.tgz", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
@@ -2738,6 +2757,8 @@
 
     "@graphql-tools/schema/@graphql-tools/utils": ["@graphql-tools/utils@11.0.0", "https://registry.npmmirror.com/@graphql-tools/utils/-/utils-11.0.0.tgz", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA=="],
 
+    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "@linchkit/cap-ai-provider/ai": ["ai@6.0.138", "", { "dependencies": { "@ai-sdk/gateway": "3.0.80", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
@@ -2764,9 +2785,9 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "cliui/string-width": ["string-width@4.2.3", "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "chromium-bidi/zod": ["zod@3.25.76", "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "cliui/string-width": ["string-width@4.2.3", "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -2889,6 +2910,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@linchkit/cap-ai-provider/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uM7kpZB5l977lW7+2X1+klBUxIZQ78+1a9jHlaHFEzcOcmmslTl3sdP0QqfuuBcO0YBM2gwOiqVdp8i4TRQYcw=="],
 
@@ -3017,5 +3040,7 @@
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
   }
 }

--- a/e2e/browser/helpers/browser.ts
+++ b/e2e/browser/helpers/browser.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared helpers for the real-browser e2e smoke suite.
+ *
+ * Drives the system Chrome/Chromium via puppeteer-core (no bundled browser
+ * download). Playwright is intentionally NOT used — it is incompatible with
+ * the Bun test runner on this project.
+ */
+
+import { existsSync } from "node:fs";
+import puppeteer, { type Browser, type Page } from "puppeteer-core";
+
+/** Base URL of the Vite dev UI (React SPA). */
+export const UI_URL = process.env.LINCHKIT_E2E_UI_URL ?? "http://localhost:3000";
+
+/** Base URL of the LinchKit API server (Elysia). */
+export const API_URL = process.env.LINCHKIT_E2E_API_URL ?? "http://localhost:3001";
+
+/** Master gate: browser e2e only runs when explicitly enabled. */
+export const BROWSER_E2E_ENABLED = process.env.LINCHKIT_E2E_BROWSER === "1";
+
+/** Known Chrome/Chromium install locations, probed in order. */
+const CHROME_CANDIDATES = [
+  // macOS default
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  // Linux candidates
+  "/usr/bin/google-chrome",
+  "/usr/bin/google-chrome-stable",
+  "/usr/bin/chromium-browser",
+  "/usr/bin/chromium",
+];
+
+/**
+ * Resolve the Chrome executable path.
+ * `LINCHKIT_CHROME_PATH` wins; otherwise the first existing known location.
+ */
+export function resolveChromePath(): string {
+  const fromEnv = process.env.LINCHKIT_CHROME_PATH;
+  if (fromEnv) {
+    if (!existsSync(fromEnv)) {
+      throw new Error(
+        `LINCHKIT_CHROME_PATH is set to "${fromEnv}" but no executable exists there.`,
+      );
+    }
+    return fromEnv;
+  }
+  for (const candidate of CHROME_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+  throw new Error(
+    "No Chrome/Chromium executable found. Set LINCHKIT_CHROME_PATH to your browser binary " +
+      `(probed: ${CHROME_CANDIDATES.join(", ")}).`,
+  );
+}
+
+/** Launch a headless browser against the system Chrome. */
+export async function launchBrowser(): Promise<Browser> {
+  return puppeteer.launch({
+    executablePath: resolveChromePath(),
+    headless: true,
+    // --no-sandbox keeps CI containers happy; --disable-dev-shm-usage avoids
+    // tiny /dev/shm crashes in Docker.
+    args: ["--no-sandbox", "--disable-dev-shm-usage"],
+  });
+}
+
+/** A page plus the uncaught in-page errors collected while driving it. */
+export interface TrackedPage {
+  page: Page;
+  /** Uncaught exceptions thrown inside the page ('pageerror' events). */
+  pageErrors: Error[];
+}
+
+/** Open a fresh page that records every uncaught in-page error. */
+export async function newTrackedPage(browser: Browser): Promise<TrackedPage> {
+  const page = await browser.newPage();
+  page.setDefaultTimeout(20_000);
+  page.setDefaultNavigationTimeout(30_000);
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(err instanceof Error ? err : new Error(String(err)));
+  });
+  return { page, pageErrors };
+}
+
+/** Format collected page errors for assertion messages. */
+export function describePageErrors(errors: Error[]): string {
+  return errors.map((e) => e.message).join(" | ");
+}

--- a/e2e/browser/smoke.test.ts
+++ b/e2e/browser/smoke.test.ts
@@ -48,13 +48,21 @@ interface ExecutionsResponse {
   data?: { items: ExecutionItem[]; total: number };
 }
 
-/** Query the execution log, optionally filtered by action name. */
+/**
+ * Query the execution log, optionally filtered by action name. Transient
+ * failures (non-200, network error) yield [] so polling call sites retry
+ * until their own deadline instead of failing the whole test on one blip.
+ */
 async function fetchExecutions(action?: string): Promise<ExecutionItem[]> {
   const qs = action ? `?action=${encodeURIComponent(action)}&pageSize=50` : "?pageSize=50";
-  const res = await fetch(`${API_URL}/api/executions${qs}`);
-  expect(res.status).toBe(200);
-  const body = (await res.json()) as ExecutionsResponse;
-  return body.data?.items ?? [];
+  try {
+    const res = await fetch(`${API_URL}/api/executions${qs}`);
+    if (res.status !== 200) return [];
+    const body = (await res.json()) as ExecutionsResponse;
+    return body.data?.items ?? [];
+  } catch {
+    return [];
+  }
 }
 
 describe.skipIf(!BROWSER_E2E_ENABLED)("browser e2e smoke", () => {

--- a/e2e/browser/smoke.test.ts
+++ b/e2e/browser/smoke.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Real-browser e2e smoke suite.
+ *
+ * Drives the actual React UI (Vite dev server or any deployed instance)
+ * through the system Chrome via puppeteer-core, against a running LinchKit
+ * API server. Each test pins a wiring-class bug found in the 2026-06-10 live
+ * testing wave that unit tests could not see:
+ *
+ *   a. blank app shell           — #533 (node:fs leak in the client barrel)
+ *   b. "[object Object]" cells   — #537 (relation/object cell rendering)
+ *   c. System Overview crash     — #538 (/health response shape)
+ *   d. transition → bound Action — #536 (header buttons bypassed Actions)
+ *   e. evolution run-cycle wired — #535/#541 (dev server evolutionRuntime)
+ *   f. AI assistant configured   — #535 (dev server aiConfig wiring)
+ *
+ * Gated: the whole file self-skips unless LINCHKIT_E2E_BROWSER=1 so the
+ * normal `bun run test` batch (which scans ./e2e/) stays green on machines
+ * without Chrome or running servers. Use `bun run test:e2e` to execute.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { Browser } from "puppeteer-core";
+import {
+  API_URL,
+  BROWSER_E2E_ENABLED,
+  describePageErrors,
+  launchBrowser,
+  newTrackedPage,
+  UI_URL,
+} from "./helpers/browser";
+
+/** Per-test timeout for browser-driven cases (page loads + polling). */
+const TEST_TIMEOUT_MS = 60_000;
+
+/** Shape of one row of GET /api/executions. */
+interface ExecutionItem {
+  id: string;
+  action: string;
+  entity?: string;
+  status: string;
+  input?: Record<string, unknown>;
+  stateTransition?: { from: string; to: string };
+}
+
+/** Envelope of GET /api/executions. */
+interface ExecutionsResponse {
+  success: boolean;
+  data?: { items: ExecutionItem[]; total: number };
+}
+
+/** Query the execution log, optionally filtered by action name. */
+async function fetchExecutions(action?: string): Promise<ExecutionItem[]> {
+  const qs = action ? `?action=${encodeURIComponent(action)}&pageSize=50` : "?pageSize=50";
+  const res = await fetch(`${API_URL}/api/executions${qs}`);
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as ExecutionsResponse;
+  return body.data?.items ?? [];
+}
+
+describe.skipIf(!BROWSER_E2E_ENABLED)("browser e2e smoke", () => {
+  let browser: Browser;
+
+  beforeAll(async () => {
+    // Guard: bun may still run hooks of a skipped describe in some versions —
+    // never launch Chrome unless the suite is actually enabled.
+    if (!BROWSER_E2E_ENABLED) return;
+    browser = await launchBrowser();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  // ── a. App shell loads non-blank (pins #533 blank-page class) ──────────
+  test(
+    "app shell renders a non-blank page with zero uncaught page errors",
+    async () => {
+      const { page, pageErrors } = await newTrackedPage(browser);
+      try {
+        await page.goto(`${UI_URL}/`, { waitUntil: "networkidle2" });
+        // The sidebar Home link is part of the app shell — present on every
+        // route once the React tree mounts.
+        await page.waitForSelector('a[href="/"]', { timeout: 20_000 });
+
+        const bodyTextLength = await page.evaluate(() => document.body.innerText.trim().length);
+        // A blank/white page renders ~0 chars; the real shell renders the
+        // sidebar + workspace content (hundreds of chars). 200 is a safe floor
+        // that tolerates demo-data variance.
+        expect(bodyTextLength).toBeGreaterThan(200);
+        expect(pageErrors, `uncaught page errors: ${describePageErrors(pageErrors)}`).toHaveLength(
+          0,
+        );
+      } finally {
+        await page.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // ── b. Entity list renders real labels (pins #537 [object Object]) ─────
+  test(
+    "purchase_request list renders rows without [object Object] cells",
+    async () => {
+      const { page, pageErrors } = await newTrackedPage(browser);
+      try {
+        await page.goto(`${UI_URL}/entities/purchase_request`, { waitUntil: "networkidle2" });
+        await page.waitForSelector("table tbody tr", { timeout: 20_000 });
+
+        const { rowCount, badCells, bodyHasObjectObject } = await page.evaluate(() => {
+          const rows = Array.from(document.querySelectorAll("table tbody tr"));
+          const cells = Array.from(document.querySelectorAll("table tbody td"));
+          const bad = cells
+            .map((cell) => (cell.textContent ?? "").trim())
+            .filter((text) => text.includes("[object Object]"));
+          return {
+            rowCount: rows.length,
+            badCells: bad,
+            bodyHasObjectObject: document.body.innerText.includes("[object Object]"),
+          };
+        });
+
+        expect(rowCount).toBeGreaterThanOrEqual(1);
+        expect(badCells, `cells rendered as [object Object]: ${badCells.join(", ")}`).toHaveLength(
+          0,
+        );
+        expect(bodyHasObjectObject).toBe(false);
+        expect(pageErrors, `uncaught page errors: ${describePageErrors(pageErrors)}`).toHaveLength(
+          0,
+        );
+      } finally {
+        await page.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // ── c. System Overview renders without crashing (pins #538) ────────────
+  test(
+    "System Overview page renders without error boundary or page errors",
+    async () => {
+      const { page, pageErrors } = await newTrackedPage(browser);
+      try {
+        await page.goto(`${UI_URL}/admin/system`, { waitUntil: "networkidle2" });
+        // The metrics grid is the page's core content; waiting for its label
+        // proves the data-driven section rendered (not just the shell).
+        await page.waitForFunction(() => document.body.innerText.includes("Registered Entities"), {
+          timeout: 20_000,
+        });
+
+        const bodyText = await page.evaluate(() => document.body.innerText);
+        // "Something went wrong" is the app's ErrorBoundary fallback title
+        // (addons/adapter-ui/cap-adapter-ui/src/components/error-boundary.tsx).
+        expect(bodyText).not.toContain("Something went wrong");
+        expect(pageErrors, `uncaught page errors: ${describePageErrors(pageErrors)}`).toHaveLength(
+          0,
+        );
+      } finally {
+        await page.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // ── d. Transition button dispatches the BOUND action (pins #536) ───────
+  test(
+    "clicking the Submit transition dispatches submit_purchase_request, not a generic update",
+    async () => {
+      // Create a fresh draft record via the API so the test never depends on
+      // pre-existing demo data being in a clickable state.
+      const title = `E2E transition ${Date.now()}`;
+      const createRes = await fetch(`${API_URL}/api/actions/create_purchase_request`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          amount: 99,
+          requester_email: "e2e-smoke@example.com",
+        }),
+      });
+      expect(createRes.status).toBe(200);
+      const created = (await createRes.json()) as {
+        success: boolean;
+        data?: { id: string; status: string };
+      };
+      expect(created.success).toBe(true);
+      const recordId = created.data?.id;
+      if (!recordId) throw new Error("create_purchase_request returned no record id");
+      expect(created.data?.status).toBe("draft");
+
+      const { page, pageErrors } = await newTrackedPage(browser);
+      try {
+        await page.goto(`${UI_URL}/entities/purchase_request/${recordId}`, {
+          waitUntil: "networkidle2",
+        });
+
+        // The header transition button is labeled from the bound action
+        // ("Submit for Approval" in the demo); match on /submit/i so a label
+        // tweak doesn't break the suite.
+        await page.waitForFunction(
+          () =>
+            Array.from(document.querySelectorAll("button")).some((b) =>
+              /submit/i.test(b.textContent ?? ""),
+            ),
+          { timeout: 20_000 },
+        );
+        const clickedLabel = await page.evaluate(() => {
+          const button = Array.from(document.querySelectorAll("button")).find((b) =>
+            /submit/i.test(b.textContent ?? ""),
+          );
+          if (!button) return null;
+          button.click();
+          return (button.textContent ?? "").trim();
+        });
+        expect(clickedLabel).not.toBeNull();
+
+        // Poll the execution log until the BOUND action shows up for this
+        // record. A bypassing implementation (#536) would log only a generic
+        // update with no state transition.
+        let matched: ExecutionItem | undefined;
+        const deadline = Date.now() + 20_000;
+        while (Date.now() < deadline && !matched) {
+          const items = await fetchExecutions("submit_purchase_request");
+          matched = items.find(
+            (item) => item.input?.id === recordId && item.status === "succeeded",
+          );
+          if (!matched) await new Promise((resolve) => setTimeout(resolve, 1_000));
+        }
+
+        expect(
+          matched,
+          "no succeeded submit_purchase_request execution recorded for the clicked record",
+        ).toBeDefined();
+        expect(matched?.action).toBe("submit_purchase_request");
+        // The state machine transition proves the click went through the bound
+        // Action (draft → pending), not a raw field write.
+        expect(matched?.stateTransition).toEqual({ from: "draft", to: "pending" });
+
+        // And the click must NOT have gone through the generic CRUD update.
+        const updates = await fetchExecutions("update_purchase_request");
+        const strayUpdate = updates.find((item) => item.input?.id === recordId);
+        expect(
+          strayUpdate,
+          "transition click was routed through generic update_purchase_request",
+        ).toBeUndefined();
+
+        expect(pageErrors, `uncaught page errors: ${describePageErrors(pageErrors)}`).toHaveLength(
+          0,
+        );
+      } finally {
+        await page.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // ── e. Evolution on-demand cycle is wired (pins #535/#541) ─────────────
+  // Asserts the post-#541 contract: the dev server wires an evolutionRuntime,
+  // so the on-demand cycle returns 200 with counters (501 = not wired).
+  // Additionally excludable via LINCHKIT_E2E_EVOLUTION=0 while #541 lands.
+  test.skipIf(process.env.LINCHKIT_E2E_EVOLUTION === "0")(
+    "POST /api/evolution/run-cycle returns 200 with cycle counters",
+    async () => {
+      const res = await fetch(`${API_URL}/api/evolution/run-cycle`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(
+        res.status,
+        "501 means the server's evolutionRuntime is not wired (the #535 dev-server gap; fixed by #541)",
+      ).toBe(200);
+      const body = (await res.json()) as {
+        success: boolean;
+        data?: { created: number; deduped: number; total: number; createdIds: string[] };
+      };
+      expect(body.success).toBe(true);
+      expect(typeof body.data?.created).toBe("number");
+      expect(typeof body.data?.deduped).toBe("number");
+      expect(typeof body.data?.total).toBe("number");
+      expect(Array.isArray(body.data?.createdIds)).toBe(true);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  // ── f. AI assistant reachability (pins #535 aiConfig wiring) ───────────
+  // Needs a real provider key — opt-in via LINCHKIT_E2E_AI=1.
+  test.skipIf(process.env.LINCHKIT_E2E_AI !== "1")(
+    "POST /api/ai/chat does not return the 'AI service is not configured' 503",
+    async () => {
+      // The endpoint speaks the Vercel AI SDK UIMessage format: each message
+      // carries a `parts` array (a flat `content` string is rejected).
+      const res = await fetch(`${API_URL}/api/ai/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", parts: [{ type: "text", text: "Reply with OK only." }] }],
+        }),
+      });
+      // 503 is the specific "AI service is not configured" failure this test
+      // pins; any 2xx (SSE stream) proves the provider wiring is live.
+      expect(res.status).not.toBe(503);
+      expect(res.status).toBe(200);
+      // Don't consume the whole SSE stream — headers are enough.
+      await res.body?.cancel();
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "bunx tsc --noEmit",
     "test": "bash scripts/run-tests.sh",
     "test:coverage": "bash scripts/verify-test-coverage.sh",
+    "test:e2e": "bash scripts/run-e2e-browser.sh",
     "build": "bun run --filter '@linchkit/core' build && bun run --filter '@linchkit/devtools' build && bun run --filter '@linchkit/cli' --filter '@linchkit/cap-adapter-ui' build",
     "dev": "bun run --filter '@linchkit/cap-adapter-server' --filter '@linchkit/cap-adapter-ui' dev",
     "dev:server": "bun run --filter @linchkit/cap-adapter-server dev",
@@ -31,6 +32,7 @@
     "@changesets/cli": "^2.30.0",
     "bun-types": "latest",
     "drizzle-kit": "^0.31.10",
+    "puppeteer-core": "^25.1.0",
     "tsup": "^8.5.1"
   },
   "dependencies": {

--- a/scripts/run-e2e-browser.sh
+++ b/scripts/run-e2e-browser.sh
@@ -36,6 +36,7 @@ kill_tree() {
 }
 
 cleanup() {
+  local exit_code=$?
   local pid
   for pid in "${started_pids[@]:-}"; do
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
@@ -43,6 +44,14 @@ cleanup() {
       kill_tree "$pid"
     fi
   done
+  # Remove the temp log dir on success; keep it for diagnosis on failure.
+  if [ -d "$LOG_DIR" ]; then
+    if [ "$exit_code" -eq 0 ]; then
+      rm -rf "$LOG_DIR"
+    else
+      echo "[e2e] server logs kept at $LOG_DIR (exit $exit_code)"
+    fi
+  fi
 }
 trap cleanup EXIT
 

--- a/scripts/run-e2e-browser.sh
+++ b/scripts/run-e2e-browser.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Real-browser e2e smoke runner.
+#
+# - Reuses already-running dev servers when both the UI and the API answer
+#   their health probes; otherwise boots `bun run dev:server` / `bun run
+#   dev:ui` in the background and tears down ONLY the processes it started.
+# - Runs the gated browser suite with LINCHKIT_E2E_BROWSER=1 and propagates
+#   the bun test exit code.
+#
+# Env knobs:
+#   LINCHKIT_E2E_UI_URL   (default http://localhost:3000)
+#   LINCHKIT_E2E_API_URL  (default http://localhost:3001)
+#   LINCHKIT_CHROME_PATH  (browser binary override; see e2e/browser/helpers)
+#   LINCHKIT_E2E_AI=1        opt-in: AI assistant reachability test
+#   LINCHKIT_E2E_EVOLUTION=0 opt-out: evolution run-cycle test
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UI_URL="${LINCHKIT_E2E_UI_URL:-http://localhost:3000}"
+API_URL="${LINCHKIT_E2E_API_URL:-http://localhost:3001}"
+BOOT_TIMEOUT_SECS=90
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/linchkit-e2e.XXXXXX")"
+
+started_pids=()
+
+# Kill a process and all of its descendants (bun run spawns child processes).
+kill_tree() {
+  local pid="$1"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    kill_tree "$child"
+  done
+  kill "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  local pid
+  for pid in "${started_pids[@]:-}"; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      echo "[e2e] stopping process tree $pid"
+      kill_tree "$pid"
+    fi
+  done
+}
+trap cleanup EXIT
+
+api_healthy() {
+  curl -fsS -m 3 "$API_URL/health" >/dev/null 2>&1
+}
+
+ui_healthy() {
+  curl -fsS -m 3 "$UI_URL/" >/dev/null 2>&1
+}
+
+wait_for() {
+  local label="$1" check_fn="$2" waited=0
+  while ! "$check_fn"; do
+    if [ "$waited" -ge "$BOOT_TIMEOUT_SECS" ]; then
+      echo "[e2e] ERROR: $label did not become ready within ${BOOT_TIMEOUT_SECS}s" >&2
+      echo "[e2e] logs (if started by this script): $LOG_DIR" >&2
+      exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo "[e2e] $label is ready"
+}
+
+if api_healthy; then
+  echo "[e2e] reusing running API server at $API_URL"
+else
+  echo "[e2e] starting dev:server (log: $LOG_DIR/server.log)"
+  (cd "$ROOT_DIR" && bun run dev:server >"$LOG_DIR/server.log" 2>&1) &
+  started_pids+=("$!")
+fi
+
+if ui_healthy; then
+  echo "[e2e] reusing running UI at $UI_URL"
+else
+  echo "[e2e] starting dev:ui (log: $LOG_DIR/ui.log)"
+  (cd "$ROOT_DIR" && bun run dev:ui >"$LOG_DIR/ui.log" 2>&1) &
+  started_pids+=("$!")
+fi
+
+wait_for "API ($API_URL/health)" api_healthy
+wait_for "UI ($UI_URL/)" ui_healthy
+
+echo "[e2e] running browser smoke suite"
+set +e
+(cd "$ROOT_DIR" && LINCHKIT_E2E_BROWSER=1 bun test ./e2e/browser/ --timeout 120000)
+status=$?
+set -e
+
+exit "$status"


### PR DESCRIPTION
## Summary
User-mandated real end-to-end browser tests after today's live-testing wave proved green unit tests can't see wiring-class bugs. Six puppeteer-core tests drive the actual Chrome against the running app:

| Test | Pins | Live result |
|---|---|---|
| App shell non-blank, zero `pageerror`s | #533 blank-page class | PASS |
| Entity list rows show resolved labels, no `[object Object]` cell | #537 | PASS |
| System Overview renders, no error boundary | #538 | PASS |
| Click transition button → BOUND action (`submit_purchase_request`) appears in `/api/executions` with `stateTransition`, and no generic update for that record | #536 | PASS (real click, full loop) |
| `POST /api/evolution/run-cycle` → 200 + counters | #541 contract | fails against pre-#541 servers by design; excludable `LINCHKIT_E2E_EVOLUTION=0` |
| `POST /api/ai/chat` not 503 | #535 | PASS (gated `LINCHKIT_E2E_AI=1`, needs a provider key) |

## Why puppeteer-core
Researched + verified empirically: Bun supports Puppeteer officially (since v0.6.7); Playwright's browser launcher hangs/times out under Bun (oven-sh/bun#23826, #27977 — not officially supported). puppeteer-core drives the system Chrome, so no browser binary download. Validated live on this machine before building.

## Safety in the batched runner
`scripts/run-tests.sh` scans `./e2e/` — the suite self-skips unless `LINCHKIT_E2E_BROWSER=1` (verified: 6 skip / exit 0 / no Chrome launch without the env). Run for real via `bun run test:e2e` — `scripts/run-e2e-browser.sh` reuses already-healthy dev servers or boots its own and tears down only what it started.

## Testing
Live run against the dev servers: 4 pass / evolution fails-as-expected (pre-#541 server) / AI passes with the configured provider. Full batched suite green; typecheck + biome clean.

New devDependency (user-approved): `puppeteer-core@^25.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)