### PR TITLE
feat(ag-ui): switch admin-UI assistant to the AG-UI protocol (dogfood /api/agui/run)

### DIFF
--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/run-endpoint.test.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/run-endpoint.test.ts
@@ -273,6 +273,105 @@ describe("POST /api/agui/run — failure mid-run", () => {
   });
 });
 
+describe("POST /api/agui/run — injected full-assistant runner", () => {
+  const historyInput = {
+    threadId: "thread_r",
+    runId: "run_r",
+    messages: [
+      { id: "m1", role: "system", content: "You are LinchKit." },
+      { id: "m2", role: "user", content: "List my orders" },
+      {
+        id: "m3",
+        role: "assistant",
+        content: "Looking it up.",
+        toolCalls: [
+          {
+            id: "tc_1",
+            type: "function",
+            function: { name: "queryRecords", arguments: '{"entity":"order"}' },
+          },
+        ],
+      },
+      { id: "m4", role: "tool", toolCallId: "tc_1", content: '[{"id":"o1"}]' },
+      { id: "m5", role: "user", content: "And the first one?" },
+    ],
+    tools: [],
+    context: [{ description: "entity", value: "order" }],
+  };
+
+  test("runner replaces the AIService bridge and its events are RUN_* framed", async () => {
+    const seen: { messages: number; context: string | undefined }[] = [];
+    const app = await createAgUiApp({
+      aiService: fakeCompleteService(),
+      runner: async ({ input, emit }) => {
+        seen.push({ messages: input.messages.length, context: input.context[0]?.description });
+        const messageId = "rm_1";
+        emit({ type: EventType.TEXT_MESSAGE_START, messageId, role: "assistant" });
+        emit({ type: EventType.TEXT_MESSAGE_CONTENT, messageId, delta: "Order o1" });
+        emit({ type: EventType.TEXT_MESSAGE_END, messageId });
+        emit({ type: EventType.TOOL_CALL_START, toolCallId: "tc_2", toolCallName: "getRecord" });
+        emit({ type: EventType.TOOL_CALL_ARGS, toolCallId: "tc_2", delta: '{"id":"o1"}' });
+        emit({ type: EventType.TOOL_CALL_END, toolCallId: "tc_2" });
+        emit({
+          type: EventType.TOOL_CALL_RESULT,
+          messageId: "rm_2",
+          toolCallId: "tc_2",
+          content: '{"id":"o1"}',
+          role: "tool",
+        });
+      },
+    });
+
+    const res = await postRun(app, historyInput);
+    expect(res.status).toBe(200);
+
+    const events = parseSseEvents(await res.text());
+    expect(eventTypes(events)).toEqual([
+      "RUN_STARTED",
+      "TEXT_MESSAGE_START",
+      "TEXT_MESSAGE_CONTENT",
+      "TEXT_MESSAGE_END",
+      "TOOL_CALL_START",
+      "TOOL_CALL_ARGS",
+      "TOOL_CALL_END",
+      "TOOL_CALL_RESULT",
+      "RUN_FINISHED",
+    ]);
+
+    // The runner received the FULL validated history (all 5 messages,
+    // including assistant tool calls and the tool result) plus context.
+    expect(seen).toEqual([{ messages: 5, context: "entity" }]);
+  });
+
+  test("a throwing runner surfaces as RUN_ERROR (no RUN_FINISHED)", async () => {
+    const app = await createAgUiApp({
+      aiService: fakeCompleteService(),
+      runner: async ({ emit, input }) => {
+        emit({ type: EventType.TEXT_MESSAGE_START, messageId: "rm", role: "assistant" });
+        throw new Error(`assistant exploded for ${input.runId}`);
+      },
+    });
+
+    const res = await postRun(app, historyInput);
+    const events = parseSseEvents(await res.text());
+    expect(eventTypes(events)).toEqual(["RUN_STARTED", "TEXT_MESSAGE_START", "RUN_ERROR"]);
+    expect(events.at(-1)).toMatchObject({ message: "assistant exploded for run_r" });
+  });
+
+  test("availability gate still reads aiService.configured when a runner is set", async () => {
+    let runnerCalls = 0;
+    const app = await createAgUiApp({
+      runner: async () => {
+        runnerCalls += 1;
+      },
+    });
+
+    const res = await postRun(app, historyInput);
+    expect(res.status).toBe(503);
+    expect(runnerCalls).toBe(0);
+  });
+});
+
 describe("custom base path", () => {
   test("mounts the run route under the provided basePath", async () => {
     const app = await createAgUiApp({ aiService: fakeCompleteService(), basePath: "/agui-v2" });

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/index.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/index.ts
@@ -39,10 +39,17 @@ export type {
   ToolCallStartEvent,
 } from "./protocol";
 export { EventType, encodeSseEvent, RunAgentInputSchema } from "./protocol";
-// Run endpoint (test seam: inject a fake AIService)
-export type { AgUiRunDeps } from "./run-endpoint";
+// Run endpoint (test seams: inject a fake AIService or a custom runner)
+export type {
+  AgUiAgentRunner,
+  AgUiEmit,
+  AgUiRunDeps,
+  AgUiRunHandler,
+  AgUiRunHandlerContext,
+} from "./run-endpoint";
 export {
   createAgUiApp,
+  createAgUiRunHandler,
   DEFAULT_AG_UI_BASE_PATH,
   mountAgUiRunRoute,
   toAiMessages,

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/run-endpoint.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/run-endpoint.ts
@@ -33,12 +33,42 @@ import {
   type TextInputContent,
 } from "./protocol";
 
+/** Emit callback handed to a custom agent runner. Drops events after disconnect. */
+export type AgUiEmit = (event: AGUIEvent) => void;
+
+/**
+ * Custom agent runner seam.
+ *
+ * A host server (e.g. cap-adapter-server) injects a runner that executes the
+ * FULL assistant semantics — ontology-aware system prompt, server-side tools,
+ * multi-step agent loop — and emits AG-UI protocol events as it goes. The
+ * endpoint still owns input validation, the RUN_STARTED / RUN_FINISHED frame,
+ * and RUN_ERROR mapping: a runner only emits the events *between* those.
+ * Throwing aborts the run and surfaces as RUN_ERROR.
+ */
+export type AgUiAgentRunner = (options: {
+  /** Validated RunAgentInput (full message history, tools, context). */
+  input: RunAgentInput;
+  /** Emit one protocol event (TEXT_MESSAGE_*, TOOL_CALL_*, ...). */
+  emit: AgUiEmit;
+  /** Aborts when the client disconnects — stop consuming the model. */
+  signal?: AbortSignal;
+  /** Raw HTTP request — for actor / tenant / locale resolution. */
+  request?: Request;
+}) => Promise<void>;
+
 /** Injected dependencies for the AG-UI run endpoint (test seam). */
 export interface AgUiRunDeps {
   /** Same seam as cap-adapter-server's ai-api.ts (`options.aiService`). */
   aiService?: AIService;
   /** Base path the run endpoint is mounted under. @default "/api/agui" */
   basePath?: string;
+  /**
+   * Optional full-assistant runner. When provided it replaces the default
+   * AIService bridge for event production (the availability gate still reads
+   * `aiService.configured` so the 503 contract matches `/api/ai/chat`).
+   */
+  runner?: AgUiAgentRunner;
 }
 
 /** Default base path for the AG-UI HTTP endpoints. */
@@ -122,11 +152,14 @@ export function toAiTools(tools: RunAgentInput["tools"]): AITool[] {
  * frontend tools were requested; otherwise falls back to `aiService.complete`
  * and re-frames the result (text + tool calls) as protocol events.
  */
-function createRunEventStream(
-  aiService: AIService,
-  input: RunAgentInput,
-  signal?: AbortSignal,
-): ReadableStream {
+function createRunEventStream(options: {
+  aiService: AIService;
+  input: RunAgentInput;
+  signal?: AbortSignal;
+  runner?: AgUiAgentRunner;
+  request?: Request;
+}): ReadableStream {
+  const { aiService, input, signal, runner, request } = options;
   const encoder = new TextEncoder();
 
   return new ReadableStream({
@@ -162,6 +195,14 @@ function createRunEventStream(
       emit({ type: EventType.RUN_STARTED, threadId: input.threadId, runId: input.runId });
 
       try {
+        if (runner) {
+          // Host-injected full-assistant runner (system prompt + server-side
+          // tools + multi-step). The endpoint keeps the RUN_* frame.
+          await runner({ input, emit, signal, request });
+          emit({ type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId });
+          return;
+        }
+
         const messages = toAiMessages(input);
         const tools = toAiTools(input.tools);
 
@@ -223,16 +264,35 @@ function createRunEventStream(
 }
 
 /**
- * Mount the AG-UI run route on an existing Elysia app.
- *
- * Reads the request body from the destructured context `body` (never
- * `request.json()` — the stream is already consumed by Elysia).
+ * Structural slice of the Elysia handler context the run handler needs.
+ * Declared structurally so a host server can forward its own Elysia context
+ * without this package appearing in its compile-time route types.
  */
-export function mountAgUiRunRoute(app: Elysia, deps: AgUiRunDeps): Elysia {
-  const basePath = deps.basePath ?? DEFAULT_AG_UI_BASE_PATH;
+export interface AgUiRunHandlerContext {
+  /** Parsed request body (Elysia context `body` — never `request.json()`). */
+  body: unknown;
+  /** Elysia response mutator (`set.status`, `set.headers`). */
+  set: { status?: number | string; headers: Record<string, unknown> };
+  /** Raw request — `request.signal` propagates client disconnects. */
+  request: Request;
+}
+
+/** The AG-UI run route handler produced by {@link createAgUiRunHandler}. */
+export type AgUiRunHandler = (
+  ctx: AgUiRunHandlerContext,
+) => Response | { success: false; error: { message: string } };
+
+/**
+ * Build the AG-UI run handler (validation → availability → SSE stream).
+ *
+ * Exported separately from {@link mountAgUiRunRoute} so host servers (e.g.
+ * cap-adapter-server) can mount the route on their own app under their own
+ * path while reusing the exact endpoint contract.
+ */
+export function createAgUiRunHandler(deps: AgUiRunDeps): AgUiRunHandler {
   const aiService = deps.aiService;
 
-  app.post(`${basePath}/run`, ({ body, set, request }) => {
+  return ({ body, set, request }) => {
     // Validate input first (mirrors ai-api.ts ordering), then availability.
     // RunAgentInputSchema is the official zod-3 schema from @ag-ui/core —
     // used as-is (its own .safeParse), never composed with local zod-4.
@@ -254,14 +314,36 @@ export function mountAgUiRunRoute(app: Elysia, deps: AgUiRunDeps): Elysia {
     }
 
     // request.signal propagates client disconnects into the event stream.
-    return new Response(createRunEventStream(aiService, parsed.data, request.signal), {
-      headers: {
-        "content-type": "text/event-stream",
-        "cache-control": "no-cache",
-        connection: "keep-alive",
+    return new Response(
+      createRunEventStream({
+        aiService,
+        input: parsed.data,
+        signal: request.signal,
+        runner: deps.runner,
+        request,
+      }),
+      {
+        headers: {
+          "content-type": "text/event-stream",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        },
       },
-    });
-  });
+    );
+  };
+}
+
+/**
+ * Mount the AG-UI run route on an existing Elysia app.
+ *
+ * Reads the request body from the destructured context `body` (never
+ * `request.json()` — the stream is already consumed by Elysia).
+ */
+export function mountAgUiRunRoute(app: Elysia, deps: AgUiRunDeps): Elysia {
+  const basePath = deps.basePath ?? DEFAULT_AG_UI_BASE_PATH;
+  const handler = createAgUiRunHandler(deps);
+
+  app.post(`${basePath}/run`, ({ body, set, request }) => handler({ body, set, request }));
 
   return app;
 }

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -31,6 +31,7 @@
     "@linchkit/core": ">=0.3.0 <0.4.0"
   },
   "devDependencies": {
+    "@linchkit/cap-adapter-ag-ui": "workspace:*",
     "@linchkit/cap-ai-provider": "workspace:*",
     "@linchkit/cap-chatter": "workspace:*",
     "@linchkit/cap-dry-run": "workspace:*",

--- a/addons/adapter-server/cap-adapter-server/src/ai/agui-runner.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/agui-runner.ts
@@ -1,0 +1,301 @@
+/**
+ * AG-UI assistant runner — runs the SAME assistant brain as `/api/ai/chat`
+ * (ontology-aware system prompt, server-side read-only tools, multi-step
+ * agent loop via Vercel AI SDK `streamText`) and emits official AG-UI
+ * protocol events instead of the Vercel UI message stream.
+ *
+ * Injected into cap-adapter-ag-ui's run endpoint (see routes/agui-api.ts)
+ * so the admin UI assistant keeps its full capabilities when it talks the
+ * AG-UI protocol: switching the transport must not lose features (#89).
+ *
+ * Zod-version note: `@ag-ui/core` ships zod-3 schemas. This module only uses
+ * its exported TYPES + the `EventType` enum — never composes its schemas
+ * with the repo's zod-4 (established pattern from #546).
+ */
+
+import type {
+  AGUIEvent,
+  AgUiAgentRunner,
+  Message as AgUiMessage,
+  RunAgentInput,
+} from "@linchkit/cap-adapter-ag-ui";
+import { EventType } from "@linchkit/cap-adapter-ag-ui";
+import type { ModelMessage, TextStreamPart, ToolSet } from "ai";
+import type { ServerOptions } from "../server";
+
+// ── Context extraction ──────────────────────────────────────
+
+/**
+ * Well-known AG-UI context entry descriptions the LinchKit transport sends
+ * (see cap-adapter-ui's agui-chat-transport.ts). AG-UI context is a flat
+ * `{ description, value }[]`; these keys mirror `/api/ai/chat`'s
+ * `body.context.{entity,recordId,locale}`.
+ */
+export const AG_UI_CONTEXT_KEYS = {
+  entity: "entity",
+  recordId: "recordId",
+  locale: "locale",
+} as const;
+
+/** Read a well-known context entry from a RunAgentInput. */
+export function agUiContextValue(
+  input: Pick<RunAgentInput, "context">,
+  description: string,
+): string | undefined {
+  const entry = input.context.find((c) => c.description === description);
+  return entry?.value || undefined;
+}
+
+// ── AG-UI messages → ModelMessage[] ─────────────────────────
+
+/** Extract plain text from an AG-UI user message content (string | parts). */
+function userText(message: AgUiMessage & { role: "user" }): string {
+  const value = message.content;
+  if (typeof value === "string") return value;
+  return value
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" && part !== null && part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n");
+}
+
+/** Parse a JSON tool-call arguments string, tolerating partial/invalid JSON. */
+function parseArgs(raw: string): unknown {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Map the AG-UI conversation history onto Vercel AI SDK `ModelMessage[]`,
+ * preserving assistant tool calls and tool results so multi-turn
+ * conversations keep their full tool context (mirrors what
+ * `convertToModelMessages` produces for `/api/ai/chat`).
+ */
+export function toModelMessagesFromAgUi(messages: AgUiMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = [];
+
+  // toolCallId → toolName lookup for tool-result messages.
+  const toolNames = new Map<string, string>();
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      for (const call of message.toolCalls ?? []) {
+        toolNames.set(call.id, call.function.name);
+      }
+    }
+  }
+
+  for (const message of messages) {
+    switch (message.role) {
+      case "developer":
+      case "system":
+        out.push({ role: "system", content: message.content });
+        break;
+      case "user": {
+        const text = userText(message);
+        if (text.length > 0) out.push({ role: "user", content: text });
+        break;
+      }
+      case "assistant": {
+        const content: Exclude<Extract<ModelMessage, { role: "assistant" }>["content"], string> =
+          [];
+        if (message.content) content.push({ type: "text", text: message.content });
+        for (const call of message.toolCalls ?? []) {
+          content.push({
+            type: "tool-call",
+            toolCallId: call.id,
+            toolName: call.function.name,
+            input: parseArgs(call.function.arguments),
+          });
+        }
+        if (content.length > 0) {
+          out.push({ role: "assistant", content });
+        }
+        break;
+      }
+      case "tool":
+        out.push({
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: message.toolCallId,
+              toolName: toolNames.get(message.toolCallId) ?? "unknown",
+              output: { type: "text", value: message.content },
+            },
+          ],
+        });
+        break;
+      case "activity":
+      case "reasoning":
+        // No ModelMessage counterpart — skipped (same as the run endpoint's
+        // default bridge).
+        break;
+    }
+  }
+
+  return out;
+}
+
+// ── streamText fullStream → AG-UI events ────────────────────
+
+/**
+ * Translate one Vercel AI SDK `fullStream` part into AG-UI protocol events.
+ *
+ * Tool calls are emitted as one consolidated START → ARGS → END triple per
+ * `tool-call` part (deterministic ordering regardless of whether the
+ * provider streamed `tool-input-delta`s), and each server-side execution
+ * result becomes a TOOL_CALL_RESULT. A model/provider `error` part throws —
+ * the run endpoint maps it to RUN_ERROR.
+ */
+export function streamPartToAgUiEvents(part: TextStreamPart<ToolSet>): AGUIEvent[] {
+  switch (part.type) {
+    case "text-start":
+      return [{ type: EventType.TEXT_MESSAGE_START, messageId: part.id, role: "assistant" }];
+    case "text-delta":
+      // Protocol: TEXT_MESSAGE_CONTENT.delta must be non-empty.
+      return part.text.length > 0
+        ? [{ type: EventType.TEXT_MESSAGE_CONTENT, messageId: part.id, delta: part.text }]
+        : [];
+    case "text-end":
+      return [{ type: EventType.TEXT_MESSAGE_END, messageId: part.id }];
+    case "tool-call":
+      return [
+        {
+          type: EventType.TOOL_CALL_START,
+          toolCallId: part.toolCallId,
+          toolCallName: part.toolName,
+        },
+        {
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId: part.toolCallId,
+          delta: JSON.stringify(part.input ?? {}),
+        },
+        { type: EventType.TOOL_CALL_END, toolCallId: part.toolCallId },
+      ];
+    case "tool-result":
+      return [
+        {
+          type: EventType.TOOL_CALL_RESULT,
+          messageId: crypto.randomUUID(),
+          toolCallId: part.toolCallId,
+          content: JSON.stringify(part.output ?? null),
+          role: "tool",
+        },
+      ];
+    case "tool-error":
+      // Surface tool failures as a structured result so the model's
+      // follow-up text (which has already seen the error) stays coherent.
+      return [
+        {
+          type: EventType.TOOL_CALL_RESULT,
+          messageId: crypto.randomUUID(),
+          toolCallId: part.toolCallId,
+          content: JSON.stringify({
+            error: part.error instanceof Error ? part.error.message : String(part.error),
+          }),
+          role: "tool",
+        },
+      ];
+    case "error":
+      throw part.error instanceof Error ? part.error : new Error(String(part.error));
+    default:
+      // start/finish/step/reasoning/source/file/raw/abort/tool-input-* —
+      // no AG-UI counterpart needed (tool-input-* is superseded by the
+      // consolidated `tool-call` triple above).
+      return [];
+  }
+}
+
+// ── Runner factory ──────────────────────────────────────────
+
+/**
+ * Build the AG-UI agent runner from ServerOptions.
+ *
+ * Mirrors the `/api/ai/chat` handler in routes/ai-api.ts: same model
+ * resolution, actor + tenant scoping, system prompt, read-only tools and
+ * multi-step loop — only the output framing differs (AG-UI events).
+ */
+export function createAssistantAgUiRunner(options: ServerOptions): AgUiAgentRunner {
+  return async ({ input, emit, signal, request }) => {
+    const aiConfig = options.aiConfig;
+    if (!aiConfig) {
+      // routes/agui-api.ts only injects this runner when aiConfig exists.
+      throw new Error("AI service is not configured.");
+    }
+
+    // Lazy imports — mirrors ai-api.ts so heavy deps load on first use only.
+    const { streamText, stepCountIs } = await import("ai");
+    const { resolveLanguageModel } = await import("@linchkit/cap-ai-provider");
+    const { createTenantAwareDataProvider } = await import("@linchkit/core/server");
+    const { buildSystemPrompt, extractLocale } = await import("./system-prompt");
+    const { buildTools } = await import("./tools");
+    const { ANONYMOUS_ACTOR } = await import("../routes/shared");
+
+    const assistantConfig = aiConfig.assistant;
+    const model = await resolveLanguageModel(aiConfig, assistantConfig?.model ?? "fast");
+
+    // Resolve actor for permission-aware tool calls.
+    const actor =
+      (request && options.resolveRequestActor
+        ? await options.resolveRequestActor(request)
+        : undefined) ?? ANONYMOUS_ACTOR;
+
+    // Tenant-scoped data provider (same scoping as the chat endpoint).
+    const tenantId =
+      request && options.resolveRequestTenantId
+        ? await options.resolveRequestTenantId(request, actor)
+        : undefined;
+    const dataProvider = options.dataProvider;
+    const scopedProvider =
+      tenantId && dataProvider
+        ? createTenantAwareDataProvider(dataProvider, tenantId)
+        : dataProvider;
+
+    // Page context travels as AG-UI context entries (entity/recordId/locale).
+    const entity = agUiContextValue(input, AG_UI_CONTEXT_KEYS.entity);
+    const recordId = agUiContextValue(input, AG_UI_CONTEXT_KEYS.recordId);
+    const locale = extractLocale(agUiContextValue(input, AG_UI_CONTEXT_KEYS.locale), request);
+
+    // Chat is read-only — writes go through the propose-and-confirm flow
+    // (intent resolver + ActionProposalCard). See issue #285 / #238.
+    const systemPrompt = buildSystemPrompt({
+      assistantConfig,
+      ontologyRegistry: options.ontologyRegistry,
+      entityRegistry: options.entityRegistry,
+      context: { entity, recordId, locale },
+      allowActionExecution: false,
+    });
+
+    const tools = buildTools({
+      dataProvider: scopedProvider,
+      commandLayer: options.commandLayer,
+      entityRegistry: options.entityRegistry,
+      ontologyRegistry: options.ontologyRegistry,
+      actor,
+      allowActionExecution: false,
+    });
+
+    const result = streamText({
+      model,
+      system: systemPrompt,
+      messages: toModelMessagesFromAgUi(input.messages),
+      tools,
+      stopWhen: stepCountIs(assistantConfig?.maxSteps ?? 5),
+      temperature: assistantConfig?.temperature ?? 0.3,
+      abortSignal: signal,
+    });
+
+    for await (const part of result.fullStream) {
+      if (signal?.aborted) break; // client went away — stop consuming
+      for (const event of streamPartToAgUiEvents(part)) {
+        emit(event);
+      }
+    }
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/__tests__/agui-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/__tests__/agui-api.test.ts
@@ -1,0 +1,276 @@
+/**
+ * AG-UI main-server route + assistant runner translation tests.
+ *
+ * Route tests use `app.handle(new Request(...))` (in-process, port-free —
+ * never `app.listen`). The AI seam is a fake injected `AIService`; no global
+ * fetch mocks. The streamText-based runner itself is exercised through its
+ * pure translation helpers (message mapping + fullStream-part translation),
+ * which carry all the protocol-mapping logic.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Message as AgUiMessage } from "@linchkit/cap-adapter-ag-ui";
+import { EventType } from "@linchkit/cap-adapter-ag-ui";
+import type { AIService, AIStreamResult, CapabilityDefinition } from "@linchkit/core";
+import type { TextStreamPart, ToolSet } from "ai";
+import { Elysia } from "elysia";
+import {
+  agUiContextValue,
+  streamPartToAgUiEvents,
+  toModelMessagesFromAgUi,
+} from "../../ai/agui-runner";
+import { AG_UI_RUN_PATH, hasAgUiCapability, mountAgUiRoutes } from "../agui-api";
+
+const RUN_URL = `http://local.test${AG_UI_RUN_PATH}`;
+
+const AG_UI_CAPABILITY: CapabilityDefinition = {
+  name: "cap-adapter-ag-ui",
+  label: "AG-UI Server",
+  description: "test stub",
+  type: "adapter",
+  category: "integration",
+  version: "0.0.1",
+};
+
+const validInput = {
+  threadId: "t1",
+  runId: "r1",
+  messages: [{ id: "m1", role: "user", content: "hello" }],
+  tools: [],
+  context: [],
+};
+
+function postRun(app: Elysia, body: unknown) {
+  return app.handle(
+    new Request(RUN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+/** Fake AIService with token streaming (drives the default bridge path). */
+function fakeStreamingService(chunks: string[]): AIService {
+  return {
+    configured: true,
+    defaultProvider: "fake",
+    providerNames: ["fake"],
+    complete: async () => {
+      throw new Error("complete() should not be called on the streaming path");
+    },
+    completeStream: async (): Promise<AIStreamResult> => ({
+      textStream: (async function* () {
+        yield* chunks;
+      })(),
+      model: "fake-model",
+      provider: "fake",
+    }),
+  };
+}
+
+// ── Route mounting ──────────────────────────────────────────
+
+describe("mountAgUiRoutes", () => {
+  test("does NOT mount the route when cap-adapter-ag-ui is not registered", async () => {
+    const app = mountAgUiRoutes(new Elysia(), { capabilities: [] });
+    const res = await postRun(app, validInput);
+    expect(res.status).toBe(404);
+    expect(hasAgUiCapability({ capabilities: [] })).toBe(false);
+  });
+
+  test("mounts the route when the capability is registered (503 without AI)", async () => {
+    const app = mountAgUiRoutes(new Elysia(), { capabilities: [AG_UI_CAPABILITY] });
+    const res = await postRun(app, validInput);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { success: boolean; error: { message: string } };
+    expect(body.error.message).toContain("AI service is not configured");
+  });
+
+  test("streams AG-UI events through the default bridge when configured (no aiConfig)", async () => {
+    const app = mountAgUiRoutes(new Elysia(), {
+      capabilities: [AG_UI_CAPABILITY],
+      aiService: fakeStreamingService(["Hi", "!"]),
+    });
+    const res = await postRun(app, validInput);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    const events = (await res.text())
+      .split("\n\n")
+      .map((frame) => frame.trim())
+      .filter((frame) => frame.length > 0)
+      .map((frame) => JSON.parse(frame.slice("data: ".length)) as { type: string });
+    expect(events.map((e) => e.type)).toEqual([
+      "RUN_STARTED",
+      "TEXT_MESSAGE_START",
+      "TEXT_MESSAGE_CONTENT",
+      "TEXT_MESSAGE_CONTENT",
+      "TEXT_MESSAGE_END",
+      "RUN_FINISHED",
+    ]);
+  });
+
+  test("rejects an invalid RunAgentInput with 400 before availability", async () => {
+    const app = mountAgUiRoutes(new Elysia(), { capabilities: [AG_UI_CAPABILITY] });
+    const res = await postRun(app, { nonsense: true });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── AG-UI history → ModelMessage[] ──────────────────────────
+
+describe("toModelMessagesFromAgUi", () => {
+  test("maps roles, tool calls, and tool results faithfully", () => {
+    const messages: AgUiMessage[] = [
+      { id: "m1", role: "system", content: "be brief" },
+      { id: "m2", role: "user", content: "list orders" },
+      {
+        id: "m3",
+        role: "assistant",
+        content: "checking",
+        toolCalls: [
+          {
+            id: "tc1",
+            type: "function",
+            function: { name: "queryRecords", arguments: '{"entity":"order"}' },
+          },
+        ],
+      },
+      { id: "m4", role: "tool", toolCallId: "tc1", content: '[{"id":"o1"}]' },
+      { id: "m5", role: "user", content: "thanks" },
+    ];
+
+    expect(toModelMessagesFromAgUi(messages)).toEqual([
+      { role: "system", content: "be brief" },
+      { role: "user", content: "list orders" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "checking" },
+          {
+            type: "tool-call",
+            toolCallId: "tc1",
+            toolName: "queryRecords",
+            input: { entity: "order" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "queryRecords",
+            output: { type: "text", value: '[{"id":"o1"}]' },
+          },
+        ],
+      },
+      { role: "user", content: "thanks" },
+    ]);
+  });
+
+  test("keeps multimodal user text parts and drops empty/structural messages", () => {
+    const messages: AgUiMessage[] = [
+      {
+        id: "m1",
+        role: "user",
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      },
+      { id: "m2", role: "assistant" },
+    ];
+    expect(toModelMessagesFromAgUi(messages)).toEqual([{ role: "user", content: "first\nsecond" }]);
+  });
+});
+
+// ── streamText fullStream → AG-UI events ────────────────────
+
+describe("streamPartToAgUiEvents", () => {
+  test("translates the text triple", () => {
+    expect(
+      streamPartToAgUiEvents({ type: "text-start", id: "t1" } as TextStreamPart<ToolSet>),
+    ).toEqual([{ type: EventType.TEXT_MESSAGE_START, messageId: "t1", role: "assistant" }]);
+    expect(
+      streamPartToAgUiEvents({
+        type: "text-delta",
+        id: "t1",
+        text: "Hi",
+      } as TextStreamPart<ToolSet>),
+    ).toEqual([{ type: EventType.TEXT_MESSAGE_CONTENT, messageId: "t1", delta: "Hi" }]);
+    // Protocol requires non-empty deltas — empty ones are dropped.
+    expect(
+      streamPartToAgUiEvents({ type: "text-delta", id: "t1", text: "" } as TextStreamPart<ToolSet>),
+    ).toEqual([]);
+    expect(
+      streamPartToAgUiEvents({ type: "text-end", id: "t1" } as TextStreamPart<ToolSet>),
+    ).toEqual([{ type: EventType.TEXT_MESSAGE_END, messageId: "t1" }]);
+  });
+
+  test("translates a tool call into a consolidated START → ARGS → END triple", () => {
+    const events = streamPartToAgUiEvents({
+      type: "tool-call",
+      toolCallId: "tc1",
+      toolName: "queryRecords",
+      input: { entity: "order" },
+    } as TextStreamPart<ToolSet>);
+    expect(events).toEqual([
+      { type: EventType.TOOL_CALL_START, toolCallId: "tc1", toolCallName: "queryRecords" },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId: "tc1", delta: '{"entity":"order"}' },
+      { type: EventType.TOOL_CALL_END, toolCallId: "tc1" },
+    ]);
+  });
+
+  test("translates a server-side tool result into TOOL_CALL_RESULT", () => {
+    const events = streamPartToAgUiEvents({
+      type: "tool-result",
+      toolCallId: "tc1",
+      toolName: "queryRecords",
+      input: {},
+      output: { count: 2 },
+    } as TextStreamPart<ToolSet>);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tc1",
+      content: '{"count":2}',
+      role: "tool",
+    });
+  });
+
+  test("throws on an error part (run endpoint maps it to RUN_ERROR)", () => {
+    expect(() =>
+      streamPartToAgUiEvents({
+        type: "error",
+        error: new Error("model died"),
+      } as TextStreamPart<ToolSet>),
+    ).toThrow("model died");
+  });
+
+  test("ignores structural parts (steps, tool-input streaming, finish)", () => {
+    for (const type of ["start", "start-step", "finish-step", "tool-input-start"] as const) {
+      expect(streamPartToAgUiEvents({ type } as unknown as TextStreamPart<ToolSet>)).toEqual([]);
+    }
+  });
+});
+
+// ── Context extraction ──────────────────────────────────────
+
+describe("agUiContextValue", () => {
+  test("reads well-known entries and tolerates absences", () => {
+    const input = {
+      context: [
+        { description: "entity", value: "order" },
+        { description: "locale", value: "zh-CN" },
+      ],
+    };
+    expect(agUiContextValue(input, "entity")).toBe("order");
+    expect(agUiContextValue(input, "locale")).toBe("zh-CN");
+    expect(agUiContextValue(input, "recordId")).toBeUndefined();
+    expect(agUiContextValue({ context: [] }, "entity")).toBeUndefined();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/routes/agui-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/agui-api.ts
@@ -1,0 +1,59 @@
+/**
+ * AG-UI run route — `POST /api/agui/run` on the MAIN server (:3001).
+ *
+ * cap-adapter-ag-ui owns the protocol endpoint (validation, SSE framing,
+ * RUN_* lifecycle); this module mounts its handler on the adapter-server app
+ * so the admin UI reaches it through the regular `/api` proxy, and injects
+ * the full-assistant runner (ai/agui-runner.ts) so the AG-UI transport keeps
+ * feature parity with `/api/ai/chat` (system prompt, server-side tools,
+ * multi-step).
+ *
+ * Mounted ONLY when the `cap-adapter-ag-ui` capability is registered in the
+ * project's capability list — registration is the opt-in. The addon package
+ * is a lazily-imported optional peer (same pattern as cap-ai-provider): the
+ * import happens on first request, and since the capability can only be
+ * registered by importing the package, the import cannot miss.
+ */
+
+import type { AgUiRunHandler } from "@linchkit/cap-adapter-ag-ui";
+import type { Elysia } from "elysia";
+import type { ServerOptions } from "../server";
+
+/** Capability name whose registration opts the run route in. */
+export const AG_UI_CAPABILITY_NAME = "cap-adapter-ag-ui";
+
+/** Path the run route is mounted under on the main server. */
+export const AG_UI_RUN_PATH = "/api/agui/run";
+
+/** Whether the AG-UI capability is registered (drives route mounting). */
+export function hasAgUiCapability(options: Pick<ServerOptions, "capabilities">): boolean {
+  return (options.capabilities ?? []).some((cap) => cap.name === AG_UI_CAPABILITY_NAME);
+}
+
+/**
+ * Mount `POST /api/agui/run` when cap-adapter-ag-ui is registered.
+ *
+ * The handler is built lazily on first request (mirrors ai-api.ts's lazy
+ * imports) and cached. When `aiConfig` is present the full-assistant runner
+ * is injected; without it the addon's default AIService bridge applies —
+ * same degradation `/api/ai/chat` has (it 503s without aiConfig; the bridge
+ * still streams plain completions).
+ */
+export function mountAgUiRoutes(app: Elysia, options: ServerOptions): Elysia {
+  if (!hasAgUiCapability(options)) return app;
+
+  let handler: AgUiRunHandler | undefined;
+
+  app.post(AG_UI_RUN_PATH, async ({ body, set, request }) => {
+    if (!handler) {
+      const { createAgUiRunHandler } = await import("@linchkit/cap-adapter-ag-ui");
+      const runner = options.aiConfig
+        ? (await import("../ai/agui-runner")).createAssistantAgUiRunner(options)
+        : undefined;
+      handler = createAgUiRunHandler({ aiService: options.aiService, runner });
+    }
+    return handler({ body, set, request });
+  });
+
+  return app;
+}

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -56,6 +56,7 @@ import { mountProposalGraduateAPI } from "./proposal-graduate-api";
 import { mountProposalMaterializeAPI } from "./proposal-materialize-api";
 import { mountActionRoutes } from "./routes/action-api";
 import { mountAdminRoutes } from "./routes/admin-api";
+import { mountAgUiRoutes } from "./routes/agui-api";
 import { mountAIRoutes } from "./routes/ai-api";
 import { mountAIByokRoutes } from "./routes/ai-byok";
 import { mountResolveIntentRoute } from "./routes/ai-resolve-intent";
@@ -416,6 +417,10 @@ export function createServer(
   mountConfigRoutes(app, opts);
   mountConfigStoreRoutes(app, opts);
   mountAIRoutes(app, opts);
+  // AG-UI protocol run endpoint (#89) — only mounts when cap-adapter-ag-ui
+  // is registered in the capability list. Bridges the same assistant brain
+  // as POST /api/ai/chat onto official AG-UI events over SSE.
+  mountAgUiRoutes(app, opts);
   // Spec 36 M2+ BYOK + usage endpoints (per-tenant key store + meter).
   // Mounted alongside the other AI routes; no-ops when the store /
   // meter are not configured (returns 503 with a structured envelope).

--- a/addons/adapter-ui/cap-adapter-ui/package.json
+++ b/addons/adapter-ui/cap-adapter-ui/package.json
@@ -24,6 +24,8 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@ag-ui/client": "~0.0.56",
+    "@ag-ui/core": "~0.0.56",
     "@ai-sdk/react": "^3.0.140",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -35,18 +35,11 @@ import {
   toast,
 } from "@linchkit/ui-kit/components";
 import { useParams } from "@tanstack/react-router";
-import type { UIMessage, UIMessagePart } from "ai";
-import { DefaultChatTransport, getToolName, isToolUIPart } from "ai";
-import {
-  BotIcon,
-  ExternalLinkIcon,
-  Loader2Icon,
-  SendIcon,
-  SparklesIcon,
-  Trash2Icon,
-} from "lucide-react";
+import type { UIMessage } from "ai";
+import { BotIcon, Loader2Icon, SendIcon, SparklesIcon, Trash2Icon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { AgUiChatTransport } from "../lib/agui-chat-transport";
 import {
   type ActionResult,
   type IntentResolution,
@@ -55,6 +48,7 @@ import {
   resolveIntent,
 } from "../lib/api";
 import { ActionProposalCard } from "./action-proposal-card";
+import { MessageBubble } from "./ai-message-bubble";
 
 // ── Proposal state ───────────────────────────────────────
 
@@ -132,17 +126,17 @@ export function AIAssistant({
   const [proposals, setProposals] = useState<ProposalItem[]>([]);
   const [isResolvingIntent, setIsResolvingIntent] = useState(false);
 
-  // Create transport with context-aware body (schema + record info + locale sent with each request)
+  // AG-UI transport (#89) — same assistant brain as /api/ai/chat, but over
+  // the official AG-UI protocol via @ag-ui/client. Page context (entity +
+  // record + locale) travels as AG-UI context entries with each run.
   const transport = useMemo(
     () =>
-      new DefaultChatTransport({
-        api: "/api/ai/chat",
-        body: () => ({
-          context: {
-            schema: params.name,
-            recordId: params.id,
-            locale: i18n.language,
-          },
+      new AgUiChatTransport({
+        api: "/api/agui/run",
+        context: () => ({
+          entity: params.name,
+          recordId: params.id,
+          locale: i18n.language,
         }),
       }),
     [params.name, params.id, i18n.language],
@@ -410,96 +404,5 @@ export function AIAssistant({
   );
 }
 
-// ── Message Bubble ────────────────────────────────────────
-
-/**
- * Renders a single message bubble with support for:
- * - Text parts (streamed or complete)
- * - Tool parts (shows tool name + loading indicator or navigation links)
- */
-function MessageBubble({ message }: { message: UIMessage }) {
-  const isUser = message.role === "user";
-
-  return (
-    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-      <div
-        className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
-          isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
-        }`}
-      >
-        {message.parts.map((part, index) => {
-          const key = `${message.id}-${index}`;
-          return <MessagePart key={key} part={part} />;
-        })}
-      </div>
-    </div>
-  );
-}
-
-/** Tool display labels for loading indicators */
-const TOOL_LABELS: Record<string, string> = {
-  queryRecords: "Querying records...",
-  getRecord: "Fetching record...",
-  executeAction: "Executing action...",
-  describeSchema: "Loading schema info...",
-  listEntities: "Listing entities...",
-  searchEntities: "Searching entities...",
-};
-
-/**
- * Render a single message part based on its type.
- * AI SDK v6 uses typed parts: text, tool-{name}, dynamic-tool, reasoning, etc.
- */
-// biome-ignore lint/suspicious/noExplicitAny: UIMessagePart generic is complex
-function MessagePart({ part }: { part: UIMessagePart<any, any> }) {
-  // Text parts
-  if (part.type === "text") {
-    return (
-      <p className="whitespace-pre-wrap">
-        {part.text}
-        {part.state === "streaming" && (
-          <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-foreground/50" />
-        )}
-      </p>
-    );
-  }
-
-  // Tool parts (static: tool-{name}, dynamic: dynamic-tool)
-  if (isToolUIPart(part)) {
-    const toolName = getToolName(part);
-    const state = part.state;
-
-    // navigateTo tool with output — render as a clickable link
-    if (toolName === "navigateTo" && state === "input-available") {
-      const input = part.input as { path?: string; label?: string } | undefined;
-      if (input?.path) {
-        return (
-          <a
-            href={input.path}
-            className="mt-1 flex items-center gap-1.5 rounded-md border border-primary/30 bg-background px-2 py-1 text-xs text-primary transition-colors hover:bg-primary/10"
-          >
-            <ExternalLinkIcon className="size-3" />
-            {input.label || input.path}
-          </a>
-        );
-      }
-    }
-
-    // In-progress tool calls — show loading indicator
-    if (state === "input-streaming" || state === "input-available") {
-      return (
-        <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Loader2Icon className="size-3 animate-spin" />
-          <span>{TOOL_LABELS[toolName] ?? `Running ${toolName}...`}</span>
-        </div>
-      );
-    }
-
-    // Tool output/error — the AI will summarize results in its text response,
-    // so we don't render tool outputs inline
-    return null;
-  }
-
-  // Step start, reasoning, source, file parts — skip rendering
-  return null;
-}
+// Message bubble + part rendering live in ai-message-bubble.tsx (extracted
+// to keep this file under the 500-line limit).

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-message-bubble.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-message-bubble.tsx
@@ -1,0 +1,104 @@
+/**
+ * AI Assistant message rendering — extracted from ai-assistant.tsx.
+ *
+ * Renders one `useChat` UIMessage bubble: text parts (with a streaming
+ * cursor) and tool parts (loading indicator while running, a clickable link
+ * for `navigateTo`). Transport-agnostic: the parts arrive from the AI SDK v6
+ * state machine regardless of whether the wire is /api/ai/chat or AG-UI.
+ */
+
+import type { UIMessage, UIMessagePart } from "ai";
+import { getToolName, isToolUIPart } from "ai";
+import { ExternalLinkIcon, Loader2Icon } from "lucide-react";
+
+/**
+ * Renders a single message bubble with support for:
+ * - Text parts (streamed or complete)
+ * - Tool parts (shows tool name + loading indicator or navigation links)
+ */
+export function MessageBubble({ message }: { message: UIMessage }) {
+  const isUser = message.role === "user";
+
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
+          isUser ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
+        }`}
+      >
+        {message.parts.map((part, index) => {
+          const key = `${message.id}-${index}`;
+          return <MessagePart key={key} part={part} />;
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Tool display labels for loading indicators */
+const TOOL_LABELS: Record<string, string> = {
+  queryRecords: "Querying records...",
+  getRecord: "Fetching record...",
+  executeAction: "Executing action...",
+  describeSchema: "Loading schema info...",
+  listEntities: "Listing entities...",
+  searchEntities: "Searching entities...",
+};
+
+/**
+ * Render a single message part based on its type.
+ * AI SDK v6 uses typed parts: text, tool-{name}, dynamic-tool, reasoning, etc.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: UIMessagePart generic is complex
+function MessagePart({ part }: { part: UIMessagePart<any, any> }) {
+  // Text parts
+  if (part.type === "text") {
+    return (
+      <p className="whitespace-pre-wrap">
+        {part.text}
+        {part.state === "streaming" && (
+          <span className="ml-0.5 inline-block h-4 w-1.5 animate-pulse bg-foreground/50" />
+        )}
+      </p>
+    );
+  }
+
+  // Tool parts (static: tool-{name}, dynamic: dynamic-tool)
+  if (isToolUIPart(part)) {
+    const toolName = getToolName(part);
+    const state = part.state;
+
+    // navigateTo tool with output — render as a clickable link
+    if (toolName === "navigateTo" && state === "input-available") {
+      const input = part.input as { path?: string; label?: string } | undefined;
+      if (input?.path) {
+        return (
+          <a
+            href={input.path}
+            className="mt-1 flex items-center gap-1.5 rounded-md border border-primary/30 bg-background px-2 py-1 text-xs text-primary transition-colors hover:bg-primary/10"
+          >
+            <ExternalLinkIcon className="size-3" />
+            {input.label || input.path}
+          </a>
+        );
+      }
+    }
+
+    // In-progress tool calls — show loading indicator
+    if (state === "input-streaming" || state === "input-available") {
+      return (
+        <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Loader2Icon className="size-3 animate-spin" />
+          <span>{TOOL_LABELS[toolName] ?? `Running ${toolName}...`}</span>
+        </div>
+      );
+    }
+
+    // Tool output/error — the AI will summarize results in its text response,
+    // so we don't render tool outputs inline
+    return null;
+  }
+
+  // Step start, reasoning, source, file parts — skip rendering
+  return null;
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/agui-chat-transport.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/agui-chat-transport.test.ts
@@ -349,6 +349,32 @@ describe("toAgUiMessages", () => {
     ];
     expect(toAgUiMessages(messages)).toEqual([]);
   });
+
+  test("skips input-available frontend tool calls (no result ever arrives)", () => {
+    // `input-available` is terminal for execute-less frontend tools. Sending
+    // the call without a tool-result message is an invalid conversation for
+    // strict providers, so it must not enter the history.
+    const messages: UIMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Opening the form." },
+          {
+            type: "tool-openForm",
+            toolCallId: "tc1",
+            state: "input-available",
+            input: { entity: "order" },
+          },
+        ],
+      },
+      { id: "u2", role: "user", parts: [{ type: "text", text: "thanks" }] },
+    ];
+    expect(toAgUiMessages(messages)).toEqual([
+      { id: "a1", role: "assistant", content: "Opening the form." },
+      { id: "u2", role: "user", content: "thanks" },
+    ]);
+  });
 });
 
 // ── Transport end-to-end (DI seam) ──────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/agui-chat-transport.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/agui-chat-transport.test.ts
@@ -1,0 +1,362 @@
+/**
+ * AG-UI ChatTransport translation tests.
+ *
+ * Pure logic-only (no jsdom): the HttpAgent seam is replaced by an injected
+ * synthetic event source (dependency injection — never a global fetch mock),
+ * and the emitted `UIMessageChunk` sequences are asserted against the
+ * Vercel AI SDK v6 chunk contract that `useChat` consumes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/client";
+import { EventType } from "@ag-ui/client";
+import type { UIMessage, UIMessageChunk } from "ai";
+import {
+  AgUiChatTransport,
+  type AgUiEventSource,
+  streamUiMessageChunks,
+  toAgUiContext,
+  toAgUiMessages,
+} from "../agui-chat-transport";
+
+// ── Helpers ─────────────────────────────────────────────────
+
+/** Synthetic event source: emits the given events asynchronously, then completes. */
+function sourceOf(events: BaseEvent[], options?: { error?: unknown }): AgUiEventSource {
+  return {
+    subscribe(observer) {
+      queueMicrotask(() => {
+        for (const event of events) observer.next(event);
+        if (options && "error" in options) observer.error(options.error);
+        else observer.complete();
+      });
+      return { unsubscribe: () => {} };
+    },
+  };
+}
+
+async function collect(stream: ReadableStream<UIMessageChunk>): Promise<UIMessageChunk[]> {
+  const chunks: UIMessageChunk[] = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+/** AG-UI event literals (typed loosely as the wire BaseEvent). */
+function ev(event: Record<string, unknown>): BaseEvent {
+  return event as unknown as BaseEvent;
+}
+
+const RUN_STARTED = ev({ type: EventType.RUN_STARTED, threadId: "t1", runId: "r1" });
+const RUN_FINISHED = ev({ type: EventType.RUN_FINISHED, threadId: "t1", runId: "r1" });
+
+// ── AG-UI events → UIMessageChunk ───────────────────────────
+
+describe("streamUiMessageChunks — text streaming", () => {
+  test("translates RUN_STARTED → text events → RUN_FINISHED", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(
+        sourceOf([
+          RUN_STARTED,
+          ev({ type: EventType.TEXT_MESSAGE_START, messageId: "m1", role: "assistant" }),
+          ev({ type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta: "Hel" }),
+          ev({ type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta: "lo" }),
+          ev({ type: EventType.TEXT_MESSAGE_END, messageId: "m1" }),
+          RUN_FINISHED,
+        ]),
+      ),
+    );
+
+    expect(chunks).toEqual([
+      { type: "start" },
+      { type: "text-start", id: "m1" },
+      { type: "text-delta", id: "m1", delta: "Hel" },
+      { type: "text-delta", id: "m1", delta: "lo" },
+      { type: "text-end", id: "m1" },
+      { type: "finish" },
+    ]);
+  });
+
+  test("ignores protocol events without a UI chunk counterpart", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(
+        sourceOf([
+          RUN_STARTED,
+          ev({ type: EventType.STEP_STARTED, stepName: "s1" }),
+          ev({ type: EventType.STATE_SNAPSHOT, snapshot: {} }),
+          ev({ type: EventType.STEP_FINISHED, stepName: "s1" }),
+          RUN_FINISHED,
+        ]),
+      ),
+    );
+    expect(chunks).toEqual([{ type: "start" }, { type: "finish" }]);
+  });
+});
+
+describe("streamUiMessageChunks — tool call sequence", () => {
+  test("translates TOOL_CALL_START/ARGS/END/RESULT into tool-input/output chunks", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(
+        sourceOf([
+          RUN_STARTED,
+          ev({ type: EventType.TOOL_CALL_START, toolCallId: "tc1", toolCallName: "queryRecords" }),
+          ev({ type: EventType.TOOL_CALL_ARGS, toolCallId: "tc1", delta: '{"entity":' }),
+          ev({ type: EventType.TOOL_CALL_ARGS, toolCallId: "tc1", delta: '"order"}' }),
+          ev({ type: EventType.TOOL_CALL_END, toolCallId: "tc1" }),
+          ev({
+            type: EventType.TOOL_CALL_RESULT,
+            messageId: "m2",
+            toolCallId: "tc1",
+            content: '[{"id":"o1"}]',
+            role: "tool",
+          }),
+          RUN_FINISHED,
+        ]),
+      ),
+    );
+
+    expect(chunks).toEqual([
+      { type: "start" },
+      { type: "tool-input-start", toolCallId: "tc1", toolName: "queryRecords" },
+      { type: "tool-input-delta", toolCallId: "tc1", inputTextDelta: '{"entity":' },
+      { type: "tool-input-delta", toolCallId: "tc1", inputTextDelta: '"order"}' },
+      {
+        type: "tool-input-available",
+        toolCallId: "tc1",
+        toolName: "queryRecords",
+        input: { entity: "order" },
+      },
+      { type: "tool-output-available", toolCallId: "tc1", output: [{ id: "o1" }] },
+      { type: "finish" },
+    ]);
+  });
+
+  test("an args-less tool call yields an empty-object input", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(
+        sourceOf([
+          RUN_STARTED,
+          ev({ type: EventType.TOOL_CALL_START, toolCallId: "tc1", toolCallName: "listEntities" }),
+          ev({ type: EventType.TOOL_CALL_END, toolCallId: "tc1" }),
+          RUN_FINISHED,
+        ]),
+      ),
+    );
+    expect(chunks[2]).toEqual({
+      type: "tool-input-available",
+      toolCallId: "tc1",
+      toolName: "listEntities",
+      input: {},
+    });
+  });
+
+  test("non-JSON tool result content is passed through as a string", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(
+        sourceOf([
+          ev({
+            type: EventType.TOOL_CALL_RESULT,
+            messageId: "m1",
+            toolCallId: "tc1",
+            content: "plain text result",
+          }),
+        ]),
+      ),
+    );
+    expect(chunks).toEqual([
+      { type: "tool-output-available", toolCallId: "tc1", output: "plain text result" },
+    ]);
+  });
+});
+
+describe("streamUiMessageChunks — failures", () => {
+  test("RUN_ERROR becomes an error chunk (and no finish)", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(
+        sourceOf([RUN_STARTED, ev({ type: EventType.RUN_ERROR, message: "provider exploded" })]),
+      ),
+    );
+    expect(chunks).toEqual([{ type: "start" }, { type: "error", errorText: "provider exploded" }]);
+  });
+
+  test("a transport-level error becomes an error chunk", async () => {
+    const chunks = await collect(
+      streamUiMessageChunks(sourceOf([RUN_STARTED], { error: new Error("boom") })),
+    );
+    expect(chunks).toEqual([{ type: "start" }, { type: "error", errorText: "boom" }]);
+  });
+
+  test("an abort error closes the stream WITHOUT an error chunk (user stop)", async () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    const chunks = await collect(
+      streamUiMessageChunks(sourceOf([RUN_STARTED], { error: abortError })),
+    );
+    expect(chunks).toEqual([{ type: "start" }]);
+  });
+});
+
+// ── UIMessage[] → AG-UI messages ────────────────────────────
+
+describe("toAgUiMessages", () => {
+  test("maps user/assistant text history", () => {
+    const messages: UIMessage[] = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hello" }] },
+      { id: "a1", role: "assistant", parts: [{ type: "text", text: "hi there" }] },
+    ];
+    expect(toAgUiMessages(messages)).toEqual([
+      { id: "u1", role: "user", content: "hello" },
+      { id: "a1", role: "assistant", content: "hi there" },
+    ]);
+  });
+
+  test("maps completed tool invocations to toolCalls + tool result messages", () => {
+    const messages: UIMessage[] = [
+      { id: "u1", role: "user", parts: [{ type: "text", text: "list orders" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          { type: "text", text: "Found these:" },
+          {
+            type: "tool-queryRecords",
+            toolCallId: "tc1",
+            state: "output-available",
+            input: { entity: "order" },
+            output: [{ id: "o1" }],
+          },
+        ],
+      },
+    ];
+
+    expect(toAgUiMessages(messages)).toEqual([
+      { id: "u1", role: "user", content: "list orders" },
+      {
+        id: "a1",
+        role: "assistant",
+        content: "Found these:",
+        toolCalls: [
+          {
+            id: "tc1",
+            type: "function",
+            function: { name: "queryRecords", arguments: '{"entity":"order"}' },
+          },
+        ],
+      },
+      { id: "tc1_result", role: "tool", toolCallId: "tc1", content: '[{"id":"o1"}]' },
+    ]);
+  });
+
+  test("maps a failed tool invocation to a tool message carrying the error", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-getRecord",
+            toolCallId: "tc1",
+            state: "output-error",
+            input: { id: "x" },
+            errorText: "not found",
+          },
+        ],
+      },
+    ];
+
+    const mapped = toAgUiMessages(messages);
+    expect(mapped).toHaveLength(2);
+    expect(mapped[1]).toEqual({
+      id: "tc1_result",
+      role: "tool",
+      toolCallId: "tc1",
+      content: "not found",
+      error: "not found",
+    });
+  });
+
+  test("skips in-flight tool invocations and empty messages", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-queryRecords",
+            toolCallId: "tc1",
+            state: "input-streaming",
+            input: undefined,
+          },
+        ],
+      },
+      { id: "u1", role: "user", parts: [] },
+    ];
+    expect(toAgUiMessages(messages)).toEqual([]);
+  });
+});
+
+// ── Transport end-to-end (DI seam) ──────────────────────────
+
+describe("AgUiChatTransport", () => {
+  test("sendMessages builds a RunAgentInput and streams translated chunks", async () => {
+    const inputs: RunAgentInput[] = [];
+    const transport = new AgUiChatTransport({
+      context: () => ({ entity: "order", recordId: "o1", locale: "zh-CN" }),
+      runAgent: (input) => {
+        inputs.push(input);
+        return sourceOf([
+          RUN_STARTED,
+          ev({ type: EventType.TEXT_MESSAGE_START, messageId: "m1", role: "assistant" }),
+          ev({ type: EventType.TEXT_MESSAGE_CONTENT, messageId: "m1", delta: "OK" }),
+          ev({ type: EventType.TEXT_MESSAGE_END, messageId: "m1" }),
+          RUN_FINISHED,
+        ]);
+      },
+    });
+
+    const stream = await transport.sendMessages({
+      trigger: "submit-message",
+      chatId: "chat_1",
+      messageId: undefined,
+      messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: "hello" }] }],
+      abortSignal: undefined,
+    });
+    const chunks = await collect(stream);
+
+    expect(inputs).toHaveLength(1);
+    const input = inputs[0];
+    expect(input?.threadId).toBe("chat_1");
+    expect(typeof input?.runId).toBe("string");
+    expect(input?.messages).toEqual([{ id: "u1", role: "user", content: "hello" }]);
+    expect(input?.tools).toEqual([]);
+    expect(input?.context).toEqual([
+      { description: "entity", value: "order" },
+      { description: "recordId", value: "o1" },
+      { description: "locale", value: "zh-CN" },
+    ]);
+
+    expect(chunks.map((c) => c.type)).toEqual([
+      "start",
+      "text-start",
+      "text-delta",
+      "text-end",
+      "finish",
+    ]);
+  });
+
+  test("reconnectToStream resolves null (AG-UI runs are not resumable)", async () => {
+    const transport = new AgUiChatTransport({ runAgent: () => sourceOf([]) });
+    expect(await transport.reconnectToStream({ chatId: "chat_1" })).toBeNull();
+  });
+});
+
+describe("toAgUiContext", () => {
+  test("emits only the entries that are present", () => {
+    expect(toAgUiContext(undefined)).toEqual([]);
+    expect(toAgUiContext({})).toEqual([]);
+    expect(toAgUiContext({ locale: "en" })).toEqual([{ description: "locale", value: "en" }]);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
@@ -126,12 +126,13 @@ export function toAgUiMessages(messages: UIMessage[]): AgUiMessage[] {
     const toolResults: Extract<AgUiMessage, { role: "tool" }>[] = [];
     for (const part of message.parts ?? []) {
       if (!isToolUIPart(part)) continue;
-      // Only invocations whose input is final belong in the history.
-      if (
-        part.state !== "input-available" &&
-        part.state !== "output-available" &&
-        part.state !== "output-error"
-      ) {
+      // Only invocations whose input is final AND whose result has been
+      // received belong in the history. `input-available` is the terminal
+      // state for execute-less frontend tools (no result is ever fed back),
+      // so treat it like the still-streaming states and skip it — a tool
+      // call without a following tool-result message is an invalid
+      // conversation for strict LLM providers (OpenAI, Anthropic).
+      if (part.state !== "output-available" && part.state !== "output-error") {
         continue;
       }
       toolCalls.push({

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
@@ -1,0 +1,369 @@
+/**
+ * AG-UI ChatTransport — drives the Vercel AI SDK `useChat` hook over the
+ * official AG-UI protocol (https://docs.ag-ui.com) instead of the SDK's
+ * proprietary UI-message stream.
+ *
+ * Wire path: `useChat` → this transport → `HttpAgent` from `@ag-ui/client`
+ * (POST /api/agui/run, SSE) → AG-UI events → translated back into
+ * `UIMessageChunk`s the `useChat` state machine consumes. The UI shell,
+ * message rendering and tool-part rendering in ai-assistant.tsx stay
+ * unchanged — only the socket speaks the open standard (#89).
+ *
+ * Zod-version note: `@ag-ui/client`/`@ag-ui/core` ship zod-3 schemas. This
+ * module uses exported TYPES + the `EventType` enum only — never composes
+ * their schemas with the repo's zod-4 (established pattern from #546).
+ */
+
+import type {
+  Context as AgUiContext,
+  Message as AgUiMessage,
+  ToolCall as AgUiToolCall,
+  BaseEvent,
+  RunAgentInput,
+  RunErrorEvent,
+  TextMessageContentEvent,
+  TextMessageEndEvent,
+  TextMessageStartEvent,
+  ToolCallArgsEvent,
+  ToolCallEndEvent,
+  ToolCallResultEvent,
+  ToolCallStartEvent,
+} from "@ag-ui/client";
+import { EventType, HttpAgent } from "@ag-ui/client";
+import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
+import { getToolName, isToolUIPart } from "ai";
+
+// ── Event source seam ────────────────────────────────────────
+
+/**
+ * Structural slice of an rxjs `Observable<BaseEvent>` — lets tests inject a
+ * synthetic event source without pulling rxjs into the test graph, and keeps
+ * this module decoupled from rxjs types (an internal dep of @ag-ui/client).
+ */
+export interface AgUiEventSource {
+  subscribe(observer: {
+    next: (event: BaseEvent) => void;
+    error: (err: unknown) => void;
+    complete: () => void;
+  }): { unsubscribe: () => void };
+}
+
+/**
+ * Produces the AG-UI event stream for one run. The default implementation
+ * wraps `HttpAgent` from `@ag-ui/client`; tests inject a fake.
+ */
+export type AgUiRunAgentFn = (
+  input: RunAgentInput,
+  options: { abortSignal?: AbortSignal },
+) => AgUiEventSource;
+
+/** Default run function — official `@ag-ui/client` HttpAgent over SSE. */
+function createHttpRunAgent(url: string): AgUiRunAgentFn {
+  return (input, { abortSignal }) => {
+    // One agent per run: `useChat` owns conversation state, so the stateful
+    // `runAgent()` orchestration is bypassed in favor of the raw `run()`
+    // Observable. `abortRun()` aborts the underlying fetch.
+    const agent = new HttpAgent({ url, threadId: input.threadId });
+    if (abortSignal) {
+      if (abortSignal.aborted) agent.abortRun();
+      else abortSignal.addEventListener("abort", () => agent.abortRun(), { once: true });
+    }
+    return agent.run(input);
+  };
+}
+
+// ── UIMessage[] → AG-UI messages ─────────────────────────────
+
+/** Join the text parts of a UIMessage into one string. */
+function textOf(message: UIMessage): string {
+  return message.parts
+    .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+/** Serialize a tool output for the AG-UI `tool` message `content` string. */
+function serializeToolOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  try {
+    return JSON.stringify(output ?? null);
+  } catch {
+    return String(output);
+  }
+}
+
+/**
+ * Map the `useChat` UIMessage history onto AG-UI protocol messages.
+ *
+ * Faithful per-role mapping: text parts become message content; completed
+ * assistant tool invocations become `toolCalls` plus a follow-up `tool`
+ * result message, so multi-turn conversations keep their tool context.
+ */
+export function toAgUiMessages(messages: UIMessage[]): AgUiMessage[] {
+  const out: AgUiMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role === "system" || message.role === "user") {
+      const text = textOf(message);
+      if (text.length > 0) out.push({ id: message.id, role: message.role, content: text });
+      continue;
+    }
+
+    // assistant — text + tool invocations
+    const toolCalls: AgUiToolCall[] = [];
+    const toolResults: Extract<AgUiMessage, { role: "tool" }>[] = [];
+    for (const part of message.parts) {
+      if (!isToolUIPart(part)) continue;
+      // Only invocations whose input is final belong in the history.
+      if (
+        part.state !== "input-available" &&
+        part.state !== "output-available" &&
+        part.state !== "output-error"
+      ) {
+        continue;
+      }
+      toolCalls.push({
+        id: part.toolCallId,
+        type: "function",
+        function: { name: getToolName(part), arguments: JSON.stringify(part.input ?? {}) },
+      });
+      if (part.state === "output-available") {
+        toolResults.push({
+          id: `${part.toolCallId}_result`,
+          role: "tool",
+          toolCallId: part.toolCallId,
+          content: serializeToolOutput(part.output),
+        });
+      } else if (part.state === "output-error") {
+        toolResults.push({
+          id: `${part.toolCallId}_result`,
+          role: "tool",
+          toolCallId: part.toolCallId,
+          content: part.errorText,
+          error: part.errorText,
+        });
+      }
+    }
+
+    const text = textOf(message);
+    if (text.length > 0 || toolCalls.length > 0) {
+      out.push({
+        id: message.id,
+        role: "assistant",
+        ...(text.length > 0 ? { content: text } : {}),
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+      });
+    }
+    out.push(...toolResults);
+  }
+
+  return out;
+}
+
+// ── AG-UI events → UIMessageChunk ────────────────────────────
+
+/** Parse a string that may contain JSON; fall back to the raw string. */
+function parseMaybeJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Create a stateful per-run translator: AG-UI protocol event → zero or more
+ * `UIMessageChunk`s. Tool-call args stream as deltas and are parsed into the
+ * final `tool-input-available` input when TOOL_CALL_END arrives.
+ */
+export function createAgUiChunkTranslator(): (event: BaseEvent) => UIMessageChunk[] {
+  const toolCalls = new Map<string, { toolName: string; argsText: string }>();
+
+  return (event) => {
+    switch (event.type) {
+      case EventType.RUN_STARTED:
+        return [{ type: "start" }];
+      case EventType.TEXT_MESSAGE_START: {
+        const e = event as TextMessageStartEvent;
+        return [{ type: "text-start", id: e.messageId }];
+      }
+      case EventType.TEXT_MESSAGE_CONTENT: {
+        const e = event as TextMessageContentEvent;
+        return [{ type: "text-delta", id: e.messageId, delta: e.delta }];
+      }
+      case EventType.TEXT_MESSAGE_END: {
+        const e = event as TextMessageEndEvent;
+        return [{ type: "text-end", id: e.messageId }];
+      }
+      case EventType.TOOL_CALL_START: {
+        const e = event as ToolCallStartEvent;
+        toolCalls.set(e.toolCallId, { toolName: e.toolCallName, argsText: "" });
+        return [{ type: "tool-input-start", toolCallId: e.toolCallId, toolName: e.toolCallName }];
+      }
+      case EventType.TOOL_CALL_ARGS: {
+        const e = event as ToolCallArgsEvent;
+        const call = toolCalls.get(e.toolCallId);
+        if (!call) return [];
+        call.argsText += e.delta;
+        return [{ type: "tool-input-delta", toolCallId: e.toolCallId, inputTextDelta: e.delta }];
+      }
+      case EventType.TOOL_CALL_END: {
+        const e = event as ToolCallEndEvent;
+        const call = toolCalls.get(e.toolCallId);
+        if (!call) return [];
+        const parsed = call.argsText.length > 0 ? parseMaybeJson(call.argsText) : {};
+        return [
+          {
+            type: "tool-input-available",
+            toolCallId: e.toolCallId,
+            toolName: call.toolName,
+            input: typeof parsed === "string" ? {} : parsed,
+          },
+        ];
+      }
+      case EventType.TOOL_CALL_RESULT: {
+        const e = event as ToolCallResultEvent;
+        return [
+          {
+            type: "tool-output-available",
+            toolCallId: e.toolCallId,
+            output: parseMaybeJson(e.content),
+          },
+        ];
+      }
+      case EventType.RUN_FINISHED:
+        return [{ type: "finish" }];
+      case EventType.RUN_ERROR: {
+        const e = event as RunErrorEvent;
+        return [{ type: "error", errorText: e.message }];
+      }
+      default:
+        // STEP_*, STATE_*, RAW, CUSTOM, ... — no UIMessageChunk counterpart.
+        return [];
+    }
+  };
+}
+
+/** True for errors raised by an intentional abort (user pressed stop). */
+function isAbortError(err: unknown): boolean {
+  return (
+    (err instanceof DOMException && err.name === "AbortError") ||
+    (err instanceof Error && (err.name === "AbortError" || /abort/i.test(err.message)))
+  );
+}
+
+/**
+ * Pipe an AG-UI event source into a `ReadableStream<UIMessageChunk>` for the
+ * `useChat` state machine. Exported for tests.
+ */
+export function streamUiMessageChunks(source: AgUiEventSource): ReadableStream<UIMessageChunk> {
+  const translate = createAgUiChunkTranslator();
+  let subscription: { unsubscribe: () => void } | undefined;
+  let closed = false;
+
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      const close = (): void => {
+        if (closed) return;
+        closed = true;
+        try {
+          controller.close();
+        } catch {
+          // already closed/cancelled by the consumer
+        }
+      };
+      subscription = source.subscribe({
+        next: (event) => {
+          if (closed) return;
+          try {
+            for (const chunk of translate(event)) controller.enqueue(chunk);
+          } catch {
+            closed = true;
+          }
+        },
+        error: (err) => {
+          if (!closed && !isAbortError(err)) {
+            try {
+              controller.enqueue({
+                type: "error",
+                errorText: err instanceof Error ? err.message : String(err),
+              });
+            } catch {
+              // consumer already cancelled — nothing to surface
+            }
+          }
+          close();
+        },
+        complete: close,
+      });
+    },
+    cancel() {
+      closed = true;
+      subscription?.unsubscribe();
+    },
+  });
+}
+
+// ── Transport ────────────────────────────────────────────────
+
+/** Page context sent with each run as AG-UI context entries. */
+export interface AgUiPageContext {
+  entity?: string;
+  recordId?: string;
+  locale?: string;
+}
+
+export interface AgUiChatTransportOptions {
+  /** AG-UI run endpoint. @default "/api/agui/run" */
+  api?: string;
+  /** Per-request page context provider (entity / recordId / locale). */
+  context?: () => AgUiPageContext;
+  /** Test seam — replaces the HttpAgent-backed event source. */
+  runAgent?: AgUiRunAgentFn;
+}
+
+/** Map the page context onto AG-UI `{ description, value }` entries. */
+export function toAgUiContext(context: AgUiPageContext | undefined): AgUiContext[] {
+  if (!context) return [];
+  const entries: AgUiContext[] = [];
+  if (context.entity) entries.push({ description: "entity", value: context.entity });
+  if (context.recordId) entries.push({ description: "recordId", value: context.recordId });
+  if (context.locale) entries.push({ description: "locale", value: context.locale });
+  return entries;
+}
+
+/**
+ * `ChatTransport` implementation speaking the AG-UI protocol via the
+ * official `@ag-ui/client` HttpAgent.
+ */
+export class AgUiChatTransport<UI_MESSAGE extends UIMessage = UIMessage>
+  implements ChatTransport<UI_MESSAGE>
+{
+  private readonly runAgentFn: AgUiRunAgentFn;
+  private readonly contextFn?: () => AgUiPageContext;
+
+  constructor(options: AgUiChatTransportOptions = {}) {
+    this.runAgentFn = options.runAgent ?? createHttpRunAgent(options.api ?? "/api/agui/run");
+    this.contextFn = options.context;
+  }
+
+  sendMessages: ChatTransport<UI_MESSAGE>["sendMessages"] = async (options) => {
+    const input: RunAgentInput = {
+      threadId: options.chatId,
+      runId: crypto.randomUUID(),
+      messages: toAgUiMessages(options.messages),
+      // Server-side tools live behind the endpoint (assistant runner);
+      // the LinchKit admin assistant registers no frontend tools.
+      tools: [],
+      context: toAgUiContext(this.contextFn?.()),
+      state: {},
+      forwardedProps: {},
+    };
+
+    const source = this.runAgentFn(input, { abortSignal: options.abortSignal });
+    return streamUiMessageChunks(source);
+  };
+
+  /** AG-UI runs are not resumable server-side — nothing to reconnect to. */
+  reconnectToStream: ChatTransport<UI_MESSAGE>["reconnectToStream"] = async () => null;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,11 @@
     "addons/adapter-ag-ui/cap-adapter-ag-ui": {
       "name": "@linchkit/cap-adapter-ag-ui",
       "version": "1.0.0",
+      "dependencies": {
+        "@ag-ui/core": "~0.0.56",
+        "elysia": "^1.4.28",
+        "zod": "^4.3.6",
+      },
       "devDependencies": {
         "@linchkit/core": "workspace:*",
         "@linchkit/devtools": "workspace:*",
@@ -94,6 +99,7 @@
         "graphql-yoga": "^5.18.1",
       },
       "devDependencies": {
+        "@linchkit/cap-adapter-ag-ui": "workspace:*",
         "@linchkit/cap-ai-provider": "workspace:*",
         "@linchkit/cap-chatter": "workspace:*",
         "@linchkit/cap-dry-run": "workspace:*",
@@ -110,6 +116,8 @@
       "name": "@linchkit/cap-adapter-ui",
       "version": "1.0.0",
       "dependencies": {
+        "@ag-ui/client": "~0.0.56",
+        "@ag-ui/core": "~0.0.56",
         "@ai-sdk/react": "^3.0.140",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -130,6 +138,7 @@
         "cmdk": "^1.1.1",
         "dagre": "^0.8.5",
         "date-fns": "^4.1.0",
+        "eventsource-parser": "^3.0.6",
         "i18next": "^26.0.6",
         "lucide-react": "^1.7.0",
         "mermaid": "^11.6.0",
@@ -591,6 +600,14 @@
     },
   },
   "packages": {
+    "@ag-ui/client": ["@ag-ui/client@0.0.56", "https://registry.npmmirror.com/@ag-ui/client/-/client-0.0.56.tgz", { "dependencies": { "@ag-ui/core": "0.0.56", "@ag-ui/encoder": "0.0.56", "@ag-ui/proto": "0.0.56", "@types/uuid": "^10.0.0", "compare-versions": "^6.1.1", "fast-json-patch": "^3.1.1", "rxjs": "7.8.1", "untruncate-json": "^0.0.1", "uuid": "^11.1.0", "zod": "^3.22.4" } }, "sha512-dxen4qVnDQB1xC9x1nND9W/plidoy0qwDarUPuasHCrtlkMl1EUlc+rNJM7Lr1NtnRmGHHX8gHrSeUXP3vPVHA=="],
+
+    "@ag-ui/core": ["@ag-ui/core@0.0.56", "https://registry.npmmirror.com/@ag-ui/core/-/core-0.0.56.tgz", { "dependencies": { "zod": "^3.22.4" } }, "sha512-PD26s7qk8dG6/TOGmOv23ByTaGwJs2Wzm53OwsM40jSjio3xmswGZzDaFpjMNP6FsASNGovCPB8xICAyWhYx8A=="],
+
+    "@ag-ui/encoder": ["@ag-ui/encoder@0.0.56", "https://registry.npmmirror.com/@ag-ui/encoder/-/encoder-0.0.56.tgz", { "dependencies": { "@ag-ui/core": "0.0.56", "@ag-ui/proto": "0.0.56" } }, "sha512-JkR7OGby8hBUOOlrvli0bArM5qvfCoavj3ajUp8324n20wYMrfN+/TR3GUm7wW1japrV+2dS7JEVX5dylrPF1A=="],
+
+    "@ag-ui/proto": ["@ag-ui/proto@0.0.56", "https://registry.npmmirror.com/@ag-ui/proto/-/proto-0.0.56.tgz", { "dependencies": { "@ag-ui/core": "0.0.56", "@bufbuild/protobuf": "^2.2.5", "@protobuf-ts/protoc": "^2.11.1" } }, "sha512-D72l/Xa3vHRBJtlxa+gG3VcycrEwDCHwCTh8BGkyrnRdraYPFl92eeWSV0tnF9+i7xLyNqCdww+NgCoPlrdhZQ=="],
+
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.63", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SiLosFr0FfKfrNpAAj8mD/i3S5YBB/z5orb1DH3pN1yATuBNjjPMLnRE4P3Dn7Y5cQsro0uzw5g5117hkShWoQ=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.77", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-UdwIG2H2YMuntJQ5L+EmED5XiwnlvDT3HOmKfVFxR4Nq/RSLFA/HcchhwfNXHZ5UJjyuL2VO0huLbWSZ9ijemQ=="],
@@ -702,6 +719,8 @@
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "https://registry.npmmirror.com/@borewit/text-codec/-/text-codec-0.2.2.tgz", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "https://registry.npmmirror.com/@bufbuild/protobuf/-/protobuf-2.12.0.tgz", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.0", "", { "dependencies": { "@changesets/config": "^3.1.3", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ=="],
 
@@ -1078,6 +1097,8 @@
     "@oxc-project/types": ["@oxc-project/types@0.120.0", "https://registry.npmmirror.com/@oxc-project/types/-/types-0.120.0.tgz", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@protobuf-ts/protoc": ["@protobuf-ts/protoc@2.11.1", "https://registry.npmmirror.com/@protobuf-ts/protoc/-/protoc-2.11.1.tgz", { "bin": { "protoc": "protoc.js" } }, "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1525,6 +1546,8 @@
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
+    "@types/uuid": ["@types/uuid@10.0.0", "https://registry.npmmirror.com/@types/uuid/-/uuid-10.0.0.tgz", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
+
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "https://registry.npmmirror.com/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
@@ -1670,6 +1693,8 @@
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "commander": ["commander@14.0.3", "https://registry.npmmirror.com/commander/-/commander-14.0.3.tgz", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "compare-versions": ["compare-versions@6.1.1", "https://registry.npmmirror.com/compare-versions/-/compare-versions-6.1.1.tgz", {}, "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
@@ -1904,6 +1929,8 @@
     "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
     "fast-glob": ["fast-glob@3.3.3", "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.3.tgz", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fast-json-patch": ["fast-json-patch@3.1.1", "https://registry.npmmirror.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
@@ -2483,6 +2510,8 @@
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
+    "rxjs": ["rxjs@7.8.1", "https://registry.npmmirror.com/rxjs/-/rxjs-7.8.1.tgz", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg=="],
+
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -2651,6 +2680,8 @@
 
     "until-async": ["until-async@3.0.2", "https://registry.npmmirror.com/until-async/-/until-async-3.0.2.tgz", {}, "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw=="],
 
+    "untruncate-json": ["untruncate-json@0.0.1", "https://registry.npmmirror.com/untruncate-json/-/untruncate-json-0.0.1.tgz", {}, "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "https://registry.npmmirror.com/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
@@ -2726,6 +2757,10 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@ag-ui/client/zod": ["zod@3.25.76", "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@ag-ui/core/zod": ["zod@3.25.76", "https://registry.npmmirror.com/zod/-/zod-3.25.76.tgz", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@ai-sdk/react/ai": ["ai@6.0.138", "", { "dependencies": { "@ai-sdk/gateway": "3.0.80", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA=="],
 

--- a/config/capabilities.ts
+++ b/config/capabilities.ts
@@ -6,6 +6,7 @@
  * Permission groups are declared by each capability, not here.
  */
 
+import { createCapAdapterAgUi } from "@linchkit/cap-adapter-ag-ui";
 import { createCapAdapterMcp } from "@linchkit/cap-adapter-mcp";
 import { capAdapterServer } from "@linchkit/cap-adapter-server";
 import { capAdapterUi } from "@linchkit/cap-adapter-ui";
@@ -25,6 +26,11 @@ export const capabilities: CapabilityDefinition[] = [
   capAdapterServer,
   createCapAdapterMcp({ config: { transport: "sse", ssePort: 3002 } }),
   capAdapterUi,
+  // AG-UI protocol (#89): registering the capability opts in the
+  // `POST /api/agui/run` route on the main server (:3001) — the admin UI
+  // assistant talks this endpoint via @ag-ui/client. The addon's own
+  // standalone transport (port 3003) stays disabled by default.
+  createCapAdapterAgUi(),
 
   // Authentication & authorization
   // createCapAuth({

--- a/e2e/browser/smoke.test.ts
+++ b/e2e/browser/smoke.test.ts
@@ -313,4 +313,57 @@ describe.skipIf(!BROWSER_E2E_ENABLED)("browser e2e smoke", () => {
     },
     TEST_TIMEOUT_MS,
   );
+
+  // ── g. AG-UI run endpoint is mounted on the main server (#89) ──────────
+  // Pins the cap-adapter-ag-ui wiring: the route only exists when the
+  // capability is registered (config/capabilities.ts) AND adapter-server
+  // mounts it (routes/agui-api.ts). The FIRST SSE event must be RUN_STARTED
+  // — it is emitted before any provider call, so this holds even when the
+  // configured AI key cannot complete a run (which would follow as
+  // RUN_ERROR, after the frame this test asserts).
+  test(
+    "POST /api/agui/run streams SSE whose first event is RUN_STARTED",
+    async () => {
+      const res = await fetch(`${API_URL}/api/agui/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId: "e2e_thread",
+          runId: "e2e_run",
+          messages: [{ id: "m1", role: "user", content: "Reply with OK only." }],
+          tools: [],
+          context: [],
+        }),
+      });
+      // 404 = route not mounted (capability/wiring gap); 503 = AI not
+      // configured on the dev server. Both are the regressions this pins.
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+      // Read only the first SSE frame, then cancel — no full-run dependency.
+      const reader = res.body?.getReader();
+      expect(reader).toBeDefined();
+      if (!reader) return;
+      let buffer = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += new TextDecoder().decode(value);
+        if (buffer.includes("\n\n")) break;
+      }
+      await reader.cancel();
+
+      const firstFrame = buffer.split("\n\n")[0] ?? "";
+      expect(firstFrame.startsWith("data: ")).toBe(true);
+      const firstEvent = JSON.parse(firstFrame.slice("data: ".length)) as {
+        type: string;
+        threadId?: string;
+        runId?: string;
+      };
+      expect(firstEvent.type).toBe("RUN_STARTED");
+      expect(firstEvent.threadId).toBe("e2e_thread");
+      expect(firstEvent.runId).toBe("e2e_run");
+    },
+    TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

Phase 2 of AG-UI adoption (#89): the standard socket shipped in #546 stops being idle — it is mounted on the main server and becomes the production transport for our own admin-UI assistant (dogfooding).

### Server
- `POST /api/agui/run` now mounted on the main app (:3001) via capability-gated lazy loading in adapter-server; registering `createCapAdapterAgUi()` in `config/capabilities.ts` switches it on for both `dev:server` and `linch dev` boot paths. The :3003 standalone transport stays opt-in.
- New `AgUiAgentRunner` injection seam in `run-endpoint.ts`. adapter-server injects a runner built from the **same pipeline as `/api/ai/chat`** (same system prompt, read-only tools, multi-step loop, tenant/actor resolution) — the assistant loses zero capabilities by switching protocols. The default AIService bridge remains for third-party AG-UI frontends.

### UI
- `AgUiChatTransport` — ai v6 `ChatTransport<UIMessage>` built on the official `@ag-ui/client` `HttpAgent`; AG-UI events translated to `UIMessageChunk` stream (text, tool calls, errors, abort → `abortRun()`).
- `ai-assistant.tsx` swaps `DefaultChatTransport(/api/ai/chat)` for `AgUiChatTransport(/api/agui/run)`. UI shell, intent resolution, ProposalCard flow, and tool rendering unchanged (505 → 408 lines; MessageBubble extracted to `ai-message-bubble.tsx`).
- Deps: `@ag-ui/client` / `@ag-ui/core` at `~0.0.56` (floating with upstream per policy).

### Untouched
`/api/ai/chat` is unchanged and still pinned by the existing e2e case.

## Verification
- `bun run check` / `bun run typecheck` clean
- Full `bun run test`: all batches PASS (298 tests in final batch, 0 fail)
- Targeted: 59 new/updated tests across run-endpoint seam (32), transport translation (15), agui-api mount (12)
- Real chain (in-process `app.handle`): `POST /api/agui/run` → `200 text/event-stream`, sequence `RUN_STARTED → TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT → TEXT_MESSAGE_END → RUN_FINISHED`
- New e2e smoke case pins `RUN_STARTED` as first SSE event (gated by `LINCHKIT_E2E_BROWSER=1`)

Closes the AG-UI half of #89.

Note: codex CLI quota exhausted (resets Jun 11); cross-model review relies on PR bots per today's established fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated AG-UI protocol support for assistant conversations with enhanced streaming capabilities.
  * Added visual indicators for tool execution status during assistant interactions.
  * Implemented navigation tool rendering in chat messages with direct action links.
  * Enhanced message display with animated indicators for streaming tool calls and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->