### PR TITLE
fix(ag-ui): bind window.fetch for HttpAgent + browser e2e for the assistant chat path

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
@@ -65,11 +65,13 @@ function createHttpRunAgent(url: string): AgUiRunAgentFn {
     // Observable. `abortRun()` aborts the underlying fetch.
     // HttpAgent stores the fetch impl and invokes it as `this.fetch(...)`;
     // an unbound window.fetch then runs with the agent as `this`, which
-    // browsers reject ("Illegal invocation"). Pass a bound fetch explicitly.
+    // browsers reject ("Illegal invocation"). Wrap it so the call resolves
+    // `globalThis.fetch` lazily (respecting late mocks/polyfills) and always
+    // invokes it with `globalThis` as the receiver.
     const agent = new HttpAgent({
       url,
       threadId: input.threadId,
-      fetch: globalThis.fetch.bind(globalThis),
+      fetch: (req, init) => globalThis.fetch(req, init),
     });
     if (abortSignal) {
       if (abortSignal.aborted) agent.abortRun();

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
@@ -63,7 +63,14 @@ function createHttpRunAgent(url: string): AgUiRunAgentFn {
     // One agent per run: `useChat` owns conversation state, so the stateful
     // `runAgent()` orchestration is bypassed in favor of the raw `run()`
     // Observable. `abortRun()` aborts the underlying fetch.
-    const agent = new HttpAgent({ url, threadId: input.threadId });
+    // HttpAgent stores the fetch impl and invokes it as `this.fetch(...)`;
+    // an unbound window.fetch then runs with the agent as `this`, which
+    // browsers reject ("Illegal invocation"). Pass a bound fetch explicitly.
+    const agent = new HttpAgent({
+      url,
+      threadId: input.threadId,
+      fetch: globalThis.fetch.bind(globalThis),
+    });
     if (abortSignal) {
       if (abortSignal.aborted) agent.abortRun();
       else abortSignal.addEventListener("abort", () => agent.abortRun(), { once: true });

--- a/e2e/browser/smoke.test.ts
+++ b/e2e/browser/smoke.test.ts
@@ -379,11 +379,6 @@ describe.skipIf(!BROWSER_E2E_ENABLED)("browser e2e smoke", () => {
     async () => {
       const { page, pageErrors } = await newTrackedPage(browser);
       try {
-        const aguiRequests: string[] = [];
-        page.on("request", (req) => {
-          if (req.url().includes("/api/agui/run")) aguiRequests.push(req.url());
-        });
-
         await page.goto(UI_URL, { waitUntil: "networkidle2" });
 
         // Open the assistant sheet via the sparkles header button.
@@ -394,18 +389,18 @@ describe.skipIf(!BROWSER_E2E_ENABLED)("browser e2e smoke", () => {
         const textareaSelector = '[role="dialog"] textarea';
         await page.waitForSelector(textareaSelector, { timeout: 10_000 });
         await page.type(textareaSelector, "Reply with OK only.");
-        await page.keyboard.press("Enter");
 
-        // The transport must actually emit the HTTP request — a broken fetch
-        // binding throws before any network I/O and this stays empty forever.
-        const deadline = Date.now() + 15_000;
-        while (Date.now() < deadline && aguiRequests.length === 0) {
-          await new Promise((resolve) => setTimeout(resolve, 250));
-        }
+        // Arm the request wait BEFORE the keystroke that triggers it. The
+        // transport must actually emit the HTTP request — a broken fetch
+        // binding throws before any network I/O, so this rejects on timeout.
+        const aguiRequest = page
+          .waitForRequest((req) => req.url().includes("/api/agui/run"), { timeout: 15_000 })
+          .catch(() => null);
+        await page.keyboard.press("Enter");
         expect(
-          aguiRequests.length,
+          await aguiRequest,
           "no POST to /api/agui/run left the browser — transport failed before network I/O",
-        ).toBeGreaterThan(0);
+        ).not.toBeNull();
 
         // The chat surface must not show the unbound-fetch failure either.
         const illegalInvocation = await page.evaluate(() =>

--- a/e2e/browser/smoke.test.ts
+++ b/e2e/browser/smoke.test.ts
@@ -366,4 +366,60 @@ describe.skipIf(!BROWSER_E2E_ENABLED)("browser e2e smoke", () => {
     },
     TEST_TIMEOUT_MS,
   );
+
+  // ── h. assistant panel sends chat over AG-UI from a real browser ───────
+  // Pins the CLIENT half of the AG-UI switch (#550) where unit tests are
+  // blind: the transport runs inside a real browser. Caught live: HttpAgent
+  // invokes its fetch as `this.fetch(...)`, so an unbound window.fetch threw
+  // "Illegal invocation" — the POST to /api/agui/run never fired, while
+  // useChat swallowed the error (zero uncaught page errors, green tests).
+  // Asserting the request actually leaves the browser is the regression net.
+  test(
+    "assistant panel dispatches its chat request to /api/agui/run",
+    async () => {
+      const { page, pageErrors } = await newTrackedPage(browser);
+      try {
+        const aguiRequests: string[] = [];
+        page.on("request", (req) => {
+          if (req.url().includes("/api/agui/run")) aguiRequests.push(req.url());
+        });
+
+        await page.goto(UI_URL, { waitUntil: "networkidle2" });
+
+        // Open the assistant sheet via the sparkles header button.
+        await page.waitForSelector("button svg.lucide-sparkles", { timeout: 20_000 });
+        await page.click("button:has(svg.lucide-sparkles)");
+
+        // Type into the sheet's textarea and send with Enter.
+        const textareaSelector = '[role="dialog"] textarea';
+        await page.waitForSelector(textareaSelector, { timeout: 10_000 });
+        await page.type(textareaSelector, "Reply with OK only.");
+        await page.keyboard.press("Enter");
+
+        // The transport must actually emit the HTTP request — a broken fetch
+        // binding throws before any network I/O and this stays empty forever.
+        const deadline = Date.now() + 15_000;
+        while (Date.now() < deadline && aguiRequests.length === 0) {
+          await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        expect(
+          aguiRequests.length,
+          "no POST to /api/agui/run left the browser — transport failed before network I/O",
+        ).toBeGreaterThan(0);
+
+        // The chat surface must not show the unbound-fetch failure either.
+        const illegalInvocation = await page.evaluate(() =>
+          document.body.innerText.includes("Illegal invocation"),
+        );
+        expect(illegalInvocation).toBe(false);
+
+        expect(pageErrors, `uncaught page errors: ${describePageErrors(pageErrors)}`).toHaveLength(
+          0,
+        );
+      } finally {
+        await page.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
## Summary

Live-browser verification of the freshly merged #550 caught a runtime killer that every unit test missed: **the assistant was dead on arrival in real browsers**.

### The bug
`@ag-ui/client`'s `HttpAgent` stores its fetch implementation and invokes it as `this.fetch(...)` (`this.fetch = config.fetch ?? fetch`). With the unbound `window.fetch` default, browsers throw `Failed to execute 'fetch' on 'Window': Illegal invocation` **before any network I/O**. Node/Bun don't bind-check `fetch`, so the entire test suite (unit + DI-seam transport tests + server-side e2e) stayed green while the actual UI chat was broken.

### The fix
One line: pass `fetch: globalThis.fetch.bind(globalThis)` to the `HttpAgent` config.

### The regression net
New browser e2e case (`LINCHKIT_E2E_BROWSER=1`): drives the real assistant panel — opens the sheet via the sparkles button, types, presses Enter — and asserts **the POST to `/api/agui/run` actually leaves the browser** (request-level tracking). `useChat` swallows transport errors into chat-bubble text, so page-error tracking alone can't catch this class; the request-departure assertion can.

- Red-light verified: the case FAILS against the unfixed code ("no POST to /api/agui/run left the browser")
- Green: full browser suite 7 pass / 1 skip (AI-gated) / 0 fail with the fix

### Live proof (merged main + this fix, real Chrome + real GLM)
Assistant answered "系统里目前有 4 条采购申请。" with the network panel showing `POST /api/agui/run [200]` — the dogfood path is now verifiably live end-to-end.

## Verification
- `bun run check` / `bun run typecheck` clean
- Full `bun run test`: all batches PASS
- `bun run test:e2e`: 7 pass / 1 skip / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
