### PR TITLE
feat(ai-provider): Drizzle/PG sink for AI traces + monthly drift cron (Spec 69 P3 wave 1)

### DIFF
--- a/.github/workflows/ai-eval.yml
+++ b/.github/workflows/ai-eval.yml
@@ -1,12 +1,16 @@
 name: AI Eval (prompt-quality)
 
-# Implements spec 69's two-tier regression strategy:
+# Implements spec 69's three-tier regression strategy (§9.1):
 #   • §9.2 — every PR touching prompt/eval surface runs offline REPLAY against
 #     the committed canonical baseline. Zero LLM cost, zero secrets required.
 #     This is the gate that actually blocks merges.
 #   • §9.3 — LIVE eval against the real LLM is gated behind workflow_dispatch
 #     so maintainers explicitly opt in (and pay the cost / consume the
 #     model quota). Same-repo only; fork PRs are skipped (secrets policy).
+#   • §9.4 — monthly provider-drift cron reuses the live path on a schedule;
+#     a >5pp strict-hit-rate drop vs the committed canonical baseline files a
+#     GitHub issue (non-blocking). A missing provider secret fails the
+#     scheduled job loudly instead of silently passing.
 #
 # Why this split: not every repo has provider secrets configured. The repo
 # default provider (zhipu/GLM here, per config/linchkit.config.ts) requires
@@ -41,6 +45,11 @@ on:
         required: true
         default: '5'
         type: string
+  schedule:
+    # Monthly provider-drift cron (spec 69 §9.1 tier 3): 03:17 UTC on the 3rd.
+    # Runs the live eval against the committed canonical baseline and files an
+    # issue on a >5pp drop (§9.4). Off-peak minute to dodge cron congestion.
+    - cron: '17 3 3 * *'
 
 jobs:
   # Tier-1: offline replay — no secrets, runs on every relevant PR.
@@ -81,12 +90,17 @@ jobs:
             ai-eval-report.json
           retention-days: 30
 
-  # Tier-2: live eval against real LLM. Manual trigger only.
-  # Requires the active provider's API key in repo secrets (see step 1 below).
+  # Tier-2: live eval against real LLM — manual trigger, plus the tier-3
+  # monthly drift cron (spec 69 §9.4) which reuses the exact same eval path.
+  # Requires the active provider's API key in repo secrets (see step 1 below);
+  # on scheduled runs a missing key fails the key-verification step loudly.
   intent-eval-live:
-    name: Intent Eval (live, manual)
-    if: github.event_name == 'workflow_dispatch'
+    name: Intent Eval (live / monthly drift)
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # drift cron files an issue on a >5pp drop (spec 69 §9.4)
     env:
       # Forward every provider key the project might be configured to use.
       # The CLI picks the active provider from config/linchkit.config.ts;
@@ -142,6 +156,14 @@ jobs:
         # `AI_EVAL_LIVE=1 bun run ai:eval --scenario intent --refresh-baseline`
         # and committed alongside the prompt change. This prevents CI from
         # silently moving the regression bar (spec 69 §6.3, §9.2).
+        #
+        # On SCHEDULED (drift-cron) runs the eval's own regression gate must
+        # not kill the job before the drift step below inspects the report —
+        # spec 69 §9.4: the cron files an issue, it does not block anything.
+        # The drift step still fails the job loudly when no report/diff was
+        # produced at all (infra failure ≠ measured drift).
+        id: live-eval
+        continue-on-error: ${{ github.event_name == 'schedule' }}
         shell: bash
         run: |
           set -o pipefail
@@ -162,3 +184,73 @@ jobs:
             ai-eval-report.md
             ai-eval-report.json
           retention-days: 30
+
+      # Tier-3 drift gate (scheduled runs only) — spec 69 §9.4: a scenario
+      # dropping more than 5 percentage points vs the committed canonical
+      # baseline files a GitHub issue; the cron never blocks merges. The
+      # report JSON carries the diff in BOTH outcomes: success-path full
+      # RunReport and the RegressionError path ({ diff }) both expose
+      # `.diff.summary.deltaPp` (see packages/devtools/src/ai-eval/cli.ts).
+      - name: Detect provider drift and file issue (scheduled runs)
+        if: github.event_name == 'schedule'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVAL_OUTCOME: ${{ steps.live-eval.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Fail LOUDLY when the eval produced no machine-readable report at
+          # all (crash, missing secret slipping past verification, …) — a
+          # silent green here would defeat the whole point of the cron.
+          if [ ! -f ai-eval-report.json ]; then
+            echo "::error::Scheduled drift run produced no ai-eval-report.json (eval outcome: ${EVAL_OUTCOME}) — failing loudly."
+            exit 1
+          fi
+
+          DELTA_PP=$(jq -r '.diff.summary.deltaPp // empty' ai-eval-report.json)
+          if [ -z "$DELTA_PP" ]; then
+            if [ "$EVAL_OUTCOME" != "success" ]; then
+              echo "::error::Live eval failed before a baseline diff was computed — failing loudly."
+              exit 1
+            fi
+            echo "Report has no baseline diff (no prior canonical baseline?) — nothing to compare."
+            exit 0
+          fi
+          echo "Strict hit-rate delta vs committed canonical baseline: ${DELTA_PP}pp"
+
+          DRIFTED=$(jq -r '.diff.summary.deltaPp < -5' ai-eval-report.json)
+          if [ "$DRIFTED" != "true" ]; then
+            echo "Drift within tolerance (threshold: >5pp drop). No issue filed."
+            exit 0
+          fi
+
+          MONTH=$(date -u +%Y-%m)
+          TITLE="AI eval drift detected ${MONTH}"
+          # Dedupe: a re-run inside the same month must not file a duplicate.
+          EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" \
+            --json title --jq "[.[] | select(.title == \"$TITLE\")] | length")
+          if [ "$EXISTING" != "0" ]; then
+            echo "Open issue \"$TITLE\" already exists — not filing a duplicate."
+            exit 0
+          fi
+
+          SCENARIO=$(jq -r '.scenario // "intent"' ai-eval-report.json)
+          MODEL=$(jq -r '.modelId // .diff.current.modelId // "unknown"' ai-eval-report.json)
+          {
+            echo "The monthly provider-drift cron (spec 69 §9.1 tier 3 / §9.4) measured a strict hit-rate drop of **${DELTA_PP}pp** vs the committed canonical baseline — beyond the 5pp threshold."
+            echo
+            echo "- Scenario: \`${SCENARIO}\`"
+            echo "- Model: \`${MODEL}\`"
+            echo "- Workflow run: ${RUN_URL}"
+            echo "- Report artifact: \`ai-eval-live-report-${{ github.run_id }}\`"
+            echo
+            echo "Per spec 69 §9.4 this is **non-blocking**. Investigate provider/model drift; if the new behavior is accepted, refresh the canonical baseline locally (\`AI_EVAL_LIVE=1 bun run ai:eval --scenario ${SCENARIO} --refresh-baseline\`) and commit it."
+          } > "${RUNNER_TEMP}/drift-issue-body.md"
+          gh issue create \
+            --title "$TITLE" \
+            --label "ai" \
+            --label "P1: High" \
+            --body-file "${RUNNER_TEMP}/drift-issue-body.md"
+          echo "Filed drift issue: $TITLE"

--- a/.github/workflows/ai-eval.yml
+++ b/.github/workflows/ai-eval.yml
@@ -229,7 +229,11 @@ jobs:
           MONTH=$(date -u +%Y-%m)
           TITLE="AI eval drift detected ${MONTH}"
           # Dedupe: a re-run inside the same month must not file a duplicate.
-          EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" \
+          # Use the Issues LIST API (strongly consistent) filtered by the `ai`
+          # label, not `--search` (Search API has seconds-to-minutes indexing
+          # latency, so a quick re-run would miss the just-filed issue and
+          # double-file). Exact-title match happens in jq.
+          EXISTING=$(gh issue list --state open --label "ai" \
             --json title --jq "[.[] | select(.title == \"$TITLE\")] | length")
           if [ "$EXISTING" != "0" ]; then
             echo "Open issue \"$TITLE\" already exists — not filing a duplicate."

--- a/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-conformance.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-conformance.test.ts
@@ -1,0 +1,144 @@
+/**
+ * AITraceSink conformance — in-memory run + non-throwing discipline.
+ *
+ * Always-on (no database required):
+ *  1. Runs the shared conformance suite against `InMemoryAITraceStore`, so CI
+ *     without PostgreSQL still exercises every contract assertion (the same
+ *     assertions run against the PG store in
+ *     `ai-trace-store-drizzle.integration.test.ts`).
+ *  2. Proves `DrizzleAITraceStore`'s non-throwing discipline with a database
+ *     stub that always fails: sink methods on the AI call path must swallow +
+ *     log mirror failures, keep the serialized write tail alive, and keep
+ *     serving the in-memory hot view.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { Logger } from "@linchkit/core";
+import { InMemoryAITraceStore } from "@linchkit/core/server";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { DrizzleAITraceStore } from "../src/ai-trace-store-drizzle";
+import {
+  type AITraceSinkHarness,
+  registerAITraceSinkConformance,
+} from "./helpers/ai-trace-sink-conformance";
+
+// ── 1. Conformance against the in-memory reference ──────────
+
+describe("InMemoryAITraceStore (sink conformance)", () => {
+  const sink = new InMemoryAITraceStore();
+  const harness: AITraceSinkHarness = {
+    sink,
+    flush: async () => {},
+    queryGenerations: async (options) => sink.query(options),
+    queryTraces: async (options) => sink.queryTraces(options),
+    reset: async () => {
+      sink.clear();
+    },
+  };
+  registerAITraceSinkConformance(() => harness);
+});
+
+// ── 2. Non-throwing discipline with a broken database ───────
+
+function createCapturingLogger(): Logger & { warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    warnings,
+    debug() {},
+    info() {},
+    warn(message: string) {
+      warnings.push(message);
+    },
+    error() {},
+  };
+}
+
+/** A "database" whose every entry point throws synchronously. */
+function createThrowingDb(): PostgresJsDatabase {
+  const boom = () => {
+    throw new Error("pg unreachable");
+  };
+  return {
+    insert: boom,
+    update: boom,
+    delete: boom,
+    select: boom,
+    execute: boom,
+  } as unknown as PostgresJsDatabase;
+}
+
+describe("DrizzleAITraceStore (non-throwing discipline, no DB needed)", () => {
+  let logger: ReturnType<typeof createCapturingLogger>;
+  let store: DrizzleAITraceStore;
+
+  beforeEach(() => {
+    logger = createCapturingLogger();
+    store = new DrizzleAITraceStore({ db: createThrowingDb(), logger });
+  });
+
+  it("never throws into the AI call path when every mirror write fails", async () => {
+    // None of the synchronous sink methods may throw.
+    const traceId = store.startTrace({ name: "intent", tenantId: "t1" });
+    const generation = store.recordGeneration({
+      traceId,
+      model: "m1",
+      provider: "p1",
+      messages: [{ role: "user", content: "top secret prompt" }],
+      completion: "top secret completion",
+      inputTokens: 5,
+      outputTokens: 6,
+      latencyMs: 10,
+      status: "ok",
+      startedAt: 1_000,
+      endedAt: 1_010,
+      redaction: { mode: "mask" },
+    });
+    store.endTrace({ traceId });
+    store.clear();
+
+    // recordGeneration still returned the (redacted) record synchronously.
+    expect(generation.traceId).toBe(traceId);
+    expect(generation.completion).not.toContain("secret");
+    expect(generation.messages[0]?.content).not.toContain("secret");
+
+    // The write tail settles (never rejects) and each failed stage logged once.
+    await store.whenPersisted();
+    expect(logger.warnings.length).toBe(4); // startTrace, recordGeneration, endTrace, clear
+    expect(logger.warnings[0]).toContain("[ai-trace-store] startTrace");
+    expect(logger.warnings[0]).toContain("pg unreachable");
+  });
+
+  it("keeps the write tail alive across failures and keeps serving the hot view", async () => {
+    const traceId = store.startTrace({ name: "intent", tenantId: "t1" });
+    await store.whenPersisted(); // first mirror write already failed
+    expect(logger.warnings.length).toBe(1);
+
+    // A later write is still attempted (tail not stuck on the earlier failure)
+    // and the synchronous hot view serves reads regardless of PG health.
+    store.recordGeneration({
+      traceId,
+      model: "m1",
+      provider: "p1",
+      messages: [{ role: "user", content: "hi" }],
+      completion: "ok",
+      inputTokens: 1,
+      outputTokens: 1,
+      latencyMs: 5,
+      status: "ok",
+      startedAt: 2_000,
+      endedAt: 2_005,
+      redaction: { mode: "none" },
+    });
+    await store.whenPersisted();
+    expect(logger.warnings.length).toBe(2);
+    expect(store.size).toBe(1);
+    expect(store.query({ tenantId: "t1" })).toHaveLength(1);
+    expect(store.queryTraces({ traceId })).toHaveLength(1);
+  });
+
+  it("purgeOlderThan validates days before touching the database", async () => {
+    await expect(store.purgeOlderThan(0)).rejects.toThrow(RangeError);
+    await expect(store.purgeOlderThan(-5)).rejects.toThrow(RangeError);
+    await expect(store.purgeOlderThan(Number.NaN)).rejects.toThrow(RangeError);
+  });
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-drizzle.integration.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-drizzle.integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * DrizzleAITraceStore integration tests against a real PostgreSQL database.
+ *
+ * The always-on suite in `ai-trace-store-conformance.test.ts` proves the
+ * contract against the in-memory reference + the non-throwing discipline.
+ * This suite drives the REAL Drizzle-backed store against real
+ * `_linchkit.ai_traces` / `_linchkit.ai_generations` tables to prove:
+ *   - the shared conformance suite holds when reads go through the SQL
+ *     translation (`queryPersisted` / `queryTracesPersisted`),
+ *   - mirror writes survive a process "restart" (a fresh store instance on
+ *     the same DB sees everything; its hot view starts empty),
+ *   - aggregate rollups are durable SQL increments (a restarted instance
+ *     keeps incrementing the same trace row),
+ *   - `purgeOlderThan` retention deletes old generations + orphaned traces.
+ *
+ * Requires a running PostgreSQL instance. Set DATABASE_TEST_URL to connect.
+ * Default: postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test
+ * Skips gracefully when no database is available (CI without PG won't fail);
+ * CI provides the `postgres` service so this suite RUNS there.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { closeDatabase, createDatabase } from "@linchkit/core/server";
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { DrizzleAITraceStore } from "../src/ai-trace-store-drizzle";
+import {
+  type AITraceSinkHarness,
+  registerAITraceSinkConformance,
+} from "./helpers/ai-trace-sink-conformance";
+
+// ── Test configuration ───────────────────────────────────────
+
+const DATABASE_URL =
+  process.env.DATABASE_TEST_URL ??
+  "postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test";
+
+const TRACES = `"_linchkit"."ai_traces"`;
+const GENERATIONS = `"_linchkit"."ai_generations"`;
+
+// ── Connection check ─────────────────────────────────────────
+
+async function canConnect(): Promise<boolean> {
+  try {
+    const testDb = createDatabase({ url: DATABASE_URL });
+    await testDb.execute(sql`SELECT 1`);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    // Always release the probe pool so a failed probe never leaks connections.
+    await closeDatabase();
+  }
+}
+
+const dbAvailable = await canConnect();
+
+if (!dbAvailable) {
+  console.warn("PostgreSQL not available, skipping DrizzleAITraceStore integration tests");
+}
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+let db: PostgresJsDatabase | null = null;
+let store: DrizzleAITraceStore;
+
+/**
+ * Narrow `db` to non-null. Assigned in beforeAll; the suite is skipped when no
+ * DB is available, so this never throws in practice. A clear error beats the
+ * repo-banned `db!` non-null assertion (biome `noNonNullAssertion`).
+ */
+function requireDb(): PostgresJsDatabase {
+  if (!db) throw new Error("db not initialized — beforeAll did not run");
+  return db;
+}
+
+// ── Test suite ───────────────────────────────────────────────
+
+describe.skipIf(!dbAvailable)("DrizzleAITraceStore (integration)", () => {
+  beforeAll(async () => {
+    db = createDatabase({ url: DATABASE_URL });
+
+    // The `_linchkit` schema already hosts framework system tables, but create
+    // it defensively so the suite is self-contained.
+    await db.execute(sql.raw(`CREATE SCHEMA IF NOT EXISTS "_linchkit"`));
+
+    // Drop any leftover tables, then recreate them as a test fixture. This is
+    // NOT production DDL (production DDL is delegated to drizzle-kit); it
+    // mirrors the column shape + indexes declared in src/ai-trace-tables.ts so
+    // the real DrizzleAITraceStore runs against an authentic schema.
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS ${GENERATIONS} CASCADE`));
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS ${TRACES} CASCADE`));
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE ${TRACES} (
+        "trace_id" text PRIMARY KEY NOT NULL,
+        "seq" bigserial NOT NULL,
+        "name" text NOT NULL,
+        "tenant_id" text,
+        "actor_id" text,
+        "scenario" text,
+        "fixture_id" text,
+        "eval_run_id" text,
+        "origin" text NOT NULL,
+        "tags" jsonb,
+        "metadata" jsonb,
+        "started_at" timestamp NOT NULL,
+        "ended_at" timestamp,
+        "input_tokens" integer DEFAULT 0 NOT NULL,
+        "output_tokens" integer DEFAULT 0 NOT NULL,
+        "cost" double precision DEFAULT 0 NOT NULL,
+        "sampled" boolean DEFAULT true NOT NULL,
+        "status" text DEFAULT 'ok' NOT NULL
+      )
+    `),
+    );
+    await db.execute(
+      sql.raw(
+        `CREATE INDEX "idx_ai_traces_tenant_started" ON ${TRACES} ("tenant_id","started_at")`,
+      ),
+    );
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE ${GENERATIONS} (
+        "id" text PRIMARY KEY NOT NULL,
+        "seq" bigserial NOT NULL,
+        "trace_id" text NOT NULL,
+        "model" text NOT NULL,
+        "provider" text NOT NULL,
+        "messages" jsonb NOT NULL,
+        "completion" text NOT NULL,
+        "input_tokens" integer NOT NULL,
+        "output_tokens" integer NOT NULL,
+        "cost" double precision,
+        "latency_ms" double precision NOT NULL,
+        "temperature" double precision,
+        "response_format" text,
+        "fallback_used" text,
+        "cached" boolean,
+        "partial" boolean,
+        "status" text NOT NULL,
+        "error" text,
+        "started_at" timestamp NOT NULL,
+        "ended_at" timestamp NOT NULL
+      )
+    `),
+    );
+    await db.execute(
+      sql.raw(`CREATE INDEX "idx_ai_generations_trace_id" ON ${GENERATIONS} ("trace_id")`),
+    );
+    await db.execute(
+      sql.raw(`CREATE INDEX "idx_ai_generations_started_at" ON ${GENERATIONS} ("started_at")`),
+    );
+
+    store = new DrizzleAITraceStore({ db });
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS ${GENERATIONS} CASCADE`));
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS ${TRACES} CASCADE`));
+      await closeDatabase();
+    }
+  });
+
+  // ── 1. Shared conformance suite, read through SQL ──────────
+
+  describe("sink conformance via queryPersisted", () => {
+    const harness: AITraceSinkHarness = {
+      get sink() {
+        return store;
+      },
+      flush: () => store.whenPersisted(),
+      queryGenerations: (options) => store.queryPersisted(options),
+      queryTraces: (options) => store.queryTracesPersisted(options),
+      reset: async () => {
+        // clear() wipes the hot view and enqueues the mirror wipe; drain it.
+        store.clear();
+        await store.whenPersisted();
+      },
+    };
+    registerAITraceSinkConformance(() => harness);
+  });
+
+  // ── 2. Restart durability ──────────────────────────────────
+
+  describe("durability across instances", () => {
+    it("a fresh store on the same DB sees persisted data; its hot view starts empty", async () => {
+      store.clear();
+      await store.whenPersisted();
+
+      const traceId = store.startTrace({ name: "intent", tenantId: "t1", startedAt: 1_000 });
+      store.recordGeneration({
+        traceId,
+        model: "m1",
+        provider: "p1",
+        messages: [{ role: "user", content: "hello" }],
+        completion: "done",
+        inputTokens: 10,
+        outputTokens: 5,
+        cost: 0.01,
+        latencyMs: 100,
+        status: "ok",
+        startedAt: 1_100,
+        endedAt: 1_200,
+        redaction: { mode: "none" },
+      });
+      await store.whenPersisted();
+
+      // Simulated restart: new store instance, same database.
+      const restarted = new DrizzleAITraceStore({ db: requireDb() });
+      expect(restarted.size).toBe(0);
+      expect(restarted.query()).toEqual([]); // hot view is process-local
+      const persisted = await restarted.queryPersisted({ tenantId: "t1" });
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0]?.completion).toBe("done");
+      const traces = await restarted.queryTracesPersisted({ traceId });
+      expect(traces[0]?.inputTokens).toBe(10);
+
+      // Durable SQL increments: the restarted instance keeps rolling up the
+      // SAME trace row even though its hot view auto-opens a fresh copy.
+      restarted.recordGeneration({
+        traceId,
+        model: "m1",
+        provider: "p1",
+        messages: [{ role: "user", content: "again" }],
+        completion: "done again",
+        inputTokens: 7,
+        outputTokens: 3,
+        cost: 0.02,
+        latencyMs: 80,
+        status: "error",
+        error: "boom",
+        startedAt: 1_300,
+        endedAt: 1_400,
+        redaction: { mode: "none" },
+      });
+      await restarted.whenPersisted();
+
+      const [rolled] = await restarted.queryTracesPersisted({ traceId });
+      expect(rolled?.inputTokens).toBe(17);
+      expect(rolled?.outputTokens).toBe(8);
+      expect(rolled?.cost ?? 0).toBeCloseTo(0.03, 10);
+      expect(rolled?.status).toBe("error");
+      // The original trace metadata survives (auto-open insert was a no-op).
+      expect(rolled?.name).toBe("intent");
+      expect(rolled?.tenantId).toBe("t1");
+      expect(await restarted.queryPersisted({ traceId })).toHaveLength(2);
+    });
+  });
+
+  // ── 3. Retention ───────────────────────────────────────────
+
+  describe("purgeOlderThan", () => {
+    it("deletes old generations and orphaned old traces, keeps referenced ones", async () => {
+      store.clear();
+      await store.whenPersisted();
+
+      const now = Date.now();
+      const oldTime = now - 100 * 86_400_000; // 100 days ago
+      const recentTime = now - 1 * 86_400_000; // yesterday
+
+      const mkGen = (traceId: string, startedAt: number) => ({
+        traceId,
+        model: "m1",
+        provider: "p1",
+        messages: [{ role: "user" as const, content: "x" }],
+        completion: "y",
+        inputTokens: 1,
+        outputTokens: 1,
+        latencyMs: 10,
+        status: "ok" as const,
+        startedAt,
+        endedAt: startedAt + 10,
+        redaction: { mode: "none" } as const,
+      });
+
+      // Old trace whose only generation is old → both purged.
+      store.startTrace({ traceId: "trace-old", name: "old", startedAt: oldTime });
+      store.recordGeneration(mkGen("trace-old", oldTime + 1_000));
+      // Old trace that ALSO has a recent generation → old gen purged, trace kept.
+      store.startTrace({ traceId: "trace-mixed", name: "mixed", startedAt: oldTime });
+      store.recordGeneration(mkGen("trace-mixed", oldTime + 2_000));
+      store.recordGeneration(mkGen("trace-mixed", recentTime));
+      // Fully recent trace → untouched.
+      store.startTrace({ traceId: "trace-new", name: "new", startedAt: recentTime });
+      store.recordGeneration(mkGen("trace-new", recentTime + 1_000));
+      await store.whenPersisted();
+
+      const purged = await store.purgeOlderThan(90);
+      expect(purged).toEqual({ generations: 2, traces: 1 });
+
+      const traceIds = (await store.queryTracesPersisted()).map((t) => t.traceId);
+      expect(traceIds.sort()).toEqual(["trace-mixed", "trace-new"]);
+      const gens = await store.queryPersisted();
+      expect(gens).toHaveLength(2);
+      expect(gens.every((g) => g.startedAt >= recentTime)).toBe(true);
+
+      // Default window (90 days) keeps everything that's left.
+      const second = await store.purgeOlderThan();
+      expect(second).toEqual({ generations: 0, traces: 0 });
+    });
+  });
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-drizzle.integration.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-drizzle.integration.test.ts
@@ -49,7 +49,14 @@ async function canConnect(): Promise<boolean> {
     return false;
   } finally {
     // Always release the probe pool so a failed probe never leaks connections.
-    await closeDatabase();
+    // Guard the close itself: a throw here would discard the catch's
+    // `return false` and reject `canConnect()`, crashing the whole module at
+    // the top-level `await` instead of letting `skipIf` skip gracefully.
+    try {
+      await closeDatabase();
+    } catch {
+      // Ignore — the probe connection may already be closed or never opened.
+    }
   }
 }
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-drizzle.integration.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/ai-trace-store-drizzle.integration.test.ts
@@ -300,5 +300,194 @@ describe.skipIf(!dbAvailable)("DrizzleAITraceStore (integration)", () => {
       const second = await store.purgeOlderThan();
       expect(second).toEqual({ generations: 0, traces: 0 });
     });
+
+    it("purge leaves generations and traces mutually consistent (no orphans / dangling refs)", async () => {
+      store.clear();
+      await store.whenPersisted();
+
+      const now = Date.now();
+      const oldTime = now - 100 * 86_400_000;
+      const recentTime = now - 1 * 86_400_000;
+
+      const mkGen = (traceId: string, startedAt: number) => ({
+        traceId,
+        model: "m1",
+        provider: "p1",
+        messages: [{ role: "user" as const, content: "x" }],
+        completion: "y",
+        inputTokens: 1,
+        outputTokens: 1,
+        latencyMs: 10,
+        status: "ok" as const,
+        startedAt,
+        endedAt: startedAt + 10,
+        redaction: { mode: "none" } as const,
+      });
+
+      store.startTrace({ traceId: "c-old", name: "old", startedAt: oldTime });
+      store.recordGeneration(mkGen("c-old", oldTime + 1_000));
+      store.startTrace({ traceId: "c-mixed", name: "mixed", startedAt: oldTime });
+      store.recordGeneration(mkGen("c-mixed", oldTime + 2_000));
+      store.recordGeneration(mkGen("c-mixed", recentTime));
+      store.startTrace({ traceId: "c-new", name: "new", startedAt: recentTime });
+      store.recordGeneration(mkGen("c-new", recentTime + 1_000));
+      await store.whenPersisted();
+
+      await store.purgeOlderThan(90);
+
+      // Atomicity invariant: the two deletes committed together. Every surviving
+      // generation still has a surviving parent trace, and no surviving trace
+      // that predates the cutoff was left orphaned (it must still be referenced
+      // by a surviving generation). A partial purge would violate one of these.
+      const traces = await store.queryTracesPersisted();
+      const gens = await store.queryPersisted();
+      const traceIds = new Set(traces.map((t) => t.traceId));
+      // No dangling generation → parent.
+      for (const g of gens) {
+        expect(traceIds.has(g.traceId)).toBe(true);
+      }
+      // No orphaned pre-cutoff trace (every kept trace is still referenced).
+      const referenced = new Set(gens.map((g) => g.traceId));
+      const cutoff = now - 90 * 86_400_000;
+      for (const t of traces) {
+        if (t.startedAt < cutoff) {
+          expect(referenced.has(t.traceId)).toBe(true);
+        }
+      }
+    });
+  });
+
+  // ── 4. recordGeneration atomicity / rollup consistency ─────
+
+  describe("recordGeneration atomicity", () => {
+    it("rolls up aggregates consistently: per-trace sum of generation tokens equals the trace aggregate", async () => {
+      store.clear();
+      await store.whenPersisted();
+
+      const base = Date.now() - 10 * 86_400_000;
+      // Several traces, each with a few generations of varying token counts.
+      // If any recordGeneration transaction had partially applied (generation
+      // inserted but rollup skipped), the per-trace SUM(generation tokens)
+      // would diverge from the trace's rolled-up aggregate.
+      const plan: Array<[string, number, number, number]> = [
+        ["agg-a", 0, 10, 5],
+        ["agg-a", 1, 7, 3],
+        ["agg-a", 2, 4, 9],
+        ["agg-b", 0, 100, 50],
+        ["agg-b", 1, 1, 1],
+        ["agg-c", 0, 42, 8],
+      ];
+      for (const [traceId, idx, inTok, outTok] of plan) {
+        store.recordGeneration({
+          traceId,
+          model: "m1",
+          provider: "p1",
+          messages: [{ role: "user", content: "x" }],
+          completion: "y",
+          inputTokens: inTok,
+          outputTokens: outTok,
+          cost: 0.001 * (idx + 1),
+          latencyMs: 10,
+          status: "ok",
+          startedAt: base + idx,
+          endedAt: base + idx + 5,
+          redaction: { mode: "none" },
+        });
+      }
+      await store.whenPersisted();
+
+      // Compare the durable trace aggregate against the SUM of its generation
+      // rows for every trace. Equality across ALL traces is the all-or-nothing
+      // invariant the transaction guarantees.
+      const traces = await store.queryTracesPersisted();
+      const gens = await store.queryPersisted();
+      const sums = new Map<string, { input: number; output: number }>();
+      for (const g of gens) {
+        const acc = sums.get(g.traceId) ?? { input: 0, output: 0 };
+        acc.input += g.inputTokens;
+        acc.output += g.outputTokens;
+        sums.set(g.traceId, acc);
+      }
+      expect(traces.length).toBe(3);
+      for (const t of traces) {
+        const acc = sums.get(t.traceId) ?? { input: 0, output: 0 };
+        expect(t.inputTokens).toBe(acc.input);
+        expect(t.outputTokens).toBe(acc.output);
+      }
+    });
+
+    it("a failing rollup statement rolls back the whole transaction (no generation row persisted)", async () => {
+      store.clear();
+      await store.whenPersisted();
+
+      // Inject a failure into the rollup (the third statement) by spying the
+      // db.transaction so the tx's `update` throws AFTER the generation insert.
+      // The transaction must roll back: neither the generation row nor the
+      // aggregate change survives. This proves the all-or-nothing guarantee
+      // for the subtle parent-insert + generation-insert + rollup sequence.
+      const liveDb = requireDb();
+      const realTransaction = liveDb.transaction.bind(liveDb);
+      let injected = false;
+      const spied = new DrizzleAITraceStore({
+        db: new Proxy(liveDb, {
+          get(target, prop, receiver) {
+            if (prop === "transaction") {
+              return (
+                cb: (tx: unknown) => Promise<unknown>,
+                ...rest: unknown[]
+              ): Promise<unknown> =>
+                realTransaction(
+                  (tx: unknown) =>
+                    cb(
+                      new Proxy(tx as object, {
+                        get(txTarget, txProp, txReceiver) {
+                          if (txProp === "update" && !injected) {
+                            injected = true;
+                            return () => {
+                              throw new Error("injected rollup failure");
+                            };
+                          }
+                          return Reflect.get(txTarget, txProp, txReceiver);
+                        },
+                      }),
+                    ),
+                  ...(rest as []),
+                );
+            }
+            return Reflect.get(target, prop, receiver);
+          },
+        }) as unknown as PostgresJsDatabase,
+      });
+
+      spied.startTrace({ traceId: "rollback-t", name: "rb", startedAt: Date.now() });
+      await spied.whenPersisted();
+
+      spied.recordGeneration({
+        traceId: "rollback-t",
+        model: "m1",
+        provider: "p1",
+        messages: [{ role: "user", content: "x" }],
+        completion: "y",
+        inputTokens: 99,
+        outputTokens: 7,
+        cost: 0.5,
+        latencyMs: 10,
+        status: "ok",
+        startedAt: Date.now(),
+        endedAt: Date.now() + 5,
+        redaction: { mode: "none" },
+      });
+      // The enqueue `.catch()` swallows the thrown transaction; never rejects.
+      await spied.whenPersisted();
+
+      expect(injected).toBe(true);
+      // No generation row landed — the transaction rolled back atomically.
+      const gens = await store.queryPersisted({ traceId: "rollback-t" });
+      expect(gens).toHaveLength(0);
+      // The parent trace's aggregate was NOT incremented (rollup never committed).
+      const [trace] = await store.queryTracesPersisted({ traceId: "rollback-t" });
+      expect(trace?.inputTokens).toBe(0);
+      expect(trace?.outputTokens).toBe(0);
+    });
   });
 });

--- a/addons/ai-provider/cap-ai-provider/__tests__/helpers/ai-trace-sink-conformance.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/helpers/ai-trace-sink-conformance.ts
@@ -1,0 +1,384 @@
+/**
+ * Shared AITraceSink conformance suite (Spec 69 Phase 3, issue #350).
+ *
+ * One set of assertions, run against BOTH sink implementations so the
+ * Drizzle/PG store provably matches `InMemoryAITraceStore`'s query semantics:
+ *  - `ai-trace-store-conformance.test.ts` runs it against the in-memory store
+ *    (always-on — CI without PostgreSQL still exercises the full contract);
+ *  - `ai-trace-store-drizzle.integration.test.ts` runs it against the real
+ *    PG-backed store (DB-gated), reading through `queryPersisted` /
+ *    `queryTracesPersisted` so the SQL filter translation is what's tested.
+ *
+ * NOT a test file itself (no `.test.ts` suffix) — it only registers `it`
+ * blocks into the caller's `describe`.
+ */
+
+import { beforeEach, expect, it } from "bun:test";
+import type {
+  AIGeneration,
+  AITrace,
+  AITraceQueryOptions,
+  AITraceSink,
+  RecordGenerationParams,
+} from "@linchkit/core/server";
+import { redactContent } from "@linchkit/core/server";
+
+/** Implementation-agnostic view of a sink under conformance test. */
+export interface AITraceSinkHarness {
+  sink: AITraceSink;
+  /** Drain any async mirror so reads observe all prior writes. */
+  flush(): Promise<void>;
+  /** The implementation's authoritative generation query. */
+  queryGenerations(options?: AITraceQueryOptions): Promise<AIGeneration[]>;
+  /** The implementation's authoritative trace query. */
+  queryTraces(options?: AITraceQueryOptions): Promise<AITrace[]>;
+  /** Remove all stored data (runs before every case). */
+  reset(): Promise<void>;
+}
+
+/** Fixed time base so strict `after`/`before` bounds are deterministic. */
+export const CONFORMANCE_BASE_MS = Date.UTC(2026, 0, 1);
+
+const NO_REDACTION = { mode: "none" } as const;
+
+function gen(overrides: Partial<RecordGenerationParams>): RecordGenerationParams {
+  return {
+    traceId: "trace-a",
+    model: "m1",
+    provider: "p1",
+    messages: [{ role: "user", content: "hello world" }],
+    completion: "a completion",
+    inputTokens: 1,
+    outputTokens: 1,
+    latencyMs: 50,
+    status: "ok",
+    startedAt: CONFORMANCE_BASE_MS,
+    endedAt: CONFORMANCE_BASE_MS + 10,
+    redaction: NO_REDACTION,
+    ...overrides,
+  };
+}
+
+/**
+ * Seed the standard dataset: two explicit traces (a: tenant t1 / eval /
+ * scenario intent; b: tenant t2 / production) plus an auto-opened trace c
+ * (recordGeneration without startTrace, tenant t3). Generation insertion
+ * order: g1(a), g2(a, error), g3(b), g4(c) — so most-recent-first is
+ * [g4, g3, g2, g1].
+ */
+async function seed(h: AITraceSinkHarness): Promise<void> {
+  const B = CONFORMANCE_BASE_MS;
+  h.sink.startTrace({
+    traceId: "trace-a",
+    name: "intent",
+    tenantId: "t1",
+    actorId: "actor-1",
+    scenario: "intent",
+    fixtureId: "fx-1",
+    evalRunId: "run-1",
+    origin: "eval",
+    tags: ["nightly", "smoke"],
+    metadata: { suite: "conformance" },
+    startedAt: B + 1_000,
+  });
+  h.sink.startTrace({
+    traceId: "trace-b",
+    name: "chat",
+    tenantId: "t2",
+    origin: "production",
+    startedAt: B + 2_000,
+  });
+  h.sink.recordGeneration(
+    gen({
+      traceId: "trace-a",
+      model: "m1",
+      provider: "p1",
+      completion: "first completion",
+      inputTokens: 10,
+      outputTokens: 5,
+      cost: 0.01,
+      latencyMs: 100.5,
+      temperature: 0.2,
+      responseFormat: "json",
+      startedAt: B + 1_100,
+      endedAt: B + 1_200,
+    }),
+  );
+  h.sink.recordGeneration(
+    gen({
+      traceId: "trace-a",
+      model: "m2",
+      provider: "p1",
+      completion: "second completion",
+      inputTokens: 20,
+      outputTokens: 7,
+      cost: 0.02,
+      latencyMs: 150,
+      status: "error",
+      error: "boom (already redacted)",
+      fallbackUsed: "p0",
+      startedAt: B + 1_300,
+      endedAt: B + 1_400,
+    }),
+  );
+  h.sink.recordGeneration(
+    gen({
+      traceId: "trace-b",
+      model: "m1",
+      provider: "p2",
+      completion: "third completion",
+      inputTokens: 1,
+      outputTokens: 2,
+      latencyMs: 50,
+      cached: true,
+      startedAt: B + 2_100,
+      endedAt: B + 2_200,
+    }),
+  );
+  h.sink.recordGeneration(
+    gen({
+      traceId: "trace-c",
+      model: "m3",
+      provider: "p3",
+      completion: "fourth completion",
+      inputTokens: 3,
+      outputTokens: 4,
+      latencyMs: 60,
+      partial: true,
+      tenantId: "t3",
+      startedAt: B + 3_100,
+      endedAt: B + 3_200,
+    }),
+  );
+  await h.flush();
+}
+
+/** Register the conformance cases inside the caller's `describe` block. */
+export function registerAITraceSinkConformance(getHarness: () => AITraceSinkHarness): void {
+  const B = CONFORMANCE_BASE_MS;
+
+  beforeEach(async () => {
+    await getHarness().reset();
+  });
+
+  it("returns generations most-recent-first with full field round-trip", async () => {
+    const h = getHarness();
+    await seed(h);
+    const all = await h.queryGenerations();
+    expect(all.map((g) => g.completion)).toEqual([
+      "fourth completion",
+      "third completion",
+      "second completion",
+      "first completion",
+    ]);
+
+    const first = all[3];
+    expect(first?.traceId).toBe("trace-a");
+    expect(first?.model).toBe("m1");
+    expect(first?.provider).toBe("p1");
+    expect(first?.messages).toEqual([{ role: "user", content: "hello world" }]);
+    expect(first?.inputTokens).toBe(10);
+    expect(first?.outputTokens).toBe(5);
+    expect(first?.cost).toBe(0.01);
+    expect(first?.latencyMs).toBe(100.5);
+    expect(first?.temperature).toBe(0.2);
+    expect(first?.responseFormat).toBe("json");
+    expect(first?.status).toBe("ok");
+    expect(first?.startedAt).toBe(B + 1_100);
+    expect(first?.endedAt).toBe(B + 1_200);
+    expect(first?.error).toBeUndefined();
+    expect(first?.cached).toBeUndefined();
+    expect(first?.partial).toBeUndefined();
+    expect(first?.fallbackUsed).toBeUndefined();
+
+    const errored = all[2];
+    expect(errored?.status).toBe("error");
+    expect(errored?.error).toBe("boom (already redacted)");
+    expect(errored?.fallbackUsed).toBe("p0");
+
+    expect(all[0]?.partial).toBe(true);
+    expect(all[1]?.cached).toBe(true);
+  });
+
+  it("applies limit semantics: 0 ⇒ empty, positive caps, negative ⇒ uncapped", async () => {
+    const h = getHarness();
+    await seed(h);
+    expect(await h.queryGenerations({ limit: 0 })).toEqual([]);
+    expect((await h.queryGenerations({ limit: 2 })).map((g) => g.completion)).toEqual([
+      "fourth completion",
+      "third completion",
+    ]);
+    expect(await h.queryGenerations({ limit: -1 })).toHaveLength(4);
+    expect(await h.queryTraces({ limit: 0 })).toEqual([]);
+    expect((await h.queryTraces({ limit: 2 })).map((t) => t.traceId)).toEqual([
+      "trace-c",
+      "trace-b",
+    ]);
+    expect(await h.queryTraces({ limit: -1 })).toHaveLength(3);
+  });
+
+  it("filters generations by traceId / model / status", async () => {
+    const h = getHarness();
+    await seed(h);
+    expect((await h.queryGenerations({ traceId: "trace-a" })).map((g) => g.model)).toEqual([
+      "m2",
+      "m1",
+    ]);
+    expect((await h.queryGenerations({ model: "m1" })).map((g) => g.completion)).toEqual([
+      "third completion",
+      "first completion",
+    ]);
+    const errored = await h.queryGenerations({ status: "error" });
+    expect(errored).toHaveLength(1);
+    expect(errored[0]?.model).toBe("m2");
+  });
+
+  it("applies STRICT after/before bounds on startedAt", async () => {
+    const h = getHarness();
+    await seed(h);
+    // `after` is exclusive: a generation starting exactly at the bound is out.
+    expect(await h.queryGenerations({ after: B + 1_100 })).toHaveLength(3);
+    expect(await h.queryGenerations({ after: B + 1_099 })).toHaveLength(4);
+    // `before` is exclusive too.
+    expect(await h.queryGenerations({ before: B + 3_100 })).toHaveLength(3);
+    expect(await h.queryGenerations({ before: B + 3_101 })).toHaveLength(4);
+    expect(
+      (await h.queryGenerations({ after: B + 1_100, before: B + 2_100 })).map((g) => g.model),
+    ).toEqual(["m2"]);
+  });
+
+  it("resolves tenant / scenario / origin filters via the parent trace", async () => {
+    const h = getHarness();
+    await seed(h);
+    expect((await h.queryGenerations({ tenantId: "t1" })).map((g) => g.model)).toEqual([
+      "m2",
+      "m1",
+    ]);
+    // Auto-opened trace c was stamped with the generation's tenantId.
+    expect((await h.queryGenerations({ tenantId: "t3" })).map((g) => g.model)).toEqual(["m3"]);
+    expect(await h.queryGenerations({ tenantId: "nobody" })).toEqual([]);
+    expect((await h.queryGenerations({ scenario: "intent" })).map((g) => g.model)).toEqual([
+      "m2",
+      "m1",
+    ]);
+    // trace-b is production; auto-opened trace-c defaults to production.
+    expect((await h.queryGenerations({ origin: "production" })).map((g) => g.model)).toEqual([
+      "m3",
+      "m1",
+    ]);
+    expect((await h.queryGenerations({ origin: "eval" })).map((g) => g.model)).toEqual([
+      "m2",
+      "m1",
+    ]);
+  });
+
+  it("queries traces most-recent-first with filters and metadata round-trip", async () => {
+    const h = getHarness();
+    await seed(h);
+    const all = await h.queryTraces();
+    expect(all.map((t) => t.traceId)).toEqual(["trace-c", "trace-b", "trace-a"]);
+
+    const a = all[2];
+    expect(a?.name).toBe("intent");
+    expect(a?.tenantId).toBe("t1");
+    expect(a?.actorId).toBe("actor-1");
+    expect(a?.scenario).toBe("intent");
+    expect(a?.fixtureId).toBe("fx-1");
+    expect(a?.evalRunId).toBe("run-1");
+    expect(a?.origin).toBe("eval");
+    expect(a?.tags).toEqual(["nightly", "smoke"]);
+    expect(a?.metadata).toEqual({ suite: "conformance" });
+    expect(a?.startedAt).toBe(B + 1_000);
+    expect(a?.sampled).toBe(true);
+
+    expect((await h.queryTraces({ tenantId: "t2" })).map((t) => t.traceId)).toEqual(["trace-b"]);
+    expect((await h.queryTraces({ scenario: "intent" })).map((t) => t.traceId)).toEqual([
+      "trace-a",
+    ]);
+    expect((await h.queryTraces({ origin: "production" })).map((t) => t.traceId)).toEqual([
+      "trace-c",
+      "trace-b",
+    ]);
+    expect((await h.queryTraces({ traceId: "trace-b" })).map((t) => t.traceId)).toEqual([
+      "trace-b",
+    ]);
+    expect((await h.queryTraces({ after: B + 1_000, before: B + 3_100 })).map((t) => t.traceId))
+      // strict bounds: trace-a (B+1000) excluded, trace-c (auto-open, ~now) excluded
+      .toEqual(["trace-b"]);
+  });
+
+  it("rolls aggregate tokens / cost up to the parent trace and escalates status", async () => {
+    const h = getHarness();
+    await seed(h);
+    const [a] = await h.queryTraces({ traceId: "trace-a" });
+    expect(a?.inputTokens).toBe(30);
+    expect(a?.outputTokens).toBe(12);
+    expect(a?.cost ?? 0).toBeCloseTo(0.03, 10);
+    // g2 was an error — trace status escalates and stays escalated.
+    expect(a?.status).toBe("error");
+
+    const [b] = await h.queryTraces({ traceId: "trace-b" });
+    expect(b?.inputTokens).toBe(1);
+    expect(b?.outputTokens).toBe(2);
+    expect(b?.cost).toBe(0);
+    expect(b?.status).toBe("ok");
+    // Trace-level status filter sees the escalation.
+    expect((await h.queryTraces({ status: "error" })).map((t) => t.traceId)).toEqual(["trace-a"]);
+  });
+
+  it("auto-opens a parent trace named after the model when none was started", async () => {
+    const h = getHarness();
+    await seed(h);
+    const [c] = await h.queryTraces({ traceId: "trace-c" });
+    expect(c?.name).toBe("m3");
+    expect(c?.tenantId).toBe("t3");
+    expect(c?.origin).toBe("production");
+    expect(c?.sampled).toBe(true);
+    expect(c?.inputTokens).toBe(3);
+    expect(c?.outputTokens).toBe(4);
+  });
+
+  it("endTrace stamps endedAt + status; unknown traceId is a no-op", async () => {
+    const h = getHarness();
+    await seed(h);
+    h.sink.endTrace({ traceId: "trace-a", status: "partial", endedAt: B + 9_000 });
+    h.sink.endTrace({ traceId: "trace-b", endedAt: B + 9_500 }); // keep status
+    h.sink.endTrace({ traceId: "trace-nope", status: "error" });
+    await h.flush();
+
+    const [a] = await h.queryTraces({ traceId: "trace-a" });
+    expect(a?.endedAt).toBe(B + 9_000);
+    expect(a?.status).toBe("partial");
+    const [b] = await h.queryTraces({ traceId: "trace-b" });
+    expect(b?.endedAt).toBe(B + 9_500);
+    expect(b?.status).toBe("ok");
+    expect(await h.queryTraces({ traceId: "trace-nope" })).toEqual([]);
+    expect(await h.queryTraces()).toHaveLength(3);
+  });
+
+  it("persists mask-redacted prompt/completion but the error verbatim", async () => {
+    const h = getHarness();
+    const policy = { mode: "mask" } as const;
+    const rawPrompt = "my secret prompt content";
+    const rawCompletion = "very confidential completion";
+    h.sink.recordGeneration(
+      gen({
+        traceId: "trace-r",
+        messages: [{ role: "user", content: rawPrompt }],
+        completion: rawCompletion,
+        status: "error",
+        error: "err-already-redacted-by-caller",
+        redaction: policy,
+      }),
+    );
+    await h.flush();
+
+    const [g] = await h.queryGenerations({ traceId: "trace-r" });
+    expect(g?.messages[0]?.content).toBe(redactContent(rawPrompt, policy));
+    expect(g?.messages[0]?.content).not.toContain("secret");
+    expect(g?.completion).toBe(redactContent(rawCompletion, policy));
+    expect(g?.completion).not.toContain("confidential");
+    // The sink must NOT re-redact the caller-redacted error string.
+    expect(g?.error).toBe("err-already-redacted-by-caller");
+  });
+}

--- a/addons/ai-provider/cap-ai-provider/src/ai-trace-store-drizzle.ts
+++ b/addons/ai-provider/cap-ai-provider/src/ai-trace-store-drizzle.ts
@@ -1,0 +1,436 @@
+/**
+ * DrizzleAITraceStore — PostgreSQL-backed {@link AITraceSink} (Spec 69
+ * Phase 3, issue #350).
+ *
+ * The core `AITraceSink` interface is SYNCHRONOUS (the instrumentation in
+ * `ai-tracing.ts` calls `recordGeneration()` inline on the AI hot path), so
+ * this store follows the same architecture as the watcher debounce-state
+ * persistence (`watcher-state-persistence.ts`): an in-memory hot path plus a
+ * durable PG mirror fed by serialized, fire-and-forget write-through.
+ *
+ *  - Synchronous interface methods (`startTrace` / `endTrace` /
+ *    `recordGeneration` / `query` / `queryTraces` / `size` / `clear`) delegate
+ *    to an embedded {@link InMemoryAITraceStore} — identical semantics,
+ *    redaction and aggregation — and additionally enqueue a PG mirror write.
+ *  - Mirror writes are serialized through a single tail promise so they apply
+ *    in submission order, and every link swallows + logs its own error: a DB
+ *    outage can NEVER throw into (or slow down) a real AI call.
+ *  - Durable reads go through the async {@link queryPersisted} /
+ *    {@link queryTracesPersisted}, which implement the exact filter semantics
+ *    of `InMemoryAITraceStore.query` / `queryTraces` in SQL (strict time
+ *    bounds, trace-level tenant/scenario/origin filters, most-recent-first by
+ *    insertion order, `limit: 0` ⇒ empty / negative limit ⇒ uncapped).
+ *  - {@link purgeOlderThan} implements retention (default 90 days). No
+ *    background timer here — scheduling is a later wave; callers invoke it.
+ *
+ * After a process restart the in-memory hot view starts empty (sync `query`
+ * sees only the current process); historical data is served by the persisted
+ * query methods. All queries are parameterized via Drizzle's query builder.
+ */
+
+import type { Logger } from "@linchkit/core";
+import type {
+  AIGeneration,
+  AITrace,
+  AITraceQueryOptions,
+  AITraceSink,
+  EndTraceParams,
+  RecordGenerationParams,
+  StartTraceParams,
+} from "@linchkit/core/server";
+import { consoleLogger, InMemoryAITraceStore } from "@linchkit/core/server";
+import { and, desc, eq, gt, lt, notExists, type SQL, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { aiGenerationsTable, aiTracesTable } from "./ai-trace-tables";
+
+/** Default retention window for {@link DrizzleAITraceStore.purgeOlderThan}. */
+export const DEFAULT_TRACE_RETENTION_DAYS = 90;
+
+const MS_PER_DAY = 86_400_000;
+
+export interface DrizzleAITraceStoreOptions {
+  db: PostgresJsDatabase;
+  /** Runtime logger for mirror-write failures. Defaults to `consoleLogger`. */
+  logger?: Logger;
+  /** Hot-view capacity — forwarded to the embedded in-memory store. */
+  maxGenerations?: number;
+  /** Hot-view capacity — forwarded to the embedded in-memory store. */
+  maxTraces?: number;
+}
+
+/** Map a `_linchkit.ai_generations` row to the domain {@link AIGeneration}. */
+function rowToGeneration(row: typeof aiGenerationsTable.$inferSelect): AIGeneration {
+  return Object.freeze({
+    id: row.id,
+    traceId: row.traceId,
+    model: row.model,
+    provider: row.provider,
+    messages: Object.freeze(row.messages.map((m) => ({ role: m.role, content: m.content }))),
+    completion: row.completion,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    ...(row.cost !== null ? { cost: row.cost } : {}),
+    latencyMs: row.latencyMs,
+    ...(row.temperature !== null ? { temperature: row.temperature } : {}),
+    ...(row.responseFormat !== null ? { responseFormat: row.responseFormat } : {}),
+    ...(row.fallbackUsed !== null ? { fallbackUsed: row.fallbackUsed } : {}),
+    ...(row.cached !== null ? { cached: row.cached } : {}),
+    ...(row.partial !== null ? { partial: row.partial } : {}),
+    status: row.status,
+    ...(row.error !== null ? { error: row.error } : {}),
+    startedAt: row.startedAt.getTime(),
+    endedAt: row.endedAt.getTime(),
+  });
+}
+
+/** Map a `_linchkit.ai_traces` row to the domain {@link AITrace}. */
+function rowToTrace(row: typeof aiTracesTable.$inferSelect): AITrace {
+  return Object.freeze({
+    traceId: row.traceId,
+    name: row.name,
+    ...(row.tenantId !== null ? { tenantId: row.tenantId } : {}),
+    ...(row.actorId !== null ? { actorId: row.actorId } : {}),
+    ...(row.scenario !== null ? { scenario: row.scenario } : {}),
+    ...(row.fixtureId !== null ? { fixtureId: row.fixtureId } : {}),
+    ...(row.evalRunId !== null ? { evalRunId: row.evalRunId } : {}),
+    origin: row.origin,
+    ...(row.tags !== null ? { tags: Object.freeze([...row.tags]) } : {}),
+    ...(row.metadata !== null ? { metadata: row.metadata } : {}),
+    startedAt: row.startedAt.getTime(),
+    ...(row.endedAt !== null ? { endedAt: row.endedAt.getTime() } : {}),
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cost: row.cost,
+    sampled: row.sampled,
+    status: row.status,
+  });
+}
+
+export class DrizzleAITraceStore implements AITraceSink {
+  private readonly db: PostgresJsDatabase;
+  private readonly logger: Logger;
+  /** Synchronous hot path — identical semantics to the pure in-memory sink. */
+  private readonly memory: InMemoryAITraceStore;
+
+  /**
+   * Tail of the serialized mirror-write chain. Every PG write appends itself
+   * here so writes land in submission order (a trace upsert always precedes
+   * the generation insert that references it). Each link swallows + logs its
+   * own failure so the chain never breaks and never rejects.
+   */
+  private writeTail: Promise<void> = Promise.resolve();
+
+  constructor(options: DrizzleAITraceStoreOptions) {
+    this.db = options.db;
+    this.logger = options.logger ?? consoleLogger;
+    this.memory = new InMemoryAITraceStore({
+      maxGenerations: options.maxGenerations,
+      maxTraces: options.maxTraces,
+    });
+  }
+
+  // ── Synchronous AITraceSink interface ──────────────────
+
+  startTrace(params: StartTraceParams): string {
+    // Resolve defaults ONCE so the memory record and the PG row are identical.
+    const resolved: StartTraceParams = {
+      ...params,
+      traceId: params.traceId ?? crypto.randomUUID(),
+      origin: params.origin ?? "production",
+      startedAt: params.startedAt ?? Date.now(),
+      sampled: params.sampled ?? true,
+    };
+    const traceId = this.memory.startTrace(resolved);
+    this.enqueue("startTrace", async () => {
+      // `onConflictDoNothing` mirrors the in-memory "already open ⇒ keep" rule.
+      await this.db
+        .insert(aiTracesTable)
+        .values(this.traceRow(resolved))
+        .onConflictDoNothing({ target: aiTracesTable.traceId });
+    });
+    return traceId;
+  }
+
+  endTrace(params: EndTraceParams): void {
+    const endedAt = params.endedAt ?? Date.now();
+    this.memory.endTrace({ ...params, endedAt });
+    this.enqueue("endTrace", async () => {
+      // Unknown traceId ⇒ 0 rows updated — same no-op as the in-memory store.
+      await this.db
+        .update(aiTracesTable)
+        .set({
+          endedAt: new Date(endedAt),
+          ...(params.status !== undefined ? { status: params.status } : {}),
+        })
+        .where(eq(aiTracesTable.traceId, params.traceId));
+    });
+  }
+
+  recordGeneration(params: RecordGenerationParams): AIGeneration {
+    // The in-memory store applies redaction + aggregation and auto-opens the
+    // parent trace; persist the returned (already-redacted) record verbatim
+    // so redaction happens exactly once.
+    const generation = this.memory.recordGeneration(params);
+    const parentRow = this.parentTraceRowFor(generation, params);
+    this.enqueue("recordGeneration", async () => {
+      await this.db
+        .insert(aiTracesTable)
+        .values(parentRow)
+        .onConflictDoNothing({ target: aiTracesTable.traceId });
+      await this.db.insert(aiGenerationsTable).values({
+        id: generation.id,
+        traceId: generation.traceId,
+        model: generation.model,
+        provider: generation.provider,
+        messages: generation.messages,
+        completion: generation.completion,
+        inputTokens: generation.inputTokens,
+        outputTokens: generation.outputTokens,
+        cost: generation.cost ?? null,
+        latencyMs: generation.latencyMs,
+        temperature: generation.temperature ?? null,
+        responseFormat: generation.responseFormat ?? null,
+        fallbackUsed: generation.fallbackUsed ?? null,
+        cached: generation.cached ?? null,
+        partial: generation.partial ?? null,
+        status: generation.status,
+        error: generation.error ?? null,
+        startedAt: new Date(generation.startedAt),
+        endedAt: new Date(generation.endedAt),
+      });
+      // Aggregate rollup as SQL increments — durable + restart-safe (matches
+      // the in-memory rollup, including the status escalation on error).
+      await this.db
+        .update(aiTracesTable)
+        .set({
+          inputTokens: sql`${aiTracesTable.inputTokens} + ${generation.inputTokens}`,
+          outputTokens: sql`${aiTracesTable.outputTokens} + ${generation.outputTokens}`,
+          cost: sql`${aiTracesTable.cost} + ${generation.cost ?? 0}`,
+          ...(generation.status === "error" ? { status: "error" as const } : {}),
+        })
+        .where(eq(aiTracesTable.traceId, generation.traceId));
+    });
+    return generation;
+  }
+
+  /** Synchronous hot view — generations recorded by THIS process only. */
+  query(options?: AITraceQueryOptions): AIGeneration[] {
+    return this.memory.query(options);
+  }
+
+  /** Synchronous hot view — traces recorded by THIS process only. */
+  queryTraces(options?: AITraceQueryOptions): AITrace[] {
+    return this.memory.queryTraces(options);
+  }
+
+  /** Hot-view generation count (process-local; durable count lives in PG). */
+  get size(): number {
+    return this.memory.size;
+  }
+
+  /** Clear hot view + enqueue a mirror wipe (test helper, like the peers). */
+  clear(): void {
+    this.memory.clear();
+    this.enqueue("clear", async () => {
+      await this.db.delete(aiGenerationsTable);
+      await this.db.delete(aiTracesTable);
+    });
+  }
+
+  // ── Durable (async) reads ──────────────────────────────
+
+  /**
+   * Query persisted generations — same filter semantics as
+   * `InMemoryAITraceStore.query`: most-recent-first (insertion order), strict
+   * `after`/`before` bounds on `startedAt`, tenant/scenario/origin resolved
+   * via the parent trace (a generation whose parent is missing is excluded by
+   * those filters), `limit: 0` ⇒ empty, negative limit ⇒ uncapped.
+   */
+  async queryPersisted(options?: AITraceQueryOptions): Promise<AIGeneration[]> {
+    const limit = options?.limit;
+    const hasLimit = limit !== undefined && limit >= 0;
+    if (hasLimit && limit === 0) return [];
+
+    const conditions: SQL[] = [];
+    if (options?.traceId) conditions.push(eq(aiGenerationsTable.traceId, options.traceId));
+    if (options?.model) conditions.push(eq(aiGenerationsTable.model, options.model));
+    if (options?.status) conditions.push(eq(aiGenerationsTable.status, options.status));
+    if (options?.after !== undefined)
+      conditions.push(gt(aiGenerationsTable.startedAt, new Date(options.after)));
+    if (options?.before !== undefined)
+      conditions.push(lt(aiGenerationsTable.startedAt, new Date(options.before)));
+    // Trace-level filters: the LEFT JOIN row is NULL for an orphan generation,
+    // so an equality condition on a trace column excludes it — identical to
+    // the in-memory `trace?.tenantId !== options.tenantId` check.
+    if (options?.tenantId) conditions.push(eq(aiTracesTable.tenantId, options.tenantId));
+    if (options?.scenario) conditions.push(eq(aiTracesTable.scenario, options.scenario));
+    if (options?.origin) conditions.push(eq(aiTracesTable.origin, options.origin));
+
+    const base = this.db
+      .select({ gen: aiGenerationsTable })
+      .from(aiGenerationsTable)
+      .leftJoin(aiTracesTable, eq(aiGenerationsTable.traceId, aiTracesTable.traceId))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(aiGenerationsTable.seq));
+    const rows = hasLimit ? await base.limit(limit) : await base;
+    return rows.map((r) => rowToGeneration(r.gen));
+  }
+
+  /**
+   * Query persisted traces — same filter semantics as
+   * `InMemoryAITraceStore.queryTraces` (see {@link queryPersisted}).
+   */
+  async queryTracesPersisted(options?: AITraceQueryOptions): Promise<AITrace[]> {
+    const limit = options?.limit;
+    const hasLimit = limit !== undefined && limit >= 0;
+    if (hasLimit && limit === 0) return [];
+
+    const conditions: SQL[] = [];
+    if (options?.traceId) conditions.push(eq(aiTracesTable.traceId, options.traceId));
+    if (options?.tenantId) conditions.push(eq(aiTracesTable.tenantId, options.tenantId));
+    if (options?.scenario) conditions.push(eq(aiTracesTable.scenario, options.scenario));
+    if (options?.origin) conditions.push(eq(aiTracesTable.origin, options.origin));
+    if (options?.status) conditions.push(eq(aiTracesTable.status, options.status));
+    if (options?.after !== undefined)
+      conditions.push(gt(aiTracesTable.startedAt, new Date(options.after)));
+    if (options?.before !== undefined)
+      conditions.push(lt(aiTracesTable.startedAt, new Date(options.before)));
+
+    const base = this.db
+      .select()
+      .from(aiTracesTable)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(aiTracesTable.seq));
+    const rows = hasLimit ? await base.limit(limit) : await base;
+    return rows.map(rowToTrace);
+  }
+
+  // ── Retention ──────────────────────────────────────────
+
+  /**
+   * Delete persisted generations older than `days` (by `started_at`), then
+   * traces older than the same cutoff that no longer have any generations.
+   * Returns deleted row counts. Propagates DB errors — this runs on a
+   * maintenance path (manual / scheduled), never on the AI call path. No
+   * background timer is wired here; scheduling is a later wave.
+   */
+  async purgeOlderThan(
+    days: number = DEFAULT_TRACE_RETENTION_DAYS,
+  ): Promise<{ generations: number; traces: number }> {
+    if (!Number.isFinite(days) || days <= 0) {
+      throw new RangeError("purgeOlderThan(days) requires a positive number of days");
+    }
+    // Drain pending mirror writes so the purge sees a consistent snapshot.
+    await this.whenPersisted();
+    const cutoff = new Date(Date.now() - days * MS_PER_DAY);
+    const generations = await this.db
+      .delete(aiGenerationsTable)
+      .where(lt(aiGenerationsTable.startedAt, cutoff))
+      .returning({ id: aiGenerationsTable.id });
+    const traces = await this.db
+      .delete(aiTracesTable)
+      .where(
+        and(
+          lt(aiTracesTable.startedAt, cutoff),
+          // Keep an old trace alive while any (newer) generation references it.
+          notExists(
+            this.db
+              .select({ one: sql<number>`1` })
+              .from(aiGenerationsTable)
+              .where(eq(aiGenerationsTable.traceId, aiTracesTable.traceId)),
+          ),
+        ),
+      )
+      .returning({ traceId: aiTracesTable.traceId });
+    return { generations: generations.length, traces: traces.length };
+  }
+
+  // ── Mirror plumbing ────────────────────────────────────
+
+  /**
+   * Resolve once every pending mirror write submitted so far has settled
+   * (applied or logged-and-skipped). Never rejects. For tests + shutdown.
+   */
+  async whenPersisted(): Promise<void> {
+    await this.writeTail;
+  }
+
+  /**
+   * Append a mirror write to the serialized tail. The op's failure (sync
+   * throw or async rejection) is logged and swallowed so the chain — and the
+   * AI call path above it — keeps going.
+   */
+  private enqueue(stage: string, op: () => Promise<void>): void {
+    this.writeTail = this.writeTail.then(op).catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      try {
+        this.logger.warn(`[ai-trace-store] ${stage} mirror write failed (skipped): ${message}`);
+      } catch {
+        // Logger itself failed — nothing more we can safely do.
+      }
+    });
+  }
+
+  /** Build a full `ai_traces` insert row from resolved start params. */
+  private traceRow(resolved: StartTraceParams): typeof aiTracesTable.$inferInsert {
+    return {
+      // `startTrace` resolves these before calling; the fallbacks only guard
+      // the type system (StartTraceParams keeps them optional).
+      traceId: resolved.traceId ?? crypto.randomUUID(),
+      name: resolved.name,
+      tenantId: resolved.tenantId ?? null,
+      actorId: resolved.actorId ?? null,
+      scenario: resolved.scenario ?? null,
+      fixtureId: resolved.fixtureId ?? null,
+      evalRunId: resolved.evalRunId ?? null,
+      origin: resolved.origin ?? "production",
+      tags: resolved.tags ? [...resolved.tags] : null,
+      metadata: resolved.metadata ?? null,
+      startedAt: new Date(resolved.startedAt ?? Date.now()),
+      endedAt: null,
+      // Aggregates always start at zero — recordGeneration's increment-update
+      // is the single place rollups happen, so first-insert never double-counts.
+      inputTokens: 0,
+      outputTokens: 0,
+      cost: 0,
+      sampled: resolved.sampled ?? true,
+      status: "ok",
+    };
+  }
+
+  /**
+   * Snapshot the parent-trace row to upsert alongside a generation insert.
+   * The in-memory store just created/loaded the parent, so mirror ITS
+   * non-aggregate fields (covers the auto-open path where `startTrace` was
+   * never called). Falls back to a minimal row derived from the generation if
+   * the hot view already trimmed the trace (extreme churn).
+   */
+  private parentTraceRowFor(
+    generation: AIGeneration,
+    params: RecordGenerationParams,
+  ): typeof aiTracesTable.$inferInsert {
+    const snapshot = this.memory.queryTraces({ traceId: generation.traceId, limit: 1 })[0];
+    if (snapshot) {
+      return this.traceRow({
+        traceId: snapshot.traceId,
+        name: snapshot.name,
+        tenantId: snapshot.tenantId,
+        actorId: snapshot.actorId,
+        scenario: snapshot.scenario,
+        fixtureId: snapshot.fixtureId,
+        evalRunId: snapshot.evalRunId,
+        origin: snapshot.origin,
+        tags: snapshot.tags,
+        metadata: snapshot.metadata,
+        startedAt: snapshot.startedAt,
+        sampled: snapshot.sampled,
+      });
+    }
+    return this.traceRow({
+      traceId: generation.traceId,
+      name: params.model,
+      tenantId: params.tenantId,
+      startedAt: generation.startedAt,
+    });
+  }
+}

--- a/addons/ai-provider/cap-ai-provider/src/ai-trace-store-drizzle.ts
+++ b/addons/ai-provider/cap-ai-provider/src/ai-trace-store-drizzle.ts
@@ -173,42 +173,50 @@ export class DrizzleAITraceStore implements AITraceSink {
     const generation = this.memory.recordGeneration(params);
     const parentRow = this.parentTraceRowFor(generation, params);
     this.enqueue("recordGeneration", async () => {
-      await this.db
-        .insert(aiTracesTable)
-        .values(parentRow)
-        .onConflictDoNothing({ target: aiTracesTable.traceId });
-      await this.db.insert(aiGenerationsTable).values({
-        id: generation.id,
-        traceId: generation.traceId,
-        model: generation.model,
-        provider: generation.provider,
-        messages: generation.messages,
-        completion: generation.completion,
-        inputTokens: generation.inputTokens,
-        outputTokens: generation.outputTokens,
-        cost: generation.cost ?? null,
-        latencyMs: generation.latencyMs,
-        temperature: generation.temperature ?? null,
-        responseFormat: generation.responseFormat ?? null,
-        fallbackUsed: generation.fallbackUsed ?? null,
-        cached: generation.cached ?? null,
-        partial: generation.partial ?? null,
-        status: generation.status,
-        error: generation.error ?? null,
-        startedAt: new Date(generation.startedAt),
-        endedAt: new Date(generation.endedAt),
+      // Atomic: parent upsert + generation insert + aggregate rollup must
+      // all-or-nothing. A mid-sequence failure (e.g. the rollup) would leave
+      // generation rows whose tokens/cost were never rolled into the trace
+      // aggregate — a permanently inconsistent durable state. The transaction
+      // throws on any statement failure; the enqueue `.catch()` rolls it back
+      // (Drizzle) AND logs, so the AI path never sees a partial write.
+      await this.db.transaction(async (tx) => {
+        await tx
+          .insert(aiTracesTable)
+          .values(parentRow)
+          .onConflictDoNothing({ target: aiTracesTable.traceId });
+        await tx.insert(aiGenerationsTable).values({
+          id: generation.id,
+          traceId: generation.traceId,
+          model: generation.model,
+          provider: generation.provider,
+          messages: generation.messages,
+          completion: generation.completion,
+          inputTokens: generation.inputTokens,
+          outputTokens: generation.outputTokens,
+          cost: generation.cost ?? null,
+          latencyMs: generation.latencyMs,
+          temperature: generation.temperature ?? null,
+          responseFormat: generation.responseFormat ?? null,
+          fallbackUsed: generation.fallbackUsed ?? null,
+          cached: generation.cached ?? null,
+          partial: generation.partial ?? null,
+          status: generation.status,
+          error: generation.error ?? null,
+          startedAt: new Date(generation.startedAt),
+          endedAt: new Date(generation.endedAt),
+        });
+        // Aggregate rollup as SQL increments — durable + restart-safe (matches
+        // the in-memory rollup, including the status escalation on error).
+        await tx
+          .update(aiTracesTable)
+          .set({
+            inputTokens: sql`${aiTracesTable.inputTokens} + ${generation.inputTokens}`,
+            outputTokens: sql`${aiTracesTable.outputTokens} + ${generation.outputTokens}`,
+            cost: sql`${aiTracesTable.cost} + ${generation.cost ?? 0}`,
+            ...(generation.status === "error" ? { status: "error" as const } : {}),
+          })
+          .where(eq(aiTracesTable.traceId, generation.traceId));
       });
-      // Aggregate rollup as SQL increments — durable + restart-safe (matches
-      // the in-memory rollup, including the status escalation on error).
-      await this.db
-        .update(aiTracesTable)
-        .set({
-          inputTokens: sql`${aiTracesTable.inputTokens} + ${generation.inputTokens}`,
-          outputTokens: sql`${aiTracesTable.outputTokens} + ${generation.outputTokens}`,
-          cost: sql`${aiTracesTable.cost} + ${generation.cost ?? 0}`,
-          ...(generation.status === "error" ? { status: "error" as const } : {}),
-        })
-        .where(eq(aiTracesTable.traceId, generation.traceId));
     });
     return generation;
   }
@@ -232,8 +240,12 @@ export class DrizzleAITraceStore implements AITraceSink {
   clear(): void {
     this.memory.clear();
     this.enqueue("clear", async () => {
-      await this.db.delete(aiGenerationsTable);
-      await this.db.delete(aiTracesTable);
+      // Atomic: wipe both tables together so a failure between the two DELETEs
+      // can't leave orphaned trace rows (generations gone, traces remaining).
+      await this.db.transaction(async (tx) => {
+        await tx.delete(aiGenerationsTable);
+        await tx.delete(aiTracesTable);
+      });
     });
   }
 
@@ -323,26 +335,36 @@ export class DrizzleAITraceStore implements AITraceSink {
     // Drain pending mirror writes so the purge sees a consistent snapshot.
     await this.whenPersisted();
     const cutoff = new Date(Date.now() - days * MS_PER_DAY);
-    const generations = await this.db
-      .delete(aiGenerationsTable)
-      .where(lt(aiGenerationsTable.startedAt, cutoff))
-      .returning({ id: aiGenerationsTable.id });
-    const traces = await this.db
-      .delete(aiTracesTable)
-      .where(
-        and(
-          lt(aiTracesTable.startedAt, cutoff),
-          // Keep an old trace alive while any (newer) generation references it.
-          notExists(
-            this.db
-              .select({ one: sql<number>`1` })
-              .from(aiGenerationsTable)
-              .where(eq(aiGenerationsTable.traceId, aiTracesTable.traceId)),
+    // Atomic: both deletes must commit together. Otherwise a failure after the
+    // generations delete but before the traces delete would leave traces that
+    // the second pass would have purged (now-orphaned), and a partial purge
+    // could also drop generations while leaving their parent — the counts
+    // returned would then mislead callers about what actually happened.
+    // Unlike the mirror-write callbacks this maintenance path DOES surface
+    // errors (its contract throws); the transaction re-throws on rollback, so
+    // a real DB error still propagates to the awaiting caller.
+    return await this.db.transaction(async (tx) => {
+      const generations = await tx
+        .delete(aiGenerationsTable)
+        .where(lt(aiGenerationsTable.startedAt, cutoff))
+        .returning({ id: aiGenerationsTable.id });
+      const traces = await tx
+        .delete(aiTracesTable)
+        .where(
+          and(
+            lt(aiTracesTable.startedAt, cutoff),
+            // Keep an old trace alive while any (newer) generation references it.
+            notExists(
+              tx
+                .select({ one: sql<number>`1` })
+                .from(aiGenerationsTable)
+                .where(eq(aiGenerationsTable.traceId, aiTracesTable.traceId)),
+            ),
           ),
-        ),
-      )
-      .returning({ traceId: aiTracesTable.traceId });
-    return { generations: generations.length, traces: traces.length };
+        )
+        .returning({ traceId: aiTracesTable.traceId });
+      return { generations: generations.length, traces: traces.length };
+    });
   }
 
   // ── Mirror plumbing ────────────────────────────────────

--- a/addons/ai-provider/cap-ai-provider/src/ai-trace-tables.ts
+++ b/addons/ai-provider/cap-ai-provider/src/ai-trace-tables.ts
@@ -1,0 +1,147 @@
+/**
+ * AI trace system tables (Spec 69 Phase 3 — durable PG sink, issue #350).
+ *
+ * Drizzle schema for `_linchkit.ai_traces` + `_linchkit.ai_generations`.
+ * Persists the `AITrace` / `AIGeneration` records emitted through the core
+ * `AITraceSink` seam so traces survive process restarts and become queryable
+ * across deploys (the in-memory ring buffer is process-local).
+ *
+ * Follows the `_linchkit` system-schema convention used by the other
+ * addon-owned system tables (`_linchkit.watcher_state` in
+ * `./watcher-state-table.ts`, `_linchkit.mcp_clients` in
+ * `addons/adapter-mcp/cap-adapter-mcp/src/system-tables.ts`,
+ * `_linchkit.search_documents` in `addons/search/cap-search/src/tables.ts`).
+ * All DDL is delegated to drizzle-kit — these declarations are the single
+ * source of truth. Like those peers, the tables are provisioned via `db:push`,
+ * NOT the core migration chain (`drizzle/migrations/` is core-schema only).
+ *
+ * Column shapes mirror the authoritative model in
+ * `packages/core/src/observability/ai-trace.ts`. Epoch-ms numbers on the
+ * domain model map to `timestamp` columns (`mode: "date"` round-trips
+ * millisecond precision exactly — PG `timestamp` carries microseconds).
+ * `seq` is a storage-only bigserial that preserves insertion order so
+ * most-recent-first queries match the in-memory store's ordering semantics
+ * (insertion order, not `started_at` order).
+ */
+
+import type { AITraceMessage, AITraceOrigin, AITraceStatus } from "@linchkit/core/server";
+import { linchkitSchema } from "@linchkit/core/server";
+import {
+  bigserial,
+  boolean,
+  doublePrecision,
+  index,
+  integer,
+  jsonb,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Parent traces — `_linchkit.ai_traces`.
+ *
+ * One row per `AITrace`. Aggregate token / cost counters are maintained by
+ * `DrizzleAITraceStore` via SQL increments as child generations are recorded.
+ * No FK to `ai_generations` — generations may auto-open their parent trace
+ * and the two mirrors stay loosely coupled (matching the in-memory store).
+ */
+export const aiTracesTable = linchkitSchema.table(
+  "ai_traces",
+  {
+    /** Unique trace id (UUID string allocated by the sink or the caller). */
+    traceId: text("trace_id").primaryKey(),
+    /** Insertion-order marker — most-recent-first queries order by this. */
+    seq: bigserial("seq", { mode: "number" }).notNull(),
+    /** Human-readable trace name (e.g. "intent"). */
+    name: text("name").notNull(),
+    /** Tenant id for isolation (null = tenant-less). */
+    tenantId: text("tenant_id"),
+    /** Acting user / agent id. */
+    actorId: text("actor_id"),
+    /** Scenario label (eval framework: scenario name). */
+    scenario: text("scenario"),
+    /** Fixture id when replaying a recorded fixture. */
+    fixtureId: text("fixture_id"),
+    /** Eval-run id grouping a batch of fixtures. */
+    evalRunId: text("eval_run_id"),
+    /** Origin — production vs eval. */
+    origin: text("origin").$type<AITraceOrigin>().notNull(),
+    /** Free-form tags for filtering. */
+    tags: jsonb("tags").$type<readonly string[]>(),
+    /** Additional structured metadata. */
+    metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    /** When the trace started. */
+    startedAt: timestamp("started_at", { mode: "date" }).notNull(),
+    /** When the trace ended (null while open). */
+    endedAt: timestamp("ended_at", { mode: "date" }),
+    /** Aggregate input tokens across all generations. */
+    inputTokens: integer("input_tokens").notNull().default(0),
+    /** Aggregate output tokens across all generations. */
+    outputTokens: integer("output_tokens").notNull().default(0),
+    /** Aggregate estimated cost in USD across all generations. */
+    cost: doublePrecision("cost").notNull().default(0),
+    /** Whether this trace was sampled in (recorded). */
+    sampled: boolean("sampled").notNull().default(true),
+    /** Overall trace status ("ok" | "error" | "partial"). */
+    status: text("status").$type<AITraceStatus>().notNull().default("ok"),
+  },
+  (table) => [index("idx_ai_traces_tenant_started").on(table.tenantId, table.startedAt)],
+);
+
+/**
+ * Child generations — `_linchkit.ai_generations`.
+ *
+ * One row per `AIGeneration` (a single provider round-trip). Prompt messages
+ * and completion are persisted ALREADY redacted — redaction happens once at
+ * record time in the sink (see `RecordGenerationParams` contract).
+ */
+export const aiGenerationsTable = linchkitSchema.table(
+  "ai_generations",
+  {
+    /** Unique generation id (UUID string). */
+    id: text("id").primaryKey(),
+    /** Insertion-order marker — most-recent-first queries order by this. */
+    seq: bigserial("seq", { mode: "number" }).notNull(),
+    /** Parent trace id this generation belongs to. */
+    traceId: text("trace_id").notNull(),
+    /** Resolved model id used. */
+    model: text("model").notNull(),
+    /** Provider name used. */
+    provider: text("provider").notNull(),
+    /** Redacted prompt messages (`{role, content}` array). */
+    messages: jsonb("messages").$type<readonly AITraceMessage[]>().notNull(),
+    /** Redacted completion text. */
+    completion: text("completion").notNull(),
+    /** Prompt tokens consumed. */
+    inputTokens: integer("input_tokens").notNull(),
+    /** Completion tokens produced. */
+    outputTokens: integer("output_tokens").notNull(),
+    /** Estimated cost in USD (null when pricing unavailable). */
+    cost: doublePrecision("cost"),
+    /** Wall-clock latency in milliseconds. */
+    latencyMs: doublePrecision("latency_ms").notNull(),
+    /** Sampling temperature, when supplied by the caller. */
+    temperature: doublePrecision("temperature"),
+    /** Response format requested ("text" | "json"). */
+    responseFormat: text("response_format").$type<"text" | "json">(),
+    /** Provider that originally failed, when a fallback served this one. */
+    fallbackUsed: text("fallback_used"),
+    /** Whether the result was served from cache. */
+    cached: boolean("cached"),
+    /** Whether this is a partial record (e.g. streaming, usage unknown). */
+    partial: boolean("partial"),
+    /** Generation status ("ok" | "error" | "partial"). */
+    status: text("status").$type<AITraceStatus>().notNull(),
+    /** Error message when status is "error" (caller-redacted, stored verbatim). */
+    error: text("error"),
+    /** When this generation started. */
+    startedAt: timestamp("started_at", { mode: "date" }).notNull(),
+    /** When this generation ended. */
+    endedAt: timestamp("ended_at", { mode: "date" }).notNull(),
+  },
+  (table) => [
+    index("idx_ai_generations_trace_id").on(table.traceId),
+    // Retention purges + time-window queries scan by start time.
+    index("idx_ai_generations_started_at").on(table.startedAt),
+  ],
+);

--- a/addons/ai-provider/cap-ai-provider/src/index.ts
+++ b/addons/ai-provider/cap-ai-provider/src/index.ts
@@ -34,7 +34,13 @@ export {
   resolveModelRoute,
   resolveTenantConfig,
 } from "./ai-service";
-
+// AI trace persistence (Spec 69 Phase 3 — durable PG-backed AITraceSink)
+export {
+  DEFAULT_TRACE_RETENTION_DAYS,
+  DrizzleAITraceStore,
+  type DrizzleAITraceStoreOptions,
+} from "./ai-trace-store-drizzle";
+export { aiGenerationsTable, aiTracesTable } from "./ai-trace-tables";
 // Anomaly Detector (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
 export type {
   AnomalyDetection,
@@ -53,7 +59,6 @@ export { createCodeGenerationProvider } from "./code-generation-provider";
 // Cost Estimator
 export type { ModelPricing } from "./cost-estimator";
 export { CostEstimator, defaultCostEstimator } from "./cost-estimator";
-
 // NOTE: the AI Eval scenario adapter (spec 69) is intentionally NOT exported
 // from the package root. It lives in `<cap-ai-provider>/eval-runner/` —
 // outside `src/` and therefore outside the published `files` allowlist —
@@ -72,7 +77,6 @@ export type {
   ResolveIntentInput,
 } from "./intent-resolver";
 export { MIN_CONFIDENCE, resolveIntent } from "./intent-resolver";
-
 // Pattern Detector (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
 export type {
   PatternDetectorConfig,
@@ -81,10 +85,8 @@ export type {
   PatternType,
 } from "./pattern-detector";
 export { PatternDetector } from "./pattern-detector";
-
 // Response Cache
 export { AIResponseCache } from "./response-cache";
-
 // Watcher Engine (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
 export {
   createWatcherEngine,
@@ -95,7 +97,6 @@ export {
   type WatcherEngine,
   type WatcherEngineOptions,
 } from "./watcher-engine";
-
 // Watcher debounce-state persistence (Spec 45 §4 — restart-safe debounce)
 export {
   InMemoryWatcherStateStore,


### PR DESCRIPTION
## Summary

Spec 69 Phase 3 wave 1 (#350). Decision recorded on the issue: **no third-party observability backend** — the #398–#410 wave already built the Langfuse-shaped data plane (AITrace→AIGeneration model, redaction, sampling, full ai-service instrumentation), but production ran on `NoopAITraceSink` and **discarded every trace**. This PR adds the missing persistence + the monthly drift cron.

### DrizzleAITraceStore (cap-ai-provider)
- `_linchkit.ai_traces` + `_linchkit.ai_generations` pgTables, addon-owned, `db:push` provisioning — same convention as watcher_state / search peers; zero hand-written DDL
- Implements the synchronous `AITraceSink` interface via an embedded in-memory hot view (bit-identical redaction/aggregation semantics) + serialized fire-and-forget PG mirror that **never throws into the AI call path** (catch + Logger.warn)
- Persisted reads (`queryPersisted`/`queryTracesPersisted`) replicate the full in-memory filter semantics in SQL (strict after/before, parent-trace filters via LEFT JOIN, insertion-order via bigserial seq, limit edge cases)
- `purgeOlderThan(days = 90)` retention method; scheduler wiring deferred to wave 2
- Shared conformance suite runs the SAME assertions against both implementations: 13/13 in-memory (always-on), 12/12 PG integration (DB-gated, `describe.skipIf` without Postgres)

### Monthly drift cron (ai-eval.yml)
- `schedule:` monthly trigger reusing the existing live-eval path; provider-key absence fails loudly (no silent green)
- On >5pp baseline drop: files a deduped `AI eval drift detected YYYY-MM` issue (`ai`, `P1: High`) with run link, per spec 69 §9.4

### Wave 2 (follow-up, after this lands)
Boot wiring (app factory + dev.ts — the #535/#541 lesson), admin read endpoint through CommandLayer, eval fixture harvest command.

## Verification
- `bun run check` / `bun run typecheck` clean
- Full `bun run test`: all batches PASS
- `bun test ./addons/ai-provider/`: 347 pass / 4 skip / 0 fail — PG integration suites ran against the real local Postgres (:5434)
- Workflow YAML parse-validated (js-yaml)

Closes the wave-1 half of #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added monthly scheduled AI evaluation workflow with automatic drift detection and GitHub issue reporting
  * Implemented PostgreSQL-backed persistent storage for AI traces with query and retention capabilities

* **Tests**
  * Added comprehensive conformance test suite for AI trace storage implementations
  * Added integration tests validating trace persistence and durability

* **Chores**
  * Updated package exports to expose AI trace persistence, pattern detection, and caching utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->