### PR TITLE
refactor: adopt eventsource-parser for SSE and consolidate toPascalCase

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-naming.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-naming.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Pins the PRODUCER side of the GraphQL subscription field-name contract.
+ *
+ * src/graphql/naming.ts is the single source of truth for PascalCase naming
+ * on the server; build-subscriptions.ts uses it to publish fields named
+ * `on{Pascal}Created|Updated|Deleted`. The UI subscribes to those fields BY
+ * NAME using its own copy of toPascalCase
+ * (addons/adapter-ui/cap-adapter-ui/src/lib/api.ts — the UI must not import
+ * server code). The UI counterpart of this pin lives in
+ * addons/adapter-ui/cap-adapter-ui/__tests__/subscription-naming.test.ts and
+ * uses the SAME example: "purchase_request" → "PurchaseRequest".
+ */
+
+import { describe, expect, test } from "bun:test";
+import { GRAPHQL_NAME_RE, joinPascal, toCamelCase, toPascalCase } from "../src/graphql/naming";
+
+describe("graphql naming contract (server producer side)", () => {
+  test("toPascalCase pins the shared example: purchase_request → PurchaseRequest", () => {
+    expect(toPascalCase("purchase_request")).toBe("PurchaseRequest");
+    // Subscription field names derived from it (see build-subscriptions.ts)
+    expect(`on${toPascalCase("purchase_request")}Created`).toBe("onPurchaseRequestCreated");
+    expect(`on${toPascalCase("purchase_request")}Updated`).toBe("onPurchaseRequestUpdated");
+    expect(`on${toPascalCase("purchase_request")}Deleted`).toBe("onPurchaseRequestDeleted");
+  });
+
+  test("toPascalCase handles kebab-case, single words, and multi-segment names", () => {
+    expect(toPascalCase("purchase-order")).toBe("PurchaseOrder");
+    expect(toPascalCase("task")).toBe("Task");
+    expect(toPascalCase("purchase_order_line_item")).toBe("PurchaseOrderLineItem");
+  });
+
+  test("toPascalCase sanitizes illegal GraphQL name characters", () => {
+    expect(toPascalCase("weird.name")).toBe("Weirdname");
+    expect(toPascalCase("1task")).toBe("_1task");
+    expect(GRAPHQL_NAME_RE.test(toPascalCase("1task"))).toBe(true);
+  });
+
+  test("joinPascal is the raw join without sanitization", () => {
+    expect(joinPascal("purchase_request")).toBe("PurchaseRequest");
+    expect(joinPascal("weird.name")).toBe("Weird.name");
+  });
+
+  test("toCamelCase derives from toPascalCase", () => {
+    expect(toCamelCase("purchase_request")).toBe("purchaseRequest");
+    expect(toCamelCase("task")).toBe("task");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -48,13 +48,12 @@ import { buildSubscriptionFields, createEventBusPubSub } from "./build-subscript
 import { buildEventsGraphQLExtension } from "./events";
 import { buildFieldMetaList, getFieldMetaType } from "./field-meta";
 import { safeParseJSON } from "./json-arg";
+import { GRAPHQL_NAME_RE, toCamelCase, toPascalCase } from "./naming";
 import {
   generateActionInputType,
   generateGraphQLInputType,
   generateGraphQLObjectType,
 } from "./schema-to-graphql";
-
-const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
 
 /**
  * Sanitize an arbitrary identifier to a valid GraphQL field-name component
@@ -66,32 +65,6 @@ const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
 export function sanitizeGraphQLFieldName(name: string): string {
   const replaced = name.replace(/[^_0-9A-Za-z]/g, "_");
   return GRAPHQL_NAME_RE.test(replaced) ? replaced : `_${replaced}`;
-}
-
-/**
- * Convert a schema name to PascalCase with GraphQL name sanitization.
- * e.g. "purchase_request" -> "PurchaseRequest"
- */
-function toPascalCase(name: string): string {
-  const raw = name
-    .split(/[_-]/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join("");
-
-  // Strip characters not allowed in GraphQL names
-  const sanitized = raw.replace(/[^_0-9A-Za-z]/g, "");
-
-  // Ensure name starts with a letter or underscore
-  return GRAPHQL_NAME_RE.test(sanitized) ? sanitized : `_${sanitized}`;
-}
-
-/**
- * Convert a schema name to camelCase.
- * e.g. "purchase_request" -> "purchaseRequest"
- */
-function toCamelCase(name: string): string {
-  const pascal = toPascalCase(name);
-  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
 }
 
 /** GraphQL resolver context — carries actor, tenant isolation, locale, and data access */

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-subscriptions.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-subscriptions.ts
@@ -18,6 +18,7 @@ import {
   GraphQLString,
 } from "graphql";
 import { createPubSub } from "graphql-yoga";
+import { toPascalCase } from "./naming";
 
 // ── PubSub topic naming ──────────────────────────────────
 
@@ -38,19 +39,6 @@ const DeletedRecordType = new GraphQLObjectType({
     schema: { type: new GraphQLNonNull(GraphQLString) },
   },
 });
-
-// ── PascalCase helper (same as build-schema.ts) ──────────
-
-const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
-
-function toPascalCase(name: string): string {
-  const raw = name
-    .split(/[_-]/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join("");
-  const sanitized = raw.replace(/[^_0-9A-Za-z]/g, "");
-  return GRAPHQL_NAME_RE.test(sanitized) ? sanitized : `_${sanitized}`;
-}
 
 // ── PubSub + EventBus bridge ─────────────────────────────
 
@@ -144,6 +132,10 @@ export function buildSubscriptionFields(
     const objectType = entityObjectTypes.get(entity.name);
     if (!objectType) continue;
 
+    // PRODUCER side of the subscription field-name contract: the UI builds
+    // these `on{Pascal}...` names independently via toPascalCase in
+    // addons/adapter-ui/cap-adapter-ui/src/lib/api.ts (consumed by
+    // buildEntitySubscriptionQuery in hooks/use-subscription.ts).
     const pascalName = toPascalCase(entity.name);
     const entityName = entity.name;
 

--- a/addons/adapter-server/cap-adapter-server/src/graphql/naming.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/naming.ts
@@ -1,0 +1,48 @@
+/**
+ * GraphQL naming helpers — single source of truth for the graphql/ modules.
+ *
+ * IMPORTANT (producer/consumer contract): build-subscriptions.ts publishes
+ * subscription fields named `on{Pascal}Created|Updated|Deleted` via
+ * `toPascalCase`, and the UI subscribes to those fields BY NAME using its own
+ * copy of this helper (addons/adapter-ui/cap-adapter-ui/src/lib/api.ts —
+ * the UI must not import server code, so the copy cannot be shared).
+ * Both implementations MUST produce identical output for entity names,
+ * e.g. "purchase_request" → "PurchaseRequest". Pinned by unit tests on both
+ * sides: __tests__/graphql-naming.test.ts (server) and
+ * __tests__/subscription-naming.test.ts (cap-adapter-ui).
+ */
+
+/** Regex for valid GraphQL names */
+export const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
+
+/**
+ * Raw PascalCase join of a snake_case/kebab-case name, WITHOUT GraphQL name
+ * sanitization. Exposed so callers can detect whether sanitization changed
+ * the result (see schema-to-graphql.ts warn path).
+ */
+export function joinPascal(name: string): string {
+  return name
+    .split(/[_-]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
+/**
+ * Convert a snake_case/kebab-case name to PascalCase for GraphQL type names.
+ * Strips characters not allowed in GraphQL names and ensures the result
+ * starts with a letter or underscore.
+ * e.g. "purchase_request" → "PurchaseRequest"
+ */
+export function toPascalCase(name: string): string {
+  const sanitized = joinPascal(name).replace(/[^_0-9A-Za-z]/g, "");
+  return GRAPHQL_NAME_RE.test(sanitized) ? sanitized : `_${sanitized}`;
+}
+
+/**
+ * Convert a snake_case/kebab-case name to camelCase for GraphQL field names.
+ * e.g. "purchase_request" → "purchaseRequest"
+ */
+export function toCamelCase(name: string): string {
+  const pascal = toPascalCase(name);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/relation-resolvers.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/relation-resolvers.ts
@@ -30,6 +30,7 @@ import {
   GraphQLString,
 } from "graphql";
 import { cardinalityHandlers } from "./cardinality-handlers";
+import { toCamelCase, toPascalCase } from "./naming";
 import type { RelationDataLoaders } from "./relation-dataloader";
 
 // ── Types ──────────────────────────────────────────────────
@@ -142,23 +143,9 @@ export async function fetchByFK(
 
 // ── Naming helpers ────────────────────────────────────────
 
-const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
-
-/** Convert a snake_case name to PascalCase for GraphQL type names */
-export function toPascalCase(name: string): string {
-  const raw = name
-    .split(/[_-]/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join("");
-  const sanitized = raw.replace(/[^_0-9A-Za-z]/g, "");
-  return GRAPHQL_NAME_RE.test(sanitized) ? sanitized : `_${sanitized}`;
-}
-
-/** Convert a snake_case name to camelCase for GraphQL field names */
-export function toCamelCase(name: string): string {
-  const pascal = toPascalCase(name);
-  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
-}
+// Re-exported for backwards compatibility — the canonical definitions live
+// in ./naming (single source of truth across the graphql/ modules).
+export { toCamelCase, toPascalCase } from "./naming";
 
 // ── Edge type helpers for M:N with properties ──────────────
 

--- a/addons/adapter-server/cap-adapter-server/src/graphql/schema-to-graphql.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/schema-to-graphql.ts
@@ -33,6 +33,7 @@ import {
   type GraphQLOutputType,
   GraphQLString,
 } from "graphql";
+import { joinPascal, toPascalCase as toPascalCaseBase } from "./naming";
 import type { RelationResolverContext } from "./relation-resolvers";
 import { buildRelationFields } from "./relation-resolvers";
 
@@ -206,27 +207,16 @@ export function setGraphQLLogger(logger: Logger): void {
   moduleLogger = logger;
 }
 
-/** Regex for valid GraphQL names */
-const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
-
 /**
  * Convert a schema name to PascalCase for GraphQL type naming.
- * Strips illegal characters and validates the result.
+ * Delegates to the shared helper in ./naming and additionally warns when
+ * GraphQL-name sanitization altered the raw PascalCase join.
  * e.g. "order_item" → "OrderItem"
  */
 function toPascalCase(name: string): string {
-  const raw = name
-    .split(/[_-]/)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join("");
+  const result = toPascalCaseBase(name);
 
-  // Strip characters not allowed in GraphQL names
-  const sanitized = raw.replace(/[^_0-9A-Za-z]/g, "");
-
-  // Ensure name starts with a letter or underscore
-  const result = GRAPHQL_NAME_RE.test(sanitized) ? sanitized : `_${sanitized}`;
-
-  if (result !== raw) {
+  if (result !== joinPascal(name)) {
     moduleLogger.warn(
       `[schema-to-graphql] Name "${name}" sanitized to "${result}" for GraphQL compatibility`,
     );

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/api-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/api-helpers.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { toPascalCase } from "../src/lib/api";
 
 // We test the pure utility functions from api.ts.
-// toCamelCase and toPascalCase are not exported, so we test them indirectly
-// or extract/re-implement the logic for testing.
+// toPascalCase is exported and tested directly; toCamelCase is not exported,
+// so we re-implement its logic for testing.
 // isAuthEnabled and isAiEnabled depend on cachedAppConfig (module state).
 
-// Re-implement the pure functions to test their logic directly
-// (since they are not exported from the module)
 function toCamelCase(name: string): string {
   const parts = name.split(/[_-]/);
   return (
@@ -16,13 +15,6 @@ function toCamelCase(name: string): string {
       .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
       .join("")
   );
-}
-
-function toPascalCase(name: string): string {
-  return name
-    .split(/[_-]/)
-    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-    .join("");
 }
 
 describe("toCamelCase", () => {

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/subscription-naming.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/subscription-naming.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Pins the CONSUMER side of the GraphQL subscription field-name contract.
+ *
+ * The server generates subscription fields named `on{Pascal}Created|Updated|Deleted`
+ * (addons/adapter-server/cap-adapter-server/src/graphql/build-subscriptions.ts,
+ * using toPascalCase from .../graphql/naming.ts). The UI subscribes to those
+ * fields BY NAME via its own toPascalCase copy in src/lib/api.ts (the UI must
+ * not import server code). Both sides must produce identical output — the
+ * server counterpart of this pin lives in
+ * addons/adapter-server/cap-adapter-server/__tests__/graphql-naming.test.ts
+ * and uses the SAME example: "purchase_request" → "PurchaseRequest".
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildEntitySubscriptionQuery } from "../src/hooks/use-subscription";
+import { toPascalCase } from "../src/lib/api";
+
+describe("subscription naming contract (UI consumer side)", () => {
+  test("toPascalCase pins the shared example: purchase_request → PurchaseRequest", () => {
+    expect(toPascalCase("purchase_request")).toBe("PurchaseRequest");
+  });
+
+  test("toPascalCase matches server behavior for kebab-case and single words", () => {
+    expect(toPascalCase("purchase-order")).toBe("PurchaseOrder");
+    expect(toPascalCase("task")).toBe("Task");
+    expect(toPascalCase("purchase_order_line_item")).toBe("PurchaseOrderLineItem");
+  });
+
+  test("toPascalCase sanitizes illegal GraphQL name characters like the server", () => {
+    // Mirrors the sanitization in adapter-server src/graphql/naming.ts
+    expect(toPascalCase("weird.name")).toBe("Weirdname");
+    expect(toPascalCase("1task")).toBe("_1task");
+  });
+
+  test("buildEntitySubscriptionQuery subscribes to the server-generated field names", () => {
+    const query = buildEntitySubscriptionQuery("purchase_request");
+    expect(query).toContain("onPurchaseRequestCreated");
+    expect(query).toContain("onPurchaseRequestUpdated");
+    expect(query).toContain("onPurchaseRequestDeleted");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/package.json
+++ b/addons/adapter-ui/cap-adapter-ui/package.json
@@ -44,6 +44,7 @@
     "cmdk": "^1.1.1",
     "dagre": "^0.8.5",
     "date-fns": "^4.1.0",
+    "eventsource-parser": "^3.0.6",
     "i18next": "^26.0.6",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.6.0",

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts
@@ -8,7 +8,9 @@
  * Both support automatic reconnection with exponential backoff.
  */
 
+import { createParser } from "eventsource-parser";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toPascalCase } from "../lib/api";
 
 // ═══════════════════════════════════════════════════════════════
 // GraphQL Subscription (existing — unchanged)
@@ -123,42 +125,34 @@ export function useSubscription(options: UseSubscriptionOptions): UseSubscriptio
         setError(null);
         reconnectAttemptRef.current = 0;
 
-        // Read the SSE stream
+        // Read the SSE stream — frame parsing delegated to eventsource-parser
         reader = response.body.getReader();
         const decoder = new TextDecoder();
-        let buffer = "";
+        let completed = false;
 
-        while (!aborted) {
+        const parser = createParser({
+          onEvent(event) {
+            if (event.event === "complete") {
+              // Server signaled completion (graphql-yoga SSE protocol)
+              completed = true;
+              return;
+            }
+            if (!event.data) return;
+            try {
+              const parsed = JSON.parse(event.data);
+              if (parsed.data && onDataRef.current) {
+                onDataRef.current(parsed.data);
+              }
+            } catch {
+              // Ignore malformed JSON
+            }
+          },
+        });
+
+        while (!aborted && !completed) {
           const { done, value } = await reader.read();
           if (done || aborted) break;
-
-          buffer += decoder.decode(value, { stream: true });
-
-          // Parse SSE events from the buffer
-          const lines = buffer.split("\n");
-          // Keep the last potentially incomplete line in the buffer
-          buffer = lines.pop() ?? "";
-
-          let eventData = "";
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              eventData += line.slice(6);
-            } else if (line.startsWith("event: complete")) {
-              // Server signaled completion
-              return;
-            } else if (line === "" && eventData) {
-              // Empty line = end of event, parse accumulated data
-              try {
-                const parsed = JSON.parse(eventData);
-                if (parsed.data && onDataRef.current) {
-                  onDataRef.current(parsed.data);
-                }
-              } catch {
-                // Ignore malformed JSON
-              }
-              eventData = "";
-            }
-          }
+          parser.feed(decoder.decode(value, { stream: true }));
         }
       } catch (err) {
         if (aborted) return;
@@ -199,12 +193,12 @@ export function useSubscription(options: UseSubscriptionOptions): UseSubscriptio
  *
  * Subscribes to created, updated, and deleted events for a given entity.
  * The subscription field names follow the pattern: on{PascalName}Created, etc.
+ * The server generates those field names in
+ * addons/adapter-server/cap-adapter-server/src/graphql/build-subscriptions.ts —
+ * both sides must derive the identical PascalCase name (see toPascalCase).
  */
 export function buildEntitySubscriptionQuery(entityName: string): string {
-  const pascal = entityName
-    .split(/[_-]/)
-    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
-    .join("");
+  const pascal = toPascalCase(entityName);
 
   // Subscribe to all three event types using GraphQL subscription aliases
   return `
@@ -354,60 +348,43 @@ export function useEntitySubscription(
 
         reconnectAttemptRef.current = 0;
 
-        // Read the SSE stream
+        // Read the SSE stream — frame parsing delegated to eventsource-parser
+        // (SSE comments such as keepalives are skipped by the parser itself)
         reader = response.body.getReader();
         const decoder = new TextDecoder();
-        let buffer = "";
+
+        const parser = createParser({
+          onEvent(event) {
+            if (!event.data) return;
+
+            // Track last event ID for reconnection replay
+            if (event.id) {
+              lastEventIdRef.current = event.id;
+            }
+
+            try {
+              const parsed = JSON.parse(event.data);
+
+              if (event.event === "connected") {
+                setConnected(true);
+                setError(null);
+                setConnectionId(parsed.connectionId ?? null);
+              } else if (event.event === "error") {
+                setError(parsed.error ?? "Subscription error");
+              } else if (onEventRef.current) {
+                // Deliver the subscription event
+                onEventRef.current(parsed as SubscriptionEvent);
+              }
+            } catch {
+              // Ignore malformed JSON
+            }
+          },
+        });
 
         while (!aborted) {
           const { done, value } = await reader.read();
           if (done || aborted) break;
-
-          buffer += decoder.decode(value, { stream: true });
-
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-
-          let currentEventType = "";
-          let currentEventId = "";
-          let eventData = "";
-
-          for (const line of lines) {
-            if (line.startsWith("id: ")) {
-              currentEventId = line.slice(4).trim();
-            } else if (line.startsWith("event: ")) {
-              currentEventType = line.slice(7).trim();
-            } else if (line.startsWith("data: ")) {
-              eventData += line.slice(6);
-            } else if (line.startsWith(":")) {
-              // SSE comment (e.g. keepalive) — ignore
-            } else if (line === "" && eventData) {
-              // End of event — track last event ID for reconnection
-              if (currentEventId) {
-                lastEventIdRef.current = currentEventId;
-              }
-
-              try {
-                const parsed = JSON.parse(eventData);
-
-                if (currentEventType === "connected") {
-                  setConnected(true);
-                  setError(null);
-                  setConnectionId(parsed.connectionId ?? null);
-                } else if (currentEventType === "error") {
-                  setError(parsed.error ?? "Subscription error");
-                } else if (onEventRef.current) {
-                  // Deliver the subscription event
-                  onEventRef.current(parsed as SubscriptionEvent);
-                }
-              } catch {
-                // Ignore malformed JSON
-              }
-              eventData = "";
-              currentEventType = "";
-              currentEventId = "";
-            }
-          }
+          parser.feed(decoder.decode(value, { stream: true }));
         }
       } catch (err) {
         if (aborted) return;

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts
@@ -355,12 +355,13 @@ export function useEntitySubscription(
 
         const parser = createParser({
           onEvent(event) {
-            if (!event.data) return;
-
-            // Track last event ID for reconnection replay
+            // Track last event ID for reconnection replay BEFORE the data
+            // check — per the SSE spec the id buffer advances even on
+            // data-less events (e.g. id-only heartbeats).
             if (event.id) {
               lastEventIdRef.current = event.id;
             }
+            if (!event.data) return;
 
             try {
               const parsed = JSON.parse(event.data);

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -154,11 +154,27 @@ export async function queryRecord<T = Record<string, unknown>>(
 
 // ── Mutations ───────────────────────────────────────────
 
-function toPascalCase(name: string): string {
-  return name
+/** Regex for valid GraphQL names */
+const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
+
+/**
+ * Convert a snake_case/kebab-case entity name to PascalCase for GraphQL names.
+ *
+ * CONSUMER side of the GraphQL naming contract: the server generates type,
+ * mutation, and subscription field names (e.g. `on{Pascal}Created`) with its
+ * own identical helper — addons/adapter-server/cap-adapter-server/src/graphql/naming.ts.
+ * The UI must not import server code (module boundary), so this copy must
+ * stay behaviorally identical: "purchase_request" → "PurchaseRequest".
+ * Pinned by __tests__/subscription-naming.test.ts here and
+ * __tests__/graphql-naming.test.ts on the server.
+ */
+export function toPascalCase(name: string): string {
+  const raw = name
     .split(/[_-]/)
-    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join("");
+  const sanitized = raw.replace(/[^_0-9A-Za-z]/g, "");
+  return GRAPHQL_NAME_RE.test(sanitized) ? sanitized : `_${sanitized}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Wheel-audit follow-ups — the REPLACE finding plus the producer/consumer drift hazard.

**SSE parsing → eventsource-parser.** `use-subscription.ts` had two near-identical hand-written SSE frame parsers (GraphQL path + entity `/api/subscribe` path), both deviating from the SSE spec: required `data: ` with a space, joined multi-line data without `\n`, no CRLF handling. Both now feed chunks to `createParser` from **eventsource-parser** — the de-facto standard, already in the dependency tree (transitive via @ai-sdk/provider-utils), now a direct dependency of cap-adapter-ui (`^3.0.6`, matching the installed version; CI's plain `bun install` resolves it — full lock registration lands with the deps-update wave). Only the byte→event layer changed; reconnect/backoff, abort, lastEventId replay and `connected`/`error`/`complete` semantics untouched. Verified graphql-yoga's data-less `event: complete` frame still dispatches (its `data:` line triggers dispatch).

**toPascalCase 6→2 (one per boundary side).** `build-subscriptions.ts` *generates* `on{Pascal}Created` field names and `use-subscription.ts` *subscribes to them by name* — yet each maintained its own copy (the exact drift shape that broke the §7.7 loop via dots-vs-colons). Server: single source `graphql/naming.ts` (relation-resolvers/build-schema/build-subscriptions/schema-to-graphql all import it). UI cannot import server (module boundary), so it keeps one exported helper in `lib/api.ts`, behaviorally identical, with contract comments naming the counterpart. Twin tests pin the same examples on both sides (`purchase_request → onPurchaseRequestCreated`), plus a direct parity run over 8 names including kebab-case and digit-leading.

## Testing
- adapter-ui 546 pass · adapter-server 792 pass (30 pre-existing DB-gated skips)
- Full batched suite green; typecheck + biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced real-time subscription handling with improved event stream parsing for more reliable data delivery.

* **Bug Fixes**
  * Improved naming validation and consistency across server-UI GraphQL operations to prevent invalid identifier generation.

* **Tests**
  * Added comprehensive validation tests for subscription field-naming contracts between server and UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->