### PR TITLE
refactor: dedupe formatRelativeTime (7→1) and unify ID generation on crypto.randomUUID

### DIFF
--- a/addons/adapter-mcp/cap-mcp-ui/src/pages/mcp-dashboard.tsx
+++ b/addons/adapter-mcp/cap-mcp-ui/src/pages/mcp-dashboard.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import { ActivityIcon, ArrowRightIcon, PlugIcon, RadioIcon, ZapIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -184,17 +185,6 @@ export function McpDashboard() {
       </Card>
     </div>
   );
-}
-
-/** Format a timestamp as relative time (e.g. "2m ago") */
-function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 1) return "<1m ago";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
 }
 
 export default McpDashboard;

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/saved-views-logic.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/saved-views-logic.test.ts
@@ -45,7 +45,7 @@ function writeViews(entityName: string, views: SavedView[]): void {
 }
 
 function generateId(): string {
-  return `sv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  return `sv_${crypto.randomUUID()}`;
 }
 
 // Mock localStorage for Bun test environment

--- a/addons/adapter-ui/cap-adapter-ui/src/components/activity-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/activity-panel.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Badge, Button } from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import {
   ArrowRight,
   ChevronDown,
@@ -83,22 +84,6 @@ const STATUS_CONFIG: Record<string, StatusConfig> = {
 const DEFAULT_STATUS_CONFIG: StatusConfig = { variant: "outline" };
 
 // ── Helpers ───────────────────────────────────────────────
-
-function formatRelativeTime(
-  iso: string,
-  t: (key: string, opts?: Record<string, unknown>) => string,
-): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return t("time.justNow", { defaultValue: "just now" });
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return t("time.minutesAgo", { defaultValue: "{{count}}m ago", count: minutes });
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return t("time.hoursAgo", { defaultValue: "{{count}}h ago", count: hours });
-  const days = Math.floor(hours / 24);
-  if (days < 30) return t("time.daysAgo", { defaultValue: "{{count}}d ago", count: days });
-  return new Date(iso).toLocaleDateString();
-}
 
 function formatActionLabel(action: string, status?: string): string {
   // Strip schema prefix: "create_purchase_order" -> "create"

--- a/addons/adapter-ui/cap-adapter-ui/src/components/chatter-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/chatter-panel.tsx
@@ -10,6 +10,7 @@
  */
 
 import { Badge, Button, Textarea } from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import {
   ArrowRight,
   Edit,
@@ -31,23 +32,6 @@ import { addChatterMessage, type ChatterMessage, queryChatterMessages } from "..
 interface ChatterPanelProps {
   entityName: string;
   recordId: string;
-}
-
-// ── Time formatting ───────────────────────────────────────
-
-type TFunc = ReturnType<typeof useTranslation>["t"];
-
-function formatRelativeTime(iso: string, t: TFunc): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return t("time.justNow", { defaultValue: "just now" });
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return t("time.minutesAgo", { defaultValue: "{{count}}m ago", count: minutes });
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return t("time.hoursAgo", { defaultValue: "{{count}}h ago", count: hours });
-  const days = Math.floor(hours / 24);
-  if (days < 30) return t("time.daysAgo", { defaultValue: "{{count}}d ago", count: days });
-  return new Date(iso).toLocaleDateString();
 }
 
 // ── Log entry metadata rendering ──────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/components/one2many-field.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/one2many-field.tsx
@@ -154,7 +154,7 @@ function formatNumber(value: unknown, fieldDef: FieldDefinition): string {
 
 /** Generate a temporary ID for pending rows */
 function tempId(): string {
-  return `_new_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  return `_new_${crypto.randomUUID()}`;
 }
 
 // ── Component ────────────────────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/components/version-history-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/version-history-panel.tsx
@@ -11,7 +11,7 @@
 
 import type { FieldDefinition } from "@linchkit/core/types";
 import { Badge, Button, Checkbox, Separator, Skeleton } from "@linchkit/ui-kit/components";
-import { cn } from "@linchkit/ui-kit/lib/utils";
+import { cn, formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import {
   ArrowRight,
   ChevronDown,
@@ -82,22 +82,6 @@ const SYSTEM_FIELDS = new Set([
 
 function formatTimestamp(iso: string): string {
   return new Date(iso).toLocaleString();
-}
-
-function formatRelativeTime(
-  iso: string,
-  t: (key: string, opts?: Record<string, unknown>) => string,
-): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return t("time.justNow", { defaultValue: "just now" });
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return t("time.minutesAgo", { defaultValue: "{{count}}m ago", count: minutes });
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return t("time.hoursAgo", { defaultValue: "{{count}}h ago", count: hours });
-  const days = Math.floor(hours / 24);
-  if (days < 30) return t("time.daysAgo", { defaultValue: "{{count}}d ago", count: days });
-  return new Date(iso).toLocaleDateString();
 }
 
 function formatValue(value: unknown): string {

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-record-templates.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-record-templates.ts
@@ -33,7 +33,7 @@ function writeTemplates(entityName: string, templates: RecordTemplate[]): void {
 }
 
 function generateId(): string {
-  return `rt_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  return `rt_${crypto.randomUUID()}`;
 }
 
 // ── External store for useSyncExternalStore ──────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-saved-views.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-saved-views.ts
@@ -53,7 +53,7 @@ function writeViews(entityName: string, views: SavedView[]): void {
 }
 
 function generateId(): string {
-  return `sv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  return `sv_${crypto.randomUUID()}`;
 }
 
 // ── External store for useSyncExternalStore ──────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/dashboard.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/dashboard.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
   Skeleton,
 } from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import { Link } from "@tanstack/react-router";
 import {
   Activity,
@@ -158,19 +159,6 @@ function toCamelCase(name: string): string {
       .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
       .join("")
   );
-}
-
-function formatRelativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  return `${diffDay}d ago`;
 }
 
 // ── Status Badge ──────────────────────────────────────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/workspace.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/workspace.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
   Skeleton,
 } from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import { Link } from "@tanstack/react-router";
 import {
   Activity,
@@ -214,24 +215,6 @@ function StatusBadge({ status }: { status: ExecutionLogEntry["status"] }) {
         </Badge>
       );
   }
-}
-
-// ── Time formatting ─────────────────────────────────────
-
-function formatRelativeTime(
-  dateStr: string,
-  t: (key: string, opts?: Record<string, unknown>) => string,
-): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return t("time.justNow", { defaultValue: "just now" });
-  if (diffMin < 60) return t("time.minutesAgo", { defaultValue: "{{count}}m ago", count: diffMin });
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return t("time.hoursAgo", { defaultValue: "{{count}}h ago", count: diffHr });
-  const diffDay = Math.floor(diffHr / 24);
-  return t("time.daysAgo", { defaultValue: "{{count}}d ago", count: diffDay });
 }
 
 // ── State Breakdown Badges ──────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/ui-kit/__tests__/format-relative-time.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/ui-kit/__tests__/format-relative-time.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the shared formatRelativeTime helper.
+ *
+ * Inputs are constructed relative to Date.now() with comfortable margins
+ * around each unit boundary so a slow test run cannot flip a bucket.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { formatRelativeTime, type RelativeTimeTranslator } from "../src/lib/format-relative-time";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+function isoAgo(ms: number): string {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+describe("formatRelativeTime (default English translator)", () => {
+  test("under a minute renders 'just now'", () => {
+    expect(formatRelativeTime(isoAgo(0))).toBe("just now");
+    expect(formatRelativeTime(isoAgo(30_000))).toBe("just now");
+  });
+
+  test("minute boundary: 61s renders '1m ago'", () => {
+    expect(formatRelativeTime(isoAgo(61_000))).toBe("1m ago");
+  });
+
+  test("under an hour renders minutes", () => {
+    expect(formatRelativeTime(isoAgo(5 * MINUTE))).toBe("5m ago");
+    expect(formatRelativeTime(isoAgo(59 * MINUTE))).toBe("59m ago");
+  });
+
+  test("hour boundary: 61m renders '1h ago'", () => {
+    expect(formatRelativeTime(isoAgo(61 * MINUTE))).toBe("1h ago");
+  });
+
+  test("under a day renders hours", () => {
+    expect(formatRelativeTime(isoAgo(23 * HOUR))).toBe("23h ago");
+  });
+
+  test("day boundary: 25h renders '1d ago'", () => {
+    expect(formatRelativeTime(isoAgo(25 * HOUR))).toBe("1d ago");
+  });
+
+  test("under 30 days renders days", () => {
+    expect(formatRelativeTime(isoAgo(29 * DAY))).toBe("29d ago");
+  });
+
+  test("30 days and older falls back to the locale date", () => {
+    const iso = isoAgo(45 * DAY);
+    expect(formatRelativeTime(iso)).toBe(new Date(iso).toLocaleDateString());
+  });
+
+  test("future timestamps render 'just now'", () => {
+    expect(formatRelativeTime(isoAgo(-10_000))).toBe("just now");
+  });
+});
+
+describe("formatRelativeTime (custom translator)", () => {
+  /** Recording translator that captures the key/options it was called with. */
+  function makeRecorder() {
+    const calls: Array<{ key: string; options?: Record<string, unknown> }> = [];
+    const t: RelativeTimeTranslator = (key, options) => {
+      calls.push({ key, options });
+      return `<${key}>`;
+    };
+    return { calls, t };
+  }
+
+  test("passes the time.justNow key", () => {
+    const { calls, t } = makeRecorder();
+    expect(formatRelativeTime(isoAgo(10_000), t)).toBe("<time.justNow>");
+    expect(calls[0]).toEqual({
+      key: "time.justNow",
+      options: { defaultValue: "just now" },
+    });
+  });
+
+  test("passes the time.minutesAgo key with count", () => {
+    const { calls, t } = makeRecorder();
+    expect(formatRelativeTime(isoAgo(5 * MINUTE), t)).toBe("<time.minutesAgo>");
+    expect(calls[0]).toEqual({
+      key: "time.minutesAgo",
+      options: { defaultValue: "{{count}}m ago", count: 5 },
+    });
+  });
+
+  test("passes the time.hoursAgo key with count", () => {
+    const { calls, t } = makeRecorder();
+    expect(formatRelativeTime(isoAgo(3 * HOUR), t)).toBe("<time.hoursAgo>");
+    expect(calls[0]).toEqual({
+      key: "time.hoursAgo",
+      options: { defaultValue: "{{count}}h ago", count: 3 },
+    });
+  });
+
+  test("passes the time.daysAgo key with count", () => {
+    const { calls, t } = makeRecorder();
+    expect(formatRelativeTime(isoAgo(7 * DAY), t)).toBe("<time.daysAgo>");
+    expect(calls[0]).toEqual({
+      key: "time.daysAgo",
+      options: { defaultValue: "{{count}}d ago", count: 7 },
+    });
+  });
+
+  test("does not call the translator for >=30d old timestamps", () => {
+    const { calls, t } = makeRecorder();
+    const iso = isoAgo(45 * DAY);
+    expect(formatRelativeTime(iso, t)).toBe(new Date(iso).toLocaleDateString());
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/ui-kit/__tests__/format-relative-time.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/ui-kit/__tests__/format-relative-time.test.ts
@@ -110,4 +110,13 @@ describe("formatRelativeTime (custom translator)", () => {
     expect(formatRelativeTime(iso, t)).toBe(new Date(iso).toLocaleDateString());
     expect(calls).toHaveLength(0);
   });
+
+  test("renders empty string for falsy or unparseable input", () => {
+    const { calls, t } = makeRecorder();
+    expect(formatRelativeTime(null, t)).toBe("");
+    expect(formatRelativeTime(undefined, t)).toBe("");
+    expect(formatRelativeTime("", t)).toBe("");
+    expect(formatRelativeTime("not-a-date", t)).toBe("");
+    expect(calls).toHaveLength(0);
+  });
 });

--- a/addons/adapter-ui/cap-adapter-ui/ui-kit/src/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/ui-kit/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./components";
 export * from "./hooks";
-export { cn } from "./lib/utils";
+export { cn, formatRelativeTime, type RelativeTimeTranslator } from "./lib/utils";

--- a/addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/format-relative-time.ts
+++ b/addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/format-relative-time.ts
@@ -25,12 +25,17 @@ const defaultTranslator: RelativeTimeTranslator = (_key, options) => {
  * Format an ISO timestamp as a relative time string (e.g. "5m ago").
  *
  * Timestamps older than 30 days fall back to the locale date string.
+ * Falsy or unparseable input renders as "" rather than a misleading
+ * epoch date or "Invalid Date".
  */
 export function formatRelativeTime(
-  iso: string,
+  iso: string | null | undefined,
   t: RelativeTimeTranslator = defaultTranslator,
 ): string {
-  const diff = Date.now() - new Date(iso).getTime();
+  if (!iso) return "";
+  const timestamp = new Date(iso).getTime();
+  if (Number.isNaN(timestamp)) return "";
+  const diff = Date.now() - timestamp;
   const seconds = Math.floor(diff / 1000);
   if (seconds < 60) return t("time.justNow", { defaultValue: "just now" });
   const minutes = Math.floor(seconds / 60);

--- a/addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/format-relative-time.ts
+++ b/addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/format-relative-time.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared relative-time formatting.
+ *
+ * Single source of truth for the "Xm ago / Xh ago / Xd ago" timestamps
+ * rendered across cap-adapter-ui, cap-chatter-ui and cap-mcp-ui.
+ *
+ * i18n: callers that render localized UI pass their i18next `t` function;
+ * the translation keys (`time.justNow`, `time.minutesAgo`, `time.hoursAgo`,
+ * `time.daysAgo`) and `{{count}}` interpolation are preserved exactly so
+ * existing locale bundles keep working. Callers without i18n omit `t` and
+ * get the English default values.
+ */
+
+/** Translator signature compatible with i18next's `t` function. */
+export type RelativeTimeTranslator = (key: string, options?: Record<string, unknown>) => string;
+
+/** Fallback translator: renders the English default value with `{{count}}` interpolation. */
+const defaultTranslator: RelativeTimeTranslator = (_key, options) => {
+  const template = String(options?.defaultValue ?? "");
+  const count = options?.count;
+  return count === undefined ? template : template.replace("{{count}}", String(count));
+};
+
+/**
+ * Format an ISO timestamp as a relative time string (e.g. "5m ago").
+ *
+ * Timestamps older than 30 days fall back to the locale date string.
+ */
+export function formatRelativeTime(
+  iso: string,
+  t: RelativeTimeTranslator = defaultTranslator,
+): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return t("time.justNow", { defaultValue: "just now" });
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return t("time.minutesAgo", { defaultValue: "{{count}}m ago", count: minutes });
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return t("time.hoursAgo", { defaultValue: "{{count}}h ago", count: hours });
+  const days = Math.floor(hours / 24);
+  if (days < 30) return t("time.daysAgo", { defaultValue: "{{count}}d ago", count: days });
+  return new Date(iso).toLocaleDateString();
+}

--- a/addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/utils.ts
+++ b/addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+export { formatRelativeTime, type RelativeTimeTranslator } from "./format-relative-time";
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }

--- a/addons/chatter/cap-chatter-ui/src/chatter-panel.tsx
+++ b/addons/chatter/cap-chatter-ui/src/chatter-panel.tsx
@@ -16,6 +16,7 @@ import {
   queryChatterMessages,
 } from "@linchkit/cap-adapter-ui/lib/api";
 import { Badge, Button, Textarea } from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import {
   ArrowRight,
   Edit,
@@ -35,23 +36,6 @@ import { useTranslation } from "react-i18next";
 interface ChatterPanelProps {
   entityName: string;
   recordId: string;
-}
-
-// ── Time formatting ───────────────────────────────────────
-
-type TFunc = ReturnType<typeof useTranslation>["t"];
-
-function formatRelativeTime(iso: string, t: TFunc): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return t("time.justNow", { defaultValue: "just now" });
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return t("time.minutesAgo", { defaultValue: "{{count}}m ago", count: minutes });
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return t("time.hoursAgo", { defaultValue: "{{count}}h ago", count: hours });
-  const days = Math.floor(hours / 24);
-  if (days < 30) return t("time.daysAgo", { defaultValue: "{{count}}d ago", count: days });
-  return new Date(iso).toLocaleDateString();
 }
 
 // ── Log entry metadata rendering ──────────────────────────

--- a/packages/core/src/engine/proposal-engine.ts
+++ b/packages/core/src/engine/proposal-engine.ts
@@ -29,7 +29,7 @@ import { type ValidationContext, validateProposal } from "./validation-engine";
 // ── ID generation helper ─────────────────────────────────
 
 function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  return crypto.randomUUID();
 }
 
 // ── Create proposal options ──────────────────────────────

--- a/packages/core/src/engine/proposal-generator.ts
+++ b/packages/core/src/engine/proposal-generator.ts
@@ -48,7 +48,7 @@ const VALID_FIELD_TYPES = new Set<FieldType>([
 // ── ID generation helper ─────────────────────────────────
 
 function generateId(): string {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  return crypto.randomUUID();
 }
 
 // ── Dependencies ─────────────────────────────────────────

--- a/packages/core/src/persistence/in-memory-overlay-store.ts
+++ b/packages/core/src/persistence/in-memory-overlay-store.ts
@@ -12,9 +12,9 @@ import type {
   OverlayStore,
 } from "../types/overlay";
 
-/** Generate a simple random ID (good enough for in-memory use) */
+/** Generate a random ID with the overlay prefix */
 function generateId(): string {
-  return `overlay_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  return `overlay_${crypto.randomUUID()}`;
 }
 
 export class InMemoryOverlayStore implements OverlayStore {


### PR DESCRIPTION
## Summary
Wheel-audit follow-ups (commodity-utility class), zero new dependencies.

**formatRelativeTime 7→1.** Identical copies lived in chatter-panel/activity-panel/version-history-panel/dashboard/workspace (cap-adapter-ui), mcp-dashboard (cap-mcp-ui) and chatter-panel (cap-chatter-ui). One shared helper now lives in `@linchkit/ui-kit` — the lowest common layer (all three packages already import ui-kit; the import path `@linchkit/ui-kit/lib/utils` is an existing export-map entry, so no package.json changes). i18next stays out of ui-kit: the translator is injected (`RelativeTimeTranslator`), translation keys + `{{count}}` defaultValues preserved byte-identical, English fallback when omitted. 14 boundary tests.
Honest behavior deltas from unifying on the majority (4/7) variant: ≥30-day timestamps now render `toLocaleDateString()` everywhere (was unbounded "45d ago" in 3 spots); mcp-dashboard's "<1m ago" wording becomes "just now".

**IDs → crypto.randomUUID().** 47 call sites already used it; 6 stragglers hand-rolled `Date.now()+Math.random().toString(36)`: persisted Proposal IDs (proposal-engine/proposal-generator), overlay-store keys, and 3 UI temp keys. Prefixes (`overlay_`, `_new_`, `rt_`, `sv_`) preserved; verified nothing parses the old suffix (`shortIdOf` takes a UUID-safe tail slice; sorting is by createdAt). `cache-health.ts` probe key intentionally untouched (audit verdict KEEP).

## Testing
- packages/core 4166 pass · adapter-ui 556 pass (incl. 14 new) · adapter-mcp 206 pass · chatter 25 pass
- Full batched suite green; typecheck + biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)