### PR TITLE
fix(adapter-server,devtools): correct core-version skew + satisfaction lint guard

### DIFF
--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -29,7 +29,7 @@
     "@linchkit/cap-adapter-ag-ui": "workspace:*",
     "@linchkit/cap-ai-provider": "^1.0.0",
     "@linchkit/cap-dry-run": "^0.1.0",
-    "@linchkit/core": ">=0.3.0 <0.4.0"
+    "@linchkit/core": "^0.2.0"
   },
   "peerDependenciesMeta": {
     "@linchkit/cap-adapter-ag-ui": {
@@ -46,7 +46,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": ">=0.3.0 <0.4.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -51,6 +51,27 @@ function writeCorePackageJson(root: string, coreRange = "^0.2.0"): void {
   );
 }
 
+/**
+ * Build a synthetic monorepo whose root contains `packages/core/package.json`
+ * pinned to `coreVersion`, with a capability nested under
+ * `addons/<group>/<cap>/`. Returns the capability dir so the lint's walk-up
+ * version resolution finds the controllable local core version. Used by the
+ * satisfaction-check tests, which need a resolvable local core version (a plain
+ * tmpdir fixture has none, so the satisfaction check is skipped there).
+ */
+function makeMonorepoCapDir(coreVersion: string): string {
+  const repoRoot = mkdtempSync(join(tmpdir(), "caplint-mono-"));
+  tmpRoots.push(repoRoot);
+  writeFile(
+    repoRoot,
+    "packages/core/package.json",
+    JSON.stringify({ name: "@linchkit/core", version: coreVersion }),
+  );
+  const capDir = join(repoRoot, "addons", "sample", "cap-sample");
+  mkdirSync(join(capDir, "src"), { recursive: true });
+  return capDir;
+}
+
 afterAll(() => {
   for (const root of tmpRoots) {
     rmSync(root, { recursive: true, force: true });
@@ -574,6 +595,110 @@ describe("lintCapability", () => {
     writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
 
     const result = lintCapability(root);
+    expect(result.issues.filter((i) => i.check === "core-version")).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  // -- Check 4 (satisfaction of the LOCAL core version) ----------------
+
+  it("passes when coreVersion ^0.2.0 satisfies the local core 0.2.0", () => {
+    const root = makeMonorepoCapDir("0.2.0");
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.2.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.issues.filter((i) => i.check === "core-version")).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it("errors when coreVersion >=0.3.0 <0.4.0 does not satisfy the local core 0.2.0", () => {
+    const root = makeMonorepoCapDir("0.2.0");
+    // The real cap-adapter-server skew: an AND-range that excludes the only
+    // core version that exists. peerDep matches coreVersion (both wrong) so the
+    // equality check passes — only the satisfaction check catches it.
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": ">=0.3.0 <0.4.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: ">=0.3.0 <0.4.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    const cv = result.issues.filter((i) => i.check === "core-version" && i.level === "error");
+    expect(cv.some((i) => /does not satisfy/.test(i.message))).toBe(true);
+    const msg = cv.find((i) => /does not satisfy/.test(i.message))?.message ?? "";
+    expect(msg).toContain(">=0.3.0 <0.4.0");
+    expect(msg).toContain("0.2.0");
+  });
+
+  it("emits a distinct satisfaction error for a concrete peerDep that differs and fails", () => {
+    const root = makeMonorepoCapDir("0.2.0");
+    // coreVersion satisfies local core, but the concrete peerDep range does not.
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.3.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.3.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    // peerDep equals coreVersion here, so a single satisfaction error is enough;
+    // assert the declared-range satisfaction error fires for ^0.3.0 vs 0.2.0.
+    const cv = result.issues.filter(
+      (i) =>
+        i.check === "core-version" && i.level === "error" && /does not satisfy/.test(i.message),
+    );
+    expect(cv.length).toBeGreaterThan(0);
+    expect(cv[0]?.message).toContain("^0.3.0");
+  });
+
+  it("skips the satisfaction check when the local core version is unresolvable (no crash, no error)", () => {
+    // A plain tmpdir fixture has no ancestor packages/core/package.json and
+    // @linchkit/core is not module-resolvable from it, so version resolution
+    // returns undefined and the satisfaction check is skipped silently — even
+    // for a range that could never satisfy any real core (>=0.3.0 <0.4.0).
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": ">=0.3.0 <0.4.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: ">=0.3.0 <0.4.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    // No satisfaction error because the local core version could not be resolved.
+    expect(result.issues.some((i) => /does not satisfy/.test(i.message))).toBe(false);
+    // peerDep equals coreVersion → the equality check also passes → fully clean.
     expect(result.issues.filter((i) => i.check === "core-version")).toHaveLength(0);
     expect(result.ok).toBe(true);
   });

--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -680,6 +680,66 @@ describe("lintCapability", () => {
     expect(cv[0]?.message).toContain("^0.3.0");
   });
 
+  it("treats a bare deprecated minCoreVersion as a '>=' minimum, not an exact pin", () => {
+    const root = makeMonorepoCapDir("0.2.0");
+    // minCoreVersion is a MINIMUM. A bare "0.1.0" must be read as ">=0.1.0", so
+    // a newer local core (0.2.0) satisfies it. The old behavior treated "0.1.0"
+    // as an exact-match comparator and falsely emitted "does not satisfy".
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        // Bare peerDep equal to the bare minCoreVersion → equality check passes;
+        // this isolates the satisfaction-check behavior under test.
+        peerDependencies: { "@linchkit/core": "0.1.0" },
+        linchkit: { type: "standard", category: "business", minCoreVersion: "0.1.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    // No false satisfaction error — 0.2.0 satisfies ">=0.1.0".
+    expect(result.issues.some((i) => /does not satisfy/.test(i.message))).toBe(false);
+    // The deprecation warning still fires (and is non-fatal).
+    expect(
+      result.issues.some(
+        (i) =>
+          i.check === "core-version" && i.level === "warning" && /minCoreVersion/.test(i.message),
+      ),
+    ).toBe(true);
+    expect(result.issues.some((i) => i.check === "core-version" && i.level === "error")).toBe(
+      false,
+    );
+  });
+
+  it("still flags a bare minCoreVersion that the local core is BELOW", () => {
+    const root = makeMonorepoCapDir("0.2.0");
+    // ">=0.3.0" is NOT satisfied by local core 0.2.0 — a real skew, must error.
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "0.3.0" },
+        linchkit: { type: "standard", category: "business", minCoreVersion: "0.3.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(
+      result.issues.some(
+        (i) =>
+          i.check === "core-version" && i.level === "error" && /does not satisfy/.test(i.message),
+      ),
+    ).toBe(true);
+  });
+
   it("skips the satisfaction check when the local core version is unresolvable (no crash, no error)", () => {
     // A plain tmpdir fixture has no ancestor packages/core/package.json and
     // @linchkit/core is not module-resolvable from it, so version resolution

--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -650,7 +650,10 @@ describe("lintCapability", () => {
 
   it("emits a distinct satisfaction error for a concrete peerDep that differs and fails", () => {
     const root = makeMonorepoCapDir("0.2.0");
-    // coreVersion satisfies local core, but the concrete peerDep range does not.
+    // The declared coreVersion (^0.2.0) DOES satisfy local core 0.2.0, so the
+    // declared-range branch stays clean. The peerDep range (^0.3.0) genuinely
+    // DIFFERS and does NOT satisfy 0.2.0 — this is the only scenario that
+    // exercises the `peerCore !== effectiveRange` distinct-peerDep branch.
     writeFile(
       root,
       "package.json",
@@ -658,7 +661,7 @@ describe("lintCapability", () => {
         name: "@linchkit/cap-cv",
         version: "1.0.0",
         peerDependencies: { "@linchkit/core": "^0.3.0" },
-        linchkit: { type: "standard", category: "business", coreVersion: "^0.3.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.2.0" },
       }),
     );
     writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
@@ -666,13 +669,14 @@ describe("lintCapability", () => {
 
     const result = lintCapability(root);
     expect(result.ok).toBe(false);
-    // peerDep equals coreVersion here, so a single satisfaction error is enough;
-    // assert the declared-range satisfaction error fires for ^0.3.0 vs 0.2.0.
     const cv = result.issues.filter(
       (i) =>
         i.check === "core-version" && i.level === "error" && /does not satisfy/.test(i.message),
     );
-    expect(cv.length).toBeGreaterThan(0);
+    // Exactly one satisfaction error — the distinct peerDep one — fires; the
+    // declared ^0.2.0 range did NOT produce an error (it satisfies 0.2.0).
+    expect(cv.length).toBe(1);
+    expect(cv[0]?.message).toContain('peerDependencies["@linchkit/core"]');
     expect(cv[0]?.message).toContain("^0.3.0");
   });
 

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -536,12 +536,33 @@ function resolveLocalCoreVersion(root: string): string | undefined {
 
   // 2. Fall back to Node-style module resolution of the installed @linchkit/core
   //    manifest, anchored at the capability dir. Handles a capability installed
-  //    against a published core outside the monorepo.
+  //    against a published core outside the monorepo. We resolve the package
+  //    ENTRY (the "." export) rather than "@linchkit/core/package.json": the
+  //    latter throws ERR_PACKAGE_PATH_NOT_EXPORTED under Node's exports
+  //    enforcement because core ships an `exports` map without a
+  //    `./package.json` entry. From the resolved entry we walk up to the
+  //    package's own manifest, asserting `name === "@linchkit/core"` so a
+  //    nested package.json can't be mistaken for it.
   try {
     const req = createRequire(join(root, "package.json"));
-    const pkgPath = req.resolve("@linchkit/core/package.json");
-    const v = readVersionField(pkgPath);
-    if (v !== undefined) return v;
+    let dir = dirname(req.resolve("@linchkit/core"));
+    for (let i = 0; i < 64; i++) {
+      const candidate = join(dir, "package.json");
+      if (existsSync(candidate)) {
+        const parsed = readJson(candidate);
+        const name =
+          !parsed.error && typeof parsed.value === "object" && parsed.value !== null
+            ? (parsed.value as Record<string, unknown>).name
+            : undefined;
+        if (name === "@linchkit/core") {
+          const v = readVersionField(candidate);
+          if (v !== undefined) return v;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break; // reached filesystem root
+      dir = parent;
+    }
   } catch {
     // Module not resolvable from here — fall through to undefined.
   }

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -19,6 +19,11 @@
  *     peerDependency and a core-version range must be declared (`coreVersion`,
  *     preferred over the deprecated `minCoreVersion`); when the peerDep pins a
  *     concrete range it must equal the declared core version (Spec 21 §10.1).
+ *     Additionally, when the local `@linchkit/core` version can be resolved, the
+ *     declared range (and any concrete peerDep range) MUST satisfy it — a range
+ *     that excludes the only core version that exists is a skew bug. Version
+ *     resolution is best-effort: if it cannot be determined, the satisfaction
+ *     check is skipped silently.
  *
  * Filesystem access uses node:fs/node:path only; import scanning is a simple
  * line/regex scan (no TS AST) to match the existing methodology approach.
@@ -28,8 +33,9 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join, relative, resolve } from "node:path";
-import { validateCapabilityMetadata } from "@linchkit/core";
+import { satisfiesVersionRange, validateCapabilityMetadata } from "@linchkit/core";
 
 // -- Types ---------------------------------------------------------------
 
@@ -342,6 +348,12 @@ const WORKSPACE_PROTOCOL_RE = /^workspace:/;
  *  - When the peerDep is a concrete semver range AND a coreVersion is declared,
  *    they MUST be equal → error on mismatch. A `workspace:*` peerDep skips the
  *    equality check (only presence of a coreVersion is required).
+ *  - When the local `@linchkit/core` version is resolvable, the declared
+ *    `coreVersion` range (and any concrete peerDep range) MUST SATISFY it →
+ *    error otherwise. This catches a range that excludes the only core version
+ *    that exists (e.g. `>=0.3.0 <0.4.0` against a published 0.2.0). The check is
+ *    best-effort: if the local core version cannot be resolved it is skipped
+ *    silently (e.g. when a capability is linted standalone outside the monorepo).
  */
 function checkCoreVersion(root: string): CapabilityLintIssue[] {
   const issues: CapabilityLintIssue[] = [];
@@ -424,11 +436,9 @@ function checkCoreVersion(root: string): CapabilityLintIssue[] {
 
   // 3. Equality check — only when the peerDep is a concrete range. workspace:*
   //    resolves locally and cannot be compared, so it is skipped.
-  if (
-    typeof peerCore === "string" &&
-    peerCore.length > 0 &&
-    !WORKSPACE_PROTOCOL_RE.test(peerCore)
-  ) {
+  const peerIsConcrete =
+    typeof peerCore === "string" && peerCore.length > 0 && !WORKSPACE_PROTOCOL_RE.test(peerCore);
+  if (peerIsConcrete) {
     if (peerCore !== effectiveRange) {
       issues.push({
         check: "core-version",
@@ -439,7 +449,114 @@ function checkCoreVersion(root: string): CapabilityLintIssue[] {
     }
   }
 
+  // 4. Satisfaction check — best-effort. When the local @linchkit/core version
+  //    is resolvable, every declared SEMVER range MUST satisfy it; a range that
+  //    excludes the only core version that exists is a skew bug (Spec 21 §10.1).
+  //    A `workspace:*` range resolves locally and is not a comparable semver, so
+  //    it is skipped (mirrors the equality check). If the version cannot be
+  //    resolved (e.g. linted standalone outside the monorepo), skip silently —
+  //    never throw, never fail the lint on resolution failure.
+  const localCoreVersion = resolveLocalCoreVersion(root);
+  if (localCoreVersion !== undefined) {
+    // Check the declared coreVersion/minCoreVersion range unless it is a
+    // non-semver workspace protocol specifier.
+    if (
+      !WORKSPACE_PROTOCOL_RE.test(effectiveRange) &&
+      !safeSatisfies(localCoreVersion, effectiveRange)
+    ) {
+      issues.push({
+        check: "core-version",
+        level: "error",
+        message: `Declared coreVersion range "${effectiveRange}" does not satisfy the current @linchkit/core version "${localCoreVersion}". Update the range to include it (Spec 21 §10.1).`,
+        file: "package.json",
+      });
+    }
+    // Also check the concrete peerDep range. When it equals the declared range
+    // (the common case) the check above already covered it, so only emit a
+    // distinct issue when the peerDep range differs and itself fails.
+    if (
+      peerIsConcrete &&
+      peerCore !== effectiveRange &&
+      !safeSatisfies(localCoreVersion, peerCore)
+    ) {
+      issues.push({
+        check: "core-version",
+        level: "error",
+        message: `peerDependencies["@linchkit/core"] range "${peerCore}" does not satisfy the current @linchkit/core version "${localCoreVersion}". Update the range to include it (Spec 21 §10.1).`,
+        file: "package.json",
+      });
+    }
+  }
+
   return issues;
+}
+
+/**
+ * Apply {@link satisfiesVersionRange} defensively. A malformed range must never
+ * crash the lint; on any thrown error treat the range as NON-satisfying is too
+ * aggressive (it would flag a clean addon on a parser quirk), so a throw is
+ * treated as "cannot determine" → satisfied (no error). This keeps the check
+ * best-effort and false-positive-averse.
+ */
+function safeSatisfies(version: string, range: string): boolean {
+  try {
+    return satisfiesVersionRange(version, range);
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Resolve the concrete local `@linchkit/core` version (e.g. "0.2.0"), best-effort.
+ *
+ * Strategy (in order):
+ *  1. Walk up from the capability dir to the monorepo root — the nearest ancestor
+ *     containing `packages/core/package.json` — and read its `.version`. This is
+ *     the authoritative source when the lint runs on an in-repo capability.
+ *  2. Fall back to Node-style module resolution of `@linchkit/core/package.json`
+ *     from the capability dir (handles a capability installed against a published
+ *     core outside the monorepo).
+ *
+ * Returns `undefined` when neither yields a usable version string. Never throws.
+ */
+function resolveLocalCoreVersion(root: string): string | undefined {
+  // 1. Walk up to the monorepo root (dir with packages/core/package.json).
+  let dir = root;
+  // Bound the walk by directory depth; resolve("/", "..") === "/" terminates it.
+  for (let i = 0; i < 64; i++) {
+    const candidate = join(dir, "packages", "core", "package.json");
+    if (existsSync(candidate)) {
+      const v = readVersionField(candidate);
+      if (v !== undefined) return v;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+
+  // 2. Fall back to Node-style module resolution of the installed @linchkit/core
+  //    manifest, anchored at the capability dir. Handles a capability installed
+  //    against a published core outside the monorepo.
+  try {
+    const req = createRequire(join(root, "package.json"));
+    const pkgPath = req.resolve("@linchkit/core/package.json");
+    const v = readVersionField(pkgPath);
+    if (v !== undefined) return v;
+  } catch {
+    // Module not resolvable from here — fall through to undefined.
+  }
+
+  return undefined;
+}
+
+/** Read and return the `.version` string field of a package.json, or undefined. */
+function readVersionField(packageJsonPath: string): string | undefined {
+  const parsed = readJson(packageJsonPath);
+  if (parsed.error || typeof parsed.value !== "object" || parsed.value === null) {
+    return undefined;
+  }
+  const version = (parsed.value as Record<string, unknown>).version;
+  return typeof version === "string" && version.length > 0 ? version : undefined;
 }
 
 interface DeclaredCoreVersion {

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -419,12 +419,16 @@ function checkCoreVersion(root: string): CapabilityLintIssue[] {
   }
 
   let effectiveRange: string;
+  // True when effectiveRange came from the deprecated `minCoreVersion`, which is
+  // a MINIMUM (">="), not an exact pin — used by the satisfaction check below.
+  let effectiveRangeIsMinimum = false;
   if (declared.coreVersion !== undefined) {
     effectiveRange = declared.coreVersion;
   } else {
     // Only the deprecated minCoreVersion is present — accept with a warning.
     // (declared.minCoreVersion is defined here per the guard above.)
     effectiveRange = declared.minCoreVersion as string;
+    effectiveRangeIsMinimum = true;
     issues.push({
       check: "core-version",
       level: "warning",
@@ -458,11 +462,21 @@ function checkCoreVersion(root: string): CapabilityLintIssue[] {
   //    never throw, never fail the lint on resolution failure.
   const localCoreVersion = resolveLocalCoreVersion(root);
   if (localCoreVersion !== undefined) {
+    // minCoreVersion is a MINIMUM (">="), not an exact pin. A BARE value such as
+    // "0.1.0" would otherwise be read as an exact-match comparator by
+    // satisfiesVersionRange, falsely rejecting any newer core (e.g. 0.2.0).
+    // Normalize a bare minimum to ">=x.y.z" for the satisfaction test. A bare
+    // `coreVersion` is intentionally left as exact-match — that field is meant
+    // to be a range, so an exact pin failing a newer core is a real declaration.
+    const satisfactionRange =
+      effectiveRangeIsMinimum && /^\d/.test(effectiveRange)
+        ? `>=${effectiveRange}`
+        : effectiveRange;
     // Check the declared coreVersion/minCoreVersion range unless it is a
     // non-semver workspace protocol specifier.
     if (
-      !WORKSPACE_PROTOCOL_RE.test(effectiveRange) &&
-      !safeSatisfies(localCoreVersion, effectiveRange)
+      !WORKSPACE_PROTOCOL_RE.test(satisfactionRange) &&
+      !safeSatisfies(localCoreVersion, satisfactionRange)
     ) {
       issues.push({
         check: "core-version",


### PR DESCRIPTION
## Summary

Fixes a real core-version skew bug surfaced by the #84 research, and adds the lint guard that would have caught it (#84 preparedness item 3).

### The bug
`cap-adapter-server` declared BOTH `peerDependencies["@linchkit/core"]` and `linchkit.coreVersion` as `">=0.3.0 <0.4.0"` — a range that **excludes the only published + local core version (0.2.0)**. An npm install of the addon against core 0.2.0 would fail peer resolution. Its 30 sibling addons all correctly declare `"^0.2.0"`.

The existing `checkCoreVersion` lint only compared the two declarations to **each other** for equality — both were `">=0.3.0 <0.4.0"`, so they matched and it passed. Nothing checked the range against the **actual** core version.

### Changes
1. **Fix**: cap-adapter-server core-version range `">=0.3.0 <0.4.0"` → `"^0.2.0"` (both fields).
2. **Guard**: `checkCoreVersion` (capability-lint) now verifies the declared `coreVersion` range (and a concrete peerDep range) actually **satisfies** the local `@linchkit/core` version.
   - Uses the in-house `satisfiesVersionRange` from `@linchkit/core` (already a devtools dep — no new dependency). Confirmed it handles the `">=x <y"` whitespace-AND-range form.
   - Resolves local core version by walking up to `packages/core/package.json` (require.resolve fallback); skips silently when unresolvable or `workspace:*` — best-effort, never throws.

### Verification
- `bun run check` / `bun run typecheck` clean
- Full `bun run test`: all batches PASS
- `bun test ./packages/devtools/ ./packages/cli/`: 473 pass / 0 fail
- **False-positive audit**: spot-checked all 31 addons — zero satisfaction false-positives (`^0.2.0` correctly satisfies `0.2.0` for every sibling); cap-adapter-server now reports zero core-version issues.

Part of #84 (preparedness model — defer the physical repo split, do readiness items now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated core framework dependency constraints from `>=0.3.0 <0.4.0` to `^0.2.0`.

* **Improvements**
  * Enhanced capability linting to validate core version satisfaction against locally resolvable versions, with improved error detection for version range mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->