### PR TITLE
refactor(adapter-ui): migrate evolution and system-overview pages to react-query

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/src/pages/evolution.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/evolution.tsx
@@ -16,6 +16,7 @@ import {
   CardTitle,
   Skeleton,
 } from "@linchkit/ui-kit/components";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import {
   AlertTriangleIcon,
@@ -33,7 +34,7 @@ import {
   UserIcon,
   XCircleIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { NlRuleDrafter } from "@/components/nl-rule-drafter";
 import { SchedulerStatusPanel } from "@/components/scheduler-status-panel";
@@ -264,45 +265,39 @@ function RunCycleOutcome({
 
 export function EvolutionPage() {
   const { t } = useTranslation();
-  const [entries, setEntries] = useState<EvolutionEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [running, setRunning] = useState(false);
-  const [runResult, setRunResult] = useState<RunEvolutionCycleResult | null>(null);
 
-  const loadHistory = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await fetchEvolutionHistory();
-      setEntries(data);
-    } catch {
-      setEntries([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // History load failures render the same empty-timeline card as "no history"
+  // (the manual loader swallowed errors into an empty list).
+  const historyQuery = useQuery<EvolutionEntry[]>({
+    queryKey: ["evolution-history"],
+    queryFn: fetchEvolutionHistory,
+  });
+  const entries = historyQuery.data ?? [];
+  const loading = historyQuery.isLoading;
 
-  const handleRunCycle = useCallback(async () => {
+  const runCycleMutation = useMutation<RunEvolutionCycleResult>({
+    mutationFn: async () => {
+      try {
+        return await runEvolutionCycle();
+      } catch (err) {
+        // runEvolutionCycle maps transport errors internally; this defensive catch
+        // keeps an unexpected throw from becoming an unhandled mutation error.
+        return {
+          kind: "error",
+          message: err instanceof Error ? err.message : "Evolution cycle failed",
+        };
+      }
+    },
+  });
+  const running = runCycleMutation.isPending;
+  // Hide the previous outcome while a new cycle is in flight (the manual
+  // handler reset the result to null before each run).
+  const runResult = running ? null : (runCycleMutation.data ?? null);
+
+  const handleRunCycle = () => {
     if (running) return;
-    setRunning(true);
-    setRunResult(null);
-    try {
-      const result = await runEvolutionCycle();
-      setRunResult(result);
-    } catch (err) {
-      // runEvolutionCycle maps transport errors internally; this defensive catch
-      // keeps an unexpected throw from becoming an unhandled rejection.
-      setRunResult({
-        kind: "error",
-        message: err instanceof Error ? err.message : "Evolution cycle failed",
-      });
-    } finally {
-      setRunning(false);
-    }
-  }, [running]);
-
-  useEffect(() => {
-    loadHistory();
-  }, [loadHistory]);
+    runCycleMutation.mutate();
+  };
 
   return (
     <div className="p-4 space-y-4">
@@ -315,7 +310,7 @@ export function EvolutionPage() {
       <NlRuleDrafter />
 
       <div className="flex flex-wrap items-center justify-end gap-2">
-        <Button size="sm" onClick={() => void handleRunCycle()} disabled={running}>
+        <Button size="sm" onClick={handleRunCycle} disabled={running}>
           {running ? (
             <Loader2Icon className="mr-1 size-3.5 animate-spin" />
           ) : (
@@ -326,7 +321,7 @@ export function EvolutionPage() {
         <Button
           variant="outline"
           size="icon-sm"
-          onClick={loadHistory}
+          onClick={() => void historyQuery.refetch()}
           aria-label={t("common.refresh", "Refresh")}
         >
           <RefreshCwIcon className="h-4 w-4" />

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
@@ -242,8 +242,11 @@ export function SystemOverviewPage() {
   const [configOpen, setConfigOpen] = useState(false);
 
   // GET /health — refetchInterval replaces the manual setInterval polling.
+  // retry: false restores the pre-migration zero-retry behavior — a health
+  // dashboard should reflect failures immediately, not after a retry cycle.
   const healthQuery = useQuery<HealthResponse | null>({
     queryKey: ["health"],
+    retry: false,
     queryFn: async () => {
       const res = await fetch("/health");
       const data: Record<string, unknown> | null = await res.json().catch(() => null);

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/system-overview.tsx
@@ -27,6 +27,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@linchkit/ui-kit/components";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangleIcon,
   BoxIcon,
@@ -42,7 +43,7 @@ import {
   ServerIcon,
   XCircleIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 // ── Types ────────────────────────────────────────────────
@@ -232,14 +233,7 @@ function BannerIcon({ status }: { status: string }) {
 export function SystemOverviewPage() {
   const { t } = useTranslation();
 
-  const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [healthLoading, setHealthLoading] = useState(false);
-  const [healthError, setHealthError] = useState<string | null>(null);
-  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  const [settings, setSettings] = useState<SettingsData | null>(null);
-  const [settingsError, setSettingsError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   // Capability detail dialog
   const [selectedCap, setSelectedCap] = useState<CapabilityDetail | null>(null);
@@ -247,50 +241,52 @@ export function SystemOverviewPage() {
   // Startup config dialog
   const [configOpen, setConfigOpen] = useState(false);
 
-  const fetchHealth = useCallback(async () => {
-    setHealthLoading(true);
-    setHealthError(null);
-    try {
+  // GET /health — refetchInterval replaces the manual setInterval polling.
+  const healthQuery = useQuery<HealthResponse | null>({
+    queryKey: ["health"],
+    queryFn: async () => {
       const res = await fetch("/health");
-      const data = await res.json().catch(() => null);
+      const data: Record<string, unknown> | null = await res.json().catch(() => null);
       if (data?.checks) {
-        setHealth({
+        return {
           ...(data as Omit<HealthResponse, "checks">),
           checks: normalizeHealthChecks(data.checks),
-        });
-        setLastRefresh(new Date());
-        return;
+        };
       }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    } catch (err) {
-      setHealthError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setHealthLoading(false);
-    }
-  }, []);
+      // OK response without a `checks` payload: keep whatever we last had
+      // (the manual loader left state untouched in this case).
+      return queryClient.getQueryData<HealthResponse | null>(["health"]) ?? null;
+    },
+    refetchInterval: REFRESH_INTERVAL_MS,
+  });
+  const health = healthQuery.data ?? null;
+  // isFetching (not isLoading) so the refresh icon also spins on interval polls,
+  // matching the manual loader which flagged loading on every fetch.
+  const healthLoading = healthQuery.isFetching;
+  const healthError = healthQuery.error
+    ? healthQuery.error instanceof Error
+      ? healthQuery.error.message
+      : String(healthQuery.error)
+    : null;
+  const lastRefresh = healthQuery.dataUpdatedAt ? new Date(healthQuery.dataUpdatedAt) : null;
 
-  const fetchSettings = useCallback(async () => {
-    try {
+  // GET /api/settings — fetched once per mount (no polling).
+  const settingsQuery = useQuery<SettingsData>({
+    queryKey: ["settings"],
+    queryFn: async () => {
       const res = await fetch("/api/settings");
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
-      setSettings(json.data as SettingsData);
-    } catch (err) {
-      setSettingsError(err instanceof Error ? err.message : String(err));
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchHealth();
-    intervalRef.current = setInterval(fetchHealth, REFRESH_INTERVAL_MS);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [fetchHealth]);
-
-  useEffect(() => {
-    fetchSettings();
-  }, [fetchSettings]);
+      const json: { data?: SettingsData } = await res.json();
+      return json.data as SettingsData;
+    },
+  });
+  const settings = settingsQuery.data ?? null;
+  const settingsError = settingsQuery.error
+    ? settingsQuery.error instanceof Error
+      ? settingsQuery.error.message
+      : String(settingsQuery.error)
+    : null;
 
   const gen = settings?.general;
   const version = health?.system?.version ?? gen?.version;
@@ -355,7 +351,7 @@ export function SystemOverviewPage() {
             <Button
               variant="ghost"
               size="sm"
-              onClick={fetchHealth}
+              onClick={() => void healthQuery.refetch()}
               disabled={healthLoading}
               className="h-7 px-2"
             >


### PR DESCRIPTION
## Summary
Wheel-audit follow-up (same-repo inconsistency): `@tanstack/react-query` has been wired for a while (Provider in `app.tsx`, `useQuery` in relation-graph / ref-widget / many-to-many-widget), but the two recently-(re)written admin pages still hand-rolled `useState+useEffect` loading and a manual `setInterval` health poll. This migrates exactly those two pages; the API layer (`lib/proposal-api.ts`) and `normalizeHealthChecks` (+ its #538 tests) are untouched.

| Data | Hook | Key | Polling |
|---|---|---|---|
| evolution history | useQuery | `["evolution-history"]` | manual refresh → refetch() |
| run evolution cycle | useMutation | — | running = isPending; outcome masking preserved |
| /health | useQuery | `["health"]` | `refetchInterval` = same 30s constant; spinner on isFetching; lastRefresh from dataUpdatedAt |
| /api/settings | useQuery | `["settings"]` | per mount, as before |

Edge case preserved: a 200 response without `checks` keeps the previous health snapshot (queryFn falls back to `queryClient.getQueryData`).

Known minor deviations (inherent to react-query, consistent with the already-migrated pages): provider defaults `retry: 1` + window-focus refetch; evolution list stays visible during refetch instead of flashing skeletons; health error banner clears on success rather than at fetch start.

Convention going forward: new pages default to useQuery — this closes the gap the audit flagged as growing.

## Testing
- `bun test ./addons/adapter-ui/` — 542 pass
- Full batched suite green; typecheck + biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)