### PR TITLE
ci: add Claude Code Action PR review workflow (replaces gemini-code-assist)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,135 @@
+name: Claude Review
+
+# Replaces gemini-code-assist as the PR review bot (issue #542; gemini
+# sunsets 2026-07-17). Uses the official Claude Code GitHub Action
+# (anthropics/claude-code-action@v1) authenticated via the Claude Max
+# subscription OAuth token (secrets.CLAUDE_CODE_OAUTH_TOKEN).
+#
+# Two jobs:
+#   1. auto-review  — automatic review of every owner-authored PR
+#                     (pull_request: opened / synchronize / ready_for_review).
+#   2. mention      — interactive @claude mention mode on PR/issue comments
+#                     and review-thread replies, so review findings can be
+#                     discussed in-thread (mirrors how gemini-code-assist
+#                     responded to replies today).
+#
+# Integration with the Review Threads gate (review-gate.yml):
+#   The reviewer is instructed to post INLINE review comments via the
+#   action's `mcp__github_inline_comment__create_inline_comment` tool.
+#   Inline comments create PR review threads, which the `review-threads`
+#   commit status (branch protection) counts until resolved — exactly how
+#   gemini/CodeRabbit findings are tracked today. The reviewer is comment-only:
+#   it never submits a formal APPROVE / REQUEST_CHANGES review, so it cannot
+#   deadlock branch protection.
+#
+# Owner-gating (solo repo):
+#   Only runs for PRs authored by the repo owner from a same-repo branch.
+#   This prevents token burn from forks/dependabot — and fork PRs could not
+#   work anyway, since secrets are unavailable to pull_request runs from forks.
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  auto-review:
+    name: Claude Auto Review
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'laofahai'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # Cancel a superseded review when new commits land on the same PR.
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Keep top-level summary feedback in one updating comment instead of
+          # a new comment per push.
+          use_sticky_comment: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are the code review bot for LinchKit (AI-Native software
+            capability runtime; Bun + TypeScript strict + Elysia + Drizzle +
+            React 19). The PR branch is already checked out in the current
+            working directory. Read CLAUDE.md for repo conventions.
+
+            Perform a thorough code review of this PR focused on REAL BUGS:
+            - Correctness: logic errors, broken edge cases, off-by-one,
+              wrong null/undefined handling, dead or unreachable code paths
+              introduced by the diff.
+            - Security: injection, authz bypass, secrets, unsafe input
+              handling. All API endpoints must go through CommandLayer and
+              the permission slot must never be skipped.
+            - Concurrency / async: race conditions, missing await, TOCTOU,
+              transaction misuse.
+            - API misuse: wrong Drizzle/Elysia/Bun/React usage. In Elysia
+              handlers, body must be read from the destructured context
+              `body`, never `request.json()` on the raw Request.
+            - Repo invariants: Bun only (never node/npx/npm), no `any` type,
+              no `eval`/`new Function`, no hand-written DDL, Actions are the
+              sole write entry (GraphQL mutations only via actions), system
+              fields are server-managed, `core` never imports from other
+              packages, `ui` never imports from `server`.
+            - Tests: missing or misleading coverage for changed behavior;
+              mock seams that mask integration bugs.
+
+            How to deliver feedback:
+            - Post findings as INLINE review comments on the exact lines using
+              `mcp__github_inline_comment__create_inline_comment` (pass
+              `confirmed: true`). Be specific: cite file:line, explain the
+              failure mode, and suggest a concrete fix.
+            - Use `gh pr comment` only for a brief overall summary (or to say
+              the PR looks good when you found nothing).
+            - Only post GitHub comments — do not output review text as a
+              plain response message.
+
+            Rules:
+            - Skip style/formatting nits entirely — Biome owns formatting.
+            - Do NOT submit a formal review verdict: never approve and never
+              request changes. Comment-only.
+            - Quality over quantity: only flag issues you are confident are
+              real. Do not pad the review with speculative or trivial points.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+
+  mention:
+    name: Claude Mention
+    if: >
+      (github.event_name == 'issue_comment' ||
+       github.event_name == 'pull_request_review_comment') &&
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.login == 'laofahai'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      # No `prompt` => interactive tag mode: Claude reads the @claude comment
+      # (including replies inside review threads) and responds in context.
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces gemini-code-assist (sunsets **2026-07-17**) with the official **Claude Code GitHub Action** as the PR review bot. Closes #542.

- `anthropics/claude-code-action@v1`, authenticated via `CLAUDE_CODE_OAUTH_TOKEN` (Claude Max subscription OAuth — secret already set, app already installed; **$0 marginal cost**)
- **auto-review job**: every owner-authored, same-repo, non-draft PR. Real-bugs-focused prompt (correctness, security/CommandLayer, concurrency/TOCTOU, Elysia context-body trap, repo invariants: Bun-only / no `any` / Action-as-sole-write-entry / import boundaries). Style nits excluded — Biome owns formatting.
- Findings are posted as **inline review comments** (via the action's MCP inline-comment tool) → they create real PR review threads → counted by the existing `review-threads` branch-protection status. Same lifecycle as gemini/CodeRabbit today.
- **Comment-only**: formal APPROVE/REQUEST_CHANGES forbidden (and not in allowedTools) — cannot deadlock branch protection.
- **mention job**: `@claude` tag mode on issue/PR/review-thread comments for in-thread discussion (owner-gated).
- Owner-gating prevents token burn from forks/dependabot; fork PRs have no secrets anyway.
- Concurrency: superseded auto-reviews are cancelled per-PR; `timeout-minutes: 25`.

All inputs/version verified against current action docs (README + docs/usage.md + docs/solutions.md): `prompt` (not deprecated `direct_prompt`), `claude_code_oauth_token`, `use_sticky_comment`, inline-comment allowedTools snippet.

## Verification
- YAML parse validated (js-yaml clean)
- `bun run check` / `bun run typecheck` clean; full `bun run test` all batches PASS (no source touched — workflow file only)
- Live validation happens on this very PR's successor: once merged, the workflow reviews the next PR

Note: codex CLI quota exhausted (resets Jun 11); cross-model review relies on PR bots per today's established fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
