### PR TITLE
feat(adapter-server,permission): wire AI trace sink at boot + admin read endpoint (Spec 69 P3 wave 2)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
@@ -165,6 +165,14 @@ describe("GET /api/ai/traces", () => {
     expect(json.success).toBe(false);
   });
 
+  test("rejects ?limit=0 with 400 (must be positive, never silently zero rows)", async () => {
+    seedTrace({ traceId: "a" });
+    const app = mountApp({ commandLayer: passLayer() });
+    const { status, json } = await getTraces(app, "?limit=0");
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
   test("treats an empty ?limit= as 'use the default' (not 0)", async () => {
     // Number("") is 0; an empty/bare limit param must fall back to the default
     // page size, not silently return zero traces.

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
@@ -142,6 +142,19 @@ describe("GET /api/ai/traces", () => {
     expect(json.success).toBe(false);
   });
 
+  test("treats an empty ?limit= as 'use the default' (not 0)", async () => {
+    // Number("") is 0; an empty/bare limit param must fall back to the default
+    // page size, not silently return zero traces.
+    seedTrace({ traceId: "a" });
+    seedTrace({ traceId: "b" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getTraces(app, "?limit=");
+
+    expect(status).toBe(200);
+    expect(json.data?.count).toBe(2);
+  });
+
   test("rejects an invalid ?origin= with 400", async () => {
     const app = mountApp({ commandLayer: passLayer() });
     const { status, json } = await getTraces(app, "?origin=bogus");

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
@@ -40,10 +40,19 @@ function passLayer(data: Record<string, unknown> = {}): CommandLayer {
   return { execute: async () => ({ success: true, data }) } as unknown as CommandLayer;
 }
 
-/** Denying command layer — simulates the permission slot rejecting the caller. */
+/**
+ * Denying command layer — mirrors the REAL permission-slot rejection shape:
+ * createPermissionMiddleware throws AuthorizationError({ code:"authz.action.denied" }),
+ * which CommandLayer propagates as `{ success:false, data:{ code:"authz.action.denied" } }`.
+ * Using the canonical code (not just an "not allowed" message) exercises the
+ * code→403 path in resolveStatusCode, not its text-matching fallback.
+ */
 function denyLayer(): CommandLayer {
   return {
-    execute: async () => ({ success: false, data: { error: "not allowed" } }),
+    execute: async () => ({
+      success: false,
+      data: { code: "authz.action.denied", error: "not allowed" },
+    }),
   } as unknown as CommandLayer;
 }
 
@@ -53,7 +62,10 @@ function spyLayer(): { layer: CommandLayer; calls: number } {
   const layer = {
     execute: async () => {
       state.calls += 1;
-      return { success: false as const, data: { error: "not allowed" } };
+      return {
+        success: false as const,
+        data: { code: "authz.action.denied", error: "not allowed" },
+      };
     },
   } as unknown as CommandLayer;
   return {

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
@@ -1,0 +1,216 @@
+/**
+ * AI trace read endpoint tests — GET /api/ai/traces (Spec 69 P3 wave 2).
+ *
+ * Pins the read side of the trace persistence wired at boot:
+ *   - traces seeded into the active sink are surfaced (most-recent-first),
+ *   - `?limit=` is honoured + capped,
+ *   - query-param validation rejects bad limit/origin/status,
+ *   - the CommandLayer permission slot is NEVER skipped: a denying layer 403s
+ *     with the canonical AUTHZ_DENIED envelope and the sink is not consulted,
+ *   - the tenant slot's resolved tenantId scopes the query (a scoped operator
+ *     cannot read across tenants).
+ *
+ * Endpoint dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ * `app.listen(PORT)` is intentionally avoided — a bound socket per suite SEGFAULTS
+ * the batched addons run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { CommandLayer } from "@linchkit/core";
+import {
+  getAITraceSink,
+  InMemoryAITraceStore,
+  resetAITraceSink,
+  setAITraceSink,
+} from "@linchkit/core/server";
+import { Elysia } from "elysia";
+import { mountAITracesRoutes } from "../src/routes/ai-traces-api";
+import type { ServerOptions } from "../src/server";
+
+const BASE = "http://local.test";
+
+interface TracesJson {
+  success: boolean;
+  data?: { traces?: Array<{ traceId: string; tenantId?: string }>; count?: number };
+  error?: { code?: string; message?: string };
+}
+
+/** Permissive command layer; `data` carries the synthetic tenant slot result. */
+function passLayer(data: Record<string, unknown> = {}): CommandLayer {
+  return { execute: async () => ({ success: true, data }) } as unknown as CommandLayer;
+}
+
+/** Denying command layer — simulates the permission slot rejecting the caller. */
+function denyLayer(): CommandLayer {
+  return {
+    execute: async () => ({ success: false, data: { error: "not allowed" } }),
+  } as unknown as CommandLayer;
+}
+
+/** Records each dispatch so we can prove the sink is NOT consulted when denied. */
+function spyLayer(): { layer: CommandLayer; calls: number } {
+  const state = { calls: 0 };
+  const layer = {
+    execute: async () => {
+      state.calls += 1;
+      return { success: false as const, data: { error: "not allowed" } };
+    },
+  } as unknown as CommandLayer;
+  return {
+    layer,
+    get calls() {
+      return state.calls;
+    },
+  };
+}
+
+function mountApp(opts: { commandLayer?: CommandLayer }): Elysia {
+  const app = new Elysia();
+  mountAITracesRoutes(app, { commandLayer: opts.commandLayer } as unknown as ServerOptions);
+  return app;
+}
+
+async function getTraces(app: Elysia, qs = ""): Promise<{ status: number; json: TracesJson }> {
+  const res = await app.handle(new Request(`${BASE}/api/ai/traces${qs}`));
+  return { status: res.status, json: (await res.json()) as TracesJson };
+}
+
+/** Seed a trace + a single generation so the parent trace exists in the sink. */
+function seedTrace(opts: { traceId: string; tenantId?: string; model?: string }): void {
+  const sink = getAITraceSink();
+  const now = Date.now();
+  sink.startTrace({ traceId: opts.traceId, name: opts.model ?? "fast", tenantId: opts.tenantId });
+  sink.recordGeneration({
+    traceId: opts.traceId,
+    model: opts.model ?? "fast",
+    provider: "test",
+    messages: [{ role: "user", content: "hi" }],
+    completion: "hello",
+    inputTokens: 3,
+    outputTokens: 5,
+    latencyMs: 12,
+    status: "ok",
+    startedAt: now,
+    endedAt: now + 12,
+    tenantId: opts.tenantId,
+    redaction: { mode: "none" },
+  });
+}
+
+describe("GET /api/ai/traces", () => {
+  beforeEach(() => {
+    // Fresh in-memory sink per test so seeded traces don't leak across cases or
+    // across the batched addons run (which shares the module singleton).
+    setAITraceSink(new InMemoryAITraceStore());
+  });
+
+  afterEach(() => {
+    resetAITraceSink();
+  });
+
+  test("returns seeded traces, most-recent-first, with a count", async () => {
+    seedTrace({ traceId: "t1" });
+    seedTrace({ traceId: "t2" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getTraces(app);
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.count).toBe(2);
+    // Most-recent-first: t2 was seeded last → it is first.
+    expect(json.data?.traces?.map((t) => t.traceId)).toEqual(["t2", "t1"]);
+  });
+
+  test("honours ?limit= (caps the result set)", async () => {
+    seedTrace({ traceId: "a" });
+    seedTrace({ traceId: "b" });
+    seedTrace({ traceId: "c" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getTraces(app, "?limit=2");
+
+    expect(status).toBe(200);
+    expect(json.data?.count).toBe(2);
+    expect(json.data?.traces?.map((t) => t.traceId)).toEqual(["c", "b"]);
+  });
+
+  test("rejects an invalid ?limit= with 400", async () => {
+    const app = mountApp({ commandLayer: passLayer() });
+    const { status, json } = await getTraces(app, "?limit=-1");
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
+  test("rejects an invalid ?origin= with 400", async () => {
+    const app = mountApp({ commandLayer: passLayer() });
+    const { status, json } = await getTraces(app, "?origin=bogus");
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
+  test("rejects an invalid ?status= with 400", async () => {
+    const app = mountApp({ commandLayer: passLayer() });
+    const { status, json } = await getTraces(app, "?status=weird");
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
+  test("command layer absent → 503 (cannot authorize, fail closed)", async () => {
+    seedTrace({ traceId: "x" });
+    const app = mountApp({ commandLayer: undefined });
+    const { status, json } = await getTraces(app);
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+  });
+
+  test("unauthorized caller → 403 canonical AUTHZ_DENIED; sink NOT consulted", async () => {
+    seedTrace({ traceId: "secret" });
+    const spy = spyLayer();
+    const app = mountApp({ commandLayer: spy.layer });
+
+    const { status, json } = await getTraces(app);
+
+    expect(status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+    // No trace data leaked in the denied response.
+    expect(json.data).toBeUndefined();
+    // Permission slot ran (and denied) — exactly one dispatch, no second attempt.
+    expect(spy.calls).toBe(1);
+  });
+
+  test("denying layer just blocks (separate denyLayer helper) → 403", async () => {
+    seedTrace({ traceId: "y" });
+    const app = mountApp({ commandLayer: denyLayer() });
+    const { status, json } = await getTraces(app);
+    expect(status).toBe(403);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+  });
+
+  test("tenant slot's resolved tenantId scopes the query (no cross-tenant read)", async () => {
+    seedTrace({ traceId: "ta", tenantId: "tenant-a" });
+    seedTrace({ traceId: "tb", tenantId: "tenant-b" });
+    // The tenant slot pinned tenant-a; a scoped operator must see only tenant-a.
+    const app = mountApp({ commandLayer: passLayer({ tenantId: "tenant-a" }) });
+
+    const { status, json } = await getTraces(app, "?tenantId=tenant-b");
+
+    expect(status).toBe(200);
+    // The ?tenantId=tenant-b param is IGNORED — the resolved pin always wins.
+    expect(json.data?.count).toBe(1);
+    expect(json.data?.traces?.[0]?.traceId).toBe("ta");
+    expect(json.data?.traces?.[0]?.tenantId).toBe("tenant-a");
+  });
+
+  test("unscoped (admin) caller sees all tenants", async () => {
+    seedTrace({ traceId: "ua", tenantId: "tenant-a" });
+    seedTrace({ traceId: "ub", tenantId: "tenant-b" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getTraces(app);
+
+    expect(status).toBe(200);
+    expect(json.data?.count).toBe(2);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-api.test.ts
@@ -64,6 +64,29 @@ function spyLayer(): { layer: CommandLayer; calls: number } {
   };
 }
 
+/**
+ * Replace the active sink's READ methods with traps that count + throw, so a
+ * denied request that wrongly consulted the sink is provable: queryCalls would
+ * be > 0 AND the response would become 500 (the throw) instead of the asserted
+ * 403. Proves the permission slot gates BEFORE any sink access.
+ */
+function trapSinkQueries(): { queryCalls: number } {
+  const sink = getAITraceSink() as unknown as {
+    queryTraces: (...a: unknown[]) => unknown;
+    queryTracesPersisted?: (...a: unknown[]) => unknown;
+  };
+  const state = { queryCalls: 0 };
+  sink.queryTraces = () => {
+    state.queryCalls += 1;
+    throw new Error("sink.queryTraces must not be reached on a denied request");
+  };
+  sink.queryTracesPersisted = () => {
+    state.queryCalls += 1;
+    throw new Error("sink.queryTracesPersisted must not be reached on a denied request");
+  };
+  return state;
+}
+
 function mountApp(opts: { commandLayer?: CommandLayer }): Elysia {
   const app = new Elysia();
   mountAITracesRoutes(app, { commandLayer: opts.commandLayer } as unknown as ServerOptions);
@@ -179,6 +202,7 @@ describe("GET /api/ai/traces", () => {
 
   test("unauthorized caller → 403 canonical AUTHZ_DENIED; sink NOT consulted", async () => {
     seedTrace({ traceId: "secret" });
+    const trap = trapSinkQueries();
     const spy = spyLayer();
     const app = mountApp({ commandLayer: spy.layer });
 
@@ -191,6 +215,9 @@ describe("GET /api/ai/traces", () => {
     expect(json.data).toBeUndefined();
     // Permission slot ran (and denied) — exactly one dispatch, no second attempt.
     expect(spy.calls).toBe(1);
+    // The sink's read methods were never reached on the denied path (a query
+    // would have counted here AND turned the 403 into a 500 via the trap throw).
+    expect(trap.queryCalls).toBe(0);
   });
 
   test("denying layer just blocks (separate denyLayer helper) → 403", async () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/wire-ai-trace-sink.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/wire-ai-trace-sink.test.ts
@@ -79,14 +79,11 @@ describe("wireAITraceSink — boot wiring", () => {
     expect(getAITraceSink()).toBeInstanceOf(InMemoryAITraceStore);
   });
 
-  it("never throws and leaves the previous sink when the provider .db access explodes", async () => {
-    // Seed a known sink, then feed a provider whose `db` getter throws. The helper
-    // must swallow the error and leave the seeded sink untouched (never crash boot).
-    const seeded = new InMemoryAITraceStore();
-    // Use setAITraceSink via wiring a clean InMemory first, then assert it stays.
-    await wireAITraceSink({ dataProvider: new InMemoryStore() });
-    const before = getAITraceSink();
-    expect(before).toBeInstanceOf(InMemoryAITraceStore);
+  it("never throws and leaves the prior (noop) sink when the provider .db access explodes", async () => {
+    // From the Noop default, a provider whose `db` getter throws must be
+    // swallowed — boot never crashes and the sink is left as-is.
+    resetAITraceSink();
+    expect(getAITraceSink()).toBeInstanceOf(NoopAITraceSink);
 
     const explodingProvider = {
       get db() {
@@ -94,14 +91,22 @@ describe("wireAITraceSink — boot wiring", () => {
       },
     } as unknown as InMemoryStore;
 
-    // Should not throw. extractDbHandle reads `.db` inside the try, so the throw
-    // is caught and the prior sink is preserved.
+    // extractDbHandle reads `.db` inside the try, so the throw is caught and the
+    // prior (noop) sink is preserved.
     const result = await wireAITraceSink({ dataProvider: explodingProvider });
     expect(result).toBeUndefined();
-    // Prior sink preserved (still an InMemory store, not swapped to noop/crashed).
-    expect(getAITraceSink()).toBe(before);
-    // `seeded` is unused as the active sink — only asserts construction is cheap.
-    expect(seeded).toBeInstanceOf(InMemoryAITraceStore);
+    expect(getAITraceSink()).toBeInstanceOf(NoopAITraceSink);
+  });
+
+  it("is idempotent — a second call returns the already-wired sink, not a new one", async () => {
+    resetAITraceSink();
+    const first = await wireAITraceSink({ dataProvider: new InMemoryStore() });
+    expect(first).toBeInstanceOf(InMemoryAITraceStore);
+    // A second call must NOT construct a second sink (which would orphan the
+    // first and drop its pending mirror writes) — it returns the existing one.
+    const second = await wireAITraceSink({ dataProvider: new InMemoryStore() });
+    expect(second).toBe(first);
+    expect(getAITraceSink()).toBe(first);
   });
 
   it("extractDbHandle returns undefined for InMemoryStore", () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/wire-ai-trace-sink.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/wire-ai-trace-sink.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Boot-wiring test for the AI trace sink (Spec 69 P3 wave 2).
+ *
+ * Proves the helper the real boot paths (`dev.ts` + `http-transport.ts`) call:
+ *   - with NO db handle (InMemoryStore / no DATABASE_URL) → the active sink is an
+ *     `InMemoryAITraceStore`, NOT the discarding `NoopAITraceSink` default,
+ *   - with a Drizzle-backed provider (DATABASE_URL set) → the active sink is a
+ *     `DrizzleAITraceStore` so traces are durably mirrored to PostgreSQL,
+ *   - `extractDbHandle` reuses the provider's existing db handle (no second pool),
+ *   - wiring is non-throwing: a provider that explodes on `.db` access leaves the
+ *     previous sink in place rather than crashing boot.
+ *
+ * The DB-mode assertion is gated on a reachable PostgreSQL (skips gracefully in CI
+ * without PG, RUNS where the `postgres` service is provided), mirroring the
+ * established DrizzleAITraceStore integration-test idiom.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { DrizzleAITraceStore } from "@linchkit/cap-ai-provider";
+import {
+  closeDatabase,
+  createDatabase,
+  DrizzleDataProvider,
+  getAITraceSink,
+  InMemoryAITraceStore,
+  InMemoryStore,
+  NoopAITraceSink,
+  resetAITraceSink,
+  TableRegistry,
+} from "@linchkit/core/server";
+import { sql } from "drizzle-orm";
+import { extractDbHandle, wireAITraceSink } from "../src/wire-ai-trace-sink";
+
+const DATABASE_URL =
+  process.env.DATABASE_TEST_URL ??
+  "postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test";
+
+async function canConnect(): Promise<boolean> {
+  try {
+    const testDb = createDatabase({ url: DATABASE_URL });
+    await testDb.execute(sql`SELECT 1`);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      await closeDatabase();
+    } catch {
+      // Ignore — probe pool may already be closed.
+    }
+  }
+}
+
+const dbAvailable = await canConnect();
+if (!dbAvailable) {
+  console.warn("PostgreSQL not available, skipping wire-ai-trace-sink DB-mode test");
+}
+
+describe("wireAITraceSink — boot wiring", () => {
+  afterEach(() => {
+    resetAITraceSink();
+  });
+
+  it("no db handle → registers InMemoryAITraceStore (not the Noop default)", async () => {
+    // Default sink is Noop until wired — assert the wiring flips it.
+    resetAITraceSink();
+    expect(getAITraceSink()).toBeInstanceOf(NoopAITraceSink);
+
+    const sink = await wireAITraceSink({ dataProvider: new InMemoryStore() });
+
+    expect(sink).toBeInstanceOf(InMemoryAITraceStore);
+    expect(getAITraceSink()).toBeInstanceOf(InMemoryAITraceStore);
+    expect(getAITraceSink()).not.toBeInstanceOf(NoopAITraceSink);
+  });
+
+  it("no provider at all → still registers InMemoryAITraceStore", async () => {
+    const sink = await wireAITraceSink();
+    expect(sink).toBeInstanceOf(InMemoryAITraceStore);
+    expect(getAITraceSink()).toBeInstanceOf(InMemoryAITraceStore);
+  });
+
+  it("never throws and leaves the previous sink when the provider .db access explodes", async () => {
+    // Seed a known sink, then feed a provider whose `db` getter throws. The helper
+    // must swallow the error and leave the seeded sink untouched (never crash boot).
+    const seeded = new InMemoryAITraceStore();
+    // Use setAITraceSink via wiring a clean InMemory first, then assert it stays.
+    await wireAITraceSink({ dataProvider: new InMemoryStore() });
+    const before = getAITraceSink();
+    expect(before).toBeInstanceOf(InMemoryAITraceStore);
+
+    const explodingProvider = {
+      get db() {
+        throw new Error("boom");
+      },
+    } as unknown as InMemoryStore;
+
+    // Should not throw. extractDbHandle reads `.db` inside the try, so the throw
+    // is caught and the prior sink is preserved.
+    const result = await wireAITraceSink({ dataProvider: explodingProvider });
+    expect(result).toBeUndefined();
+    // Prior sink preserved (still an InMemory store, not swapped to noop/crashed).
+    expect(getAITraceSink()).toBe(before);
+    // `seeded` is unused as the active sink — only asserts construction is cheap.
+    expect(seeded).toBeInstanceOf(InMemoryAITraceStore);
+  });
+
+  it("extractDbHandle returns undefined for InMemoryStore", () => {
+    expect(extractDbHandle(new InMemoryStore())).toBeUndefined();
+    expect(extractDbHandle(undefined)).toBeUndefined();
+  });
+
+  it.skipIf(!dbAvailable)(
+    "db handle present → registers DrizzleAITraceStore (durable PG mirror)",
+    async () => {
+      const db = createDatabase({ url: DATABASE_URL });
+      const provider = new DrizzleDataProvider(db, new TableRegistry());
+
+      // extractDbHandle reuses the SAME db object the provider holds (no 2nd pool).
+      expect(extractDbHandle(provider)).toBe(db);
+
+      const sink = await wireAITraceSink({ dataProvider: provider });
+
+      expect(sink).toBeInstanceOf(DrizzleAITraceStore);
+      expect(getAITraceSink()).toBeInstanceOf(DrizzleAITraceStore);
+      expect(getAITraceSink()).not.toBeInstanceOf(NoopAITraceSink);
+
+      await closeDatabase();
+    },
+  );
+});

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -12,6 +12,7 @@ import { assembleDevSchema } from "./assemble-schema";
 import { loadConfig } from "./config-loader";
 import { buildDevEvolutionRuntime, buildDevOntologyRegistry } from "./dev-app";
 import { createServer } from "./server";
+import { wireAITraceSink } from "./wire-ai-trace-sink";
 
 // ── Resolve project root ────────────────────────────────
 // When run via `bun run --filter` in a workspace, CWD is the package
@@ -129,6 +130,15 @@ consoleLogger.info(
   `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered ` +
     "(insight→proposal translator + pre-analysis pipeline wired)",
 );
+
+// AI trace sink (Spec 69 P3 wave 2) — register a LIVE sink so the AI
+// instrumentation's `getAITraceSink().recordGeneration(...)` calls are actually
+// persisted instead of discarded by the Noop default. DB mode → DrizzleAITraceStore
+// (durable PG mirror); no DATABASE_URL → InMemoryAITraceStore (in-process only).
+// Non-throwing: a wiring failure logs + leaves the prior sink in place, never
+// crashing boot. On the dev path the dataProvider is the in-memory store unless a
+// DATABASE_URL-backed provider was injected, so this is InMemory here by default.
+await wireAITraceSink({ dataProvider: runtime.dataProvider });
 
 const port = config.server?.port ?? 3001;
 const host = config.server?.host ?? "0.0.0.0";

--- a/addons/adapter-server/cap-adapter-server/src/http-transport.ts
+++ b/addons/adapter-server/cap-adapter-server/src/http-transport.ts
@@ -14,6 +14,7 @@ import {
   resolveCadenceIntervalMs,
   resolveCadenceTenantIds,
 } from "./evolution-scheduler-wiring";
+import { wireAITraceSink } from "./wire-ai-trace-sink";
 
 export function resolveRequestTenantId(request: Request, actor?: Actor): string | undefined {
   // Prefer tenant from verified actor (auth middleware already validated the JWT).
@@ -63,6 +64,15 @@ export async function createHttpTransport(ctx: TransportContext): Promise<Transp
         executionLogger: ctx.executionLogger,
       })
     : undefined;
+
+  // AI trace sink (Spec 69 P3 wave 2) — register a LIVE sink so the AI
+  // instrumentation's `getAITraceSink().recordGeneration(...)` calls are actually
+  // persisted in the real serving path (NOT dev-only). When `ctx.dataProvider` is a
+  // DrizzleDataProvider (DATABASE_URL set) its db handle is reused for a durable
+  // DrizzleAITraceStore; otherwise (InMemoryStore fallback) an InMemoryAITraceStore
+  // is wired. Non-throwing: a wiring failure logs + leaves the prior sink in place,
+  // never aborting transport startup.
+  await wireAITraceSink({ dataProvider: ctx.dataProvider });
 
   // Generate CRUD actions for each business schema (skip internal)
   const crudOpts = ctx.derivedPropertyEngine

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
@@ -1,0 +1,203 @@
+/**
+ * AI trace admin read endpoint (Spec 69 Phase 3 wave 2).
+ *
+ * GET /api/ai/traces — recent AI traces from the active {@link getAITraceSink}.
+ *
+ * This is the read side of the trace persistence wired at boot
+ * (`wire-ai-trace-sink.ts`): the AI instrumentation records every generation into
+ * the registered sink, and this endpoint surfaces the rolled-up parent traces for
+ * an operator / admin UI.
+ *
+ * Permission (CLAUDE.md: "All API endpoints go through CommandLayer (permission slot
+ * never skipped)"): like the onchange (Spec 64) and evolution run-cycle (Spec 55 §7)
+ * routes, the request first passes through CommandLayer with `skipActionSlots = true`
+ * so auth / permission / tenant slots still run while the action-specific slots are
+ * bypassed (there is no write action). The authoritative permission target is carried
+ * in `meta.aiObservability = { operation: "read_traces" }`, which the permission
+ * middleware gates on `grant.ai.actions.read_traces` (companion to `meta.evolution`).
+ *
+ * Tenant scoping: the tenant the CommandLayer tenant slot resolved is forwarded into
+ * the trace query so a tenant-scoped operator never sees another tenant's traces. An
+ * unscoped (admin) caller sees all tenants. Query params (`limit`, `tenantId`,
+ * `scenario`, `origin`, `status`, `model`) are validated/clamped; `limit` has a sane
+ * default and hard cap. The body is never read — this is a GET.
+ *
+ * Reads through the sink's DURABLE async query when available (the Drizzle store
+ * exposes `queryTracesPersisted`, serving history that survived a restart) and falls
+ * back to the synchronous process-local hot view (`queryTraces`) otherwise.
+ */
+
+import type { AITrace, AITraceOrigin, AITraceQueryOptions, AITraceStatus } from "@linchkit/core";
+import { getAITraceSink } from "@linchkit/core/server";
+import type { Elysia } from "elysia";
+import type { ServerOptions } from "../server";
+import { badRequest, resolveActor, resolveStatusCode, serviceUnavailable } from "./shared";
+
+/**
+ * Canonical authorization-denied envelope — every 401/403 path returns the SAME
+ * payload so the response text cannot be used as a side channel.
+ */
+const AUTHZ_DENIED_BODY = {
+  success: false as const,
+  error: {
+    code: "AUTHZ_DENIED",
+    message: "Access denied",
+  },
+} as const;
+
+/** Synthetic command name for the trace-read dispatch (metrics/tracing only). */
+export const READ_TRACES_COMMAND_NAME = "ai.read_traces";
+
+/** Permission operation gated as `grant.ai.actions.<operation>`. */
+export const READ_TRACES_OPERATION = "read_traces";
+
+/** Default page size when `?limit=` is absent. */
+const DEFAULT_TRACE_LIMIT = 50;
+/** Hard cap on `?limit=` — protects the durable query from unbounded scans. */
+const MAX_TRACE_LIMIT = 500;
+
+const VALID_ORIGINS: ReadonlySet<string> = new Set<AITraceOrigin>(["production", "eval"]);
+const VALID_STATUSES: ReadonlySet<string> = new Set<AITraceStatus>(["ok", "error", "partial"]);
+
+/**
+ * A sink that additionally exposes the async durable trace query (the Drizzle
+ * store). Structural — we don't import the concrete class so cap-adapter-server
+ * keeps only a lazy dependency on cap-ai-provider.
+ */
+interface PersistedTraceReader {
+  queryTracesPersisted(options?: AITraceQueryOptions): Promise<AITrace[]>;
+}
+
+function hasPersistedReader(sink: unknown): sink is PersistedTraceReader {
+  return (
+    typeof sink === "object" &&
+    sink !== null &&
+    typeof (sink as { queryTracesPersisted?: unknown }).queryTracesPersisted === "function"
+  );
+}
+
+/**
+ * Mount `GET /api/ai/traces` onto the given Elysia app.
+ *
+ * Behavior summary:
+ *   400 — invalid `?limit=` / `?origin=` / `?status=` query param.
+ *   503 — command layer not configured (cannot run the permission slot, fail closed).
+ *   401/403 — caller failed the CommandLayer permission slot (canonical envelope).
+ *   200 — `{ success: true, data: { traces, count } }` (most-recent-first).
+ */
+export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
+  const { commandLayer } = options;
+
+  app.get("/api/ai/traces", async ({ query, set, request }) => {
+    if (!commandLayer) {
+      // The permission slot lives in CommandLayer; without it we cannot authorize
+      // the read, so fail closed rather than skipping the slot.
+      return serviceUnavailable(
+        set,
+        "Command layer is not configured — cannot authorize the AI trace read.",
+      );
+    }
+
+    // ── Validate + clamp query params BEFORE auth-touching work ──────────
+    // (cheap input validation; nothing is leaked because we 400 the same way
+    // regardless of authorization — the values aren't tenant data.)
+    let limit = DEFAULT_TRACE_LIMIT;
+    if (query.limit !== undefined) {
+      const parsed = Number(query.limit);
+      if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+        return badRequest(set, "Invalid 'limit' — must be a non-negative integer.");
+      }
+      limit = Math.min(parsed, MAX_TRACE_LIMIT);
+    }
+
+    const origin = query.origin as string | undefined;
+    if (origin !== undefined && !VALID_ORIGINS.has(origin)) {
+      return badRequest(set, "Invalid 'origin' — must be 'production' or 'eval'.");
+    }
+    const status = query.status as string | undefined;
+    if (status !== undefined && !VALID_STATUSES.has(status)) {
+      return badRequest(set, "Invalid 'status' — must be 'ok', 'error', or 'partial'.");
+    }
+
+    // ── Permission slot (CommandLayer, skipActionSlots) ──────────────────
+    // Run auth / permission / tenant BEFORE touching the sink so an unauthorized
+    // caller learns nothing about which traces exist.
+    const actor = await resolveActor(request, options.resolveRequestActor);
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+    const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
+
+    const commandResult = await commandLayer.execute({
+      command: READ_TRACES_COMMAND_NAME,
+      input: {},
+      actor,
+      channel: "http",
+      headers,
+      traceId: incomingTraceId,
+      meta: {
+        // Permission middleware gates on `grant.ai.actions.read_traces` rather
+        // than an action named "read_traces". Mirrors the run-cycle route's
+        // `meta.evolution` convention (Spec 69 P3 / companion to #527/#528).
+        aiObservability: { operation: READ_TRACES_OPERATION },
+      },
+      skipActionSlots: true,
+    });
+
+    if (!commandResult.success) {
+      const statusCode = resolveStatusCode(commandResult);
+      set.status = statusCode;
+      if (statusCode === 401 || statusCode === 403) {
+        return AUTHZ_DENIED_BODY;
+      }
+      const errData = commandResult.data as Record<string, unknown> | undefined;
+      const middlewareMessage = (errData?.error as string) ?? "AI trace read blocked";
+      const middlewareCode = (errData?.code as string) ?? "AI.READ_TRACES.BLOCKED";
+      return { success: false, error: { code: middlewareCode, message: middlewareMessage } };
+    }
+
+    // ── Resolve tenant scope from the tenant slot ────────────────────────
+    // The skipActionSlots dispatch returns the tenant the tenant slot resolved on
+    // `data.tenantId`. When the caller is unscoped (admin) it is undefined → all
+    // tenants. A `?tenantId=` query param can only NARROW within the resolved
+    // scope: when the tenant slot pinned a tenant, that pin always wins so a
+    // scoped operator can never read across tenants by passing a foreign id.
+    const resolvedTenantId = (commandResult.data as { tenantId?: string } | undefined)?.tenantId;
+    const queryTenantParam =
+      typeof query.tenantId === "string" && query.tenantId.length > 0 ? query.tenantId : undefined;
+    const tenantId = resolvedTenantId ?? queryTenantParam;
+
+    // ── Query the sink ───────────────────────────────────────────────────
+    const queryOptions: AITraceQueryOptions = {
+      limit,
+      ...(tenantId !== undefined ? { tenantId } : {}),
+      ...(origin !== undefined ? { origin: origin as AITraceOrigin } : {}),
+      ...(status !== undefined ? { status: status as AITraceStatus } : {}),
+      ...(typeof query.scenario === "string" && query.scenario.length > 0
+        ? { scenario: query.scenario }
+        : {}),
+      ...(typeof query.model === "string" && query.model.length > 0 ? { model: query.model } : {}),
+    };
+
+    try {
+      const sink = getAITraceSink();
+      // Prefer the durable async query (Drizzle store) so the endpoint serves
+      // history that survived a restart; fall back to the sync process-local
+      // hot view for the in-memory / noop sinks.
+      const traces = hasPersistedReader(sink)
+        ? await sink.queryTracesPersisted(queryOptions)
+        : sink.queryTraces(queryOptions);
+      return { success: true, data: { traces, count: traces.length } };
+    } catch (err) {
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Failed to query AI traces."
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      set.status = 500;
+      return { success: false, error: { message } };
+    }
+  });
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
@@ -28,7 +28,7 @@
  */
 
 import type { AITrace, AITraceOrigin, AITraceQueryOptions, AITraceStatus } from "@linchkit/core";
-import { getAITraceSink } from "@linchkit/core/server";
+import { consoleLogger, getAITraceSink } from "@linchkit/core/server";
 import type { Elysia } from "elysia";
 import type { ServerOptions } from "../server";
 import { badRequest, resolveActor, resolveStatusCode, serviceUnavailable } from "./shared";
@@ -102,7 +102,10 @@ export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
     // (cheap input validation; nothing is leaked because we 400 the same way
     // regardless of authorization — the values aren't tenant data.)
     let limit = DEFAULT_TRACE_LIMIT;
-    if (query.limit !== undefined) {
+    // Treat an absent OR empty (`?limit=` / bare `?limit`) param as "use the
+    // default". Number("") is 0, which would otherwise pass the non-negative
+    // check below and silently return zero traces.
+    if (query.limit !== undefined && String(query.limit).trim() !== "") {
       const parsed = Number(query.limit);
       if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
         return badRequest(set, "Invalid 'limit' — must be a non-negative integer.");
@@ -190,6 +193,11 @@ export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
         : sink.queryTraces(queryOptions);
       return { success: true, data: { traces, count: traces.length } };
     } catch (err) {
+      // Always log the real error server-side; only the CLIENT-facing message is
+      // redacted in production (the raw text could leak query/schema detail).
+      consoleLogger.error(
+        `[ai-traces] query failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
       const message =
         process.env.NODE_ENV === "production"
           ? "Failed to query AI traces."

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
@@ -103,12 +103,14 @@ export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
     // regardless of authorization — the values aren't tenant data.)
     let limit = DEFAULT_TRACE_LIMIT;
     // Treat an absent OR empty (`?limit=` / bare `?limit`) param as "use the
-    // default". Number("") is 0, which would otherwise pass the non-negative
-    // check below and silently return zero traces.
+    // default". A provided value must be a POSITIVE integer: `limit < 1` is
+    // rejected (400) — including `?limit=0`, which would otherwise pass and
+    // silently return zero traces (Number("") is also 0, already short-circuited
+    // by the empty-string check above).
     if (query.limit !== undefined && String(query.limit).trim() !== "") {
       const parsed = Number(query.limit);
-      if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
-        return badRequest(set, "Invalid 'limit' — must be a non-negative integer.");
+      if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1) {
+        return badRequest(set, "Invalid 'limit' — must be a positive integer.");
       }
       limit = Math.min(parsed, MAX_TRACE_LIMIT);
     }

--- a/addons/adapter-server/cap-adapter-server/src/routes/mount-core-routes.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/mount-core-routes.ts
@@ -1,0 +1,68 @@
+/**
+ * Core route-module mounting, extracted from `server.ts` to keep that
+ * entrypoint under the repo's 500-line ceiling. These are the order-sensitive,
+ * closure-free route mounts — each takes only `(app, opts)` (plus
+ * `serverStartedAt` for admin). The remaining mounts that close over server-
+ * local state (overlay → schema hot-reload, graphql-yoga, deploy, proposal /
+ * evolution / subscription) stay inline in `server.ts`.
+ *
+ * Mount ORDER is significant and preserved verbatim from the original site:
+ *  - health AFTER admin so the canonical `/health` (Spec 12) overrides any
+ *    duplicate admin handler;
+ *  - resolveIntent AFTER the AI routes so the canonical handler wins routing.
+ */
+
+import type { Elysia } from "elysia";
+import type { ServerOptions } from "../server";
+import { mountActionRoutes } from "./action-api";
+import { mountAdminRoutes } from "./admin-api";
+import { mountAgUiRoutes } from "./agui-api";
+import { mountAIRoutes } from "./ai-api";
+import { mountAIByokRoutes } from "./ai-byok";
+import { mountResolveIntentRoute } from "./ai-resolve-intent";
+import { mountResolveSchemaIntentRoute } from "./ai-resolve-schema-intent";
+import { mountAITracesRoutes } from "./ai-traces-api";
+import { mountApprovalRoutes } from "./approval-api";
+import { mountConfigRoutes } from "./config-api";
+import { mountConfigStoreRoutes } from "./config-store-api";
+import { mountEntityRoutes } from "./entity-api";
+import { mountHealthRoutes } from "./health";
+import { mountImportRoutes } from "./import-api";
+import { mountOnchangeRoutes } from "./onchange-api";
+import { mountTranslationRoutes } from "./translation-api";
+
+/** Mount the order-sensitive, closure-free core route modules onto `app`. */
+export function mountCoreRoutes(app: Elysia, opts: ServerOptions, serverStartedAt: number): void {
+  mountAdminRoutes(app, opts, serverStartedAt);
+  // Mounted AFTER admin so the canonical, minimal `/health` (Spec 12 — liveness)
+  // overrides any duplicate handler in admin-api.ts. `/ready` is exclusive to
+  // this module.
+  mountHealthRoutes(app, opts);
+  mountEntityRoutes(app, opts);
+  mountActionRoutes(app, opts);
+  mountImportRoutes(app, opts);
+  mountApprovalRoutes(app, opts);
+  mountConfigRoutes(app, opts);
+  mountConfigStoreRoutes(app, opts);
+  mountAIRoutes(app, opts);
+  // AG-UI protocol run endpoint (#89) — only mounts when cap-adapter-ag-ui
+  // is registered in the capability list. Bridges the same assistant brain
+  // as POST /api/ai/chat onto official AG-UI events over SSE.
+  mountAgUiRoutes(app, opts);
+  // Spec 36 M2+ BYOK + usage endpoints (per-tenant key store + meter).
+  // Mounted alongside the other AI routes; no-ops when the store /
+  // meter are not configured (returns 503 with a structured envelope).
+  mountAIByokRoutes(app, opts);
+  // Spec 52 §2.6 canonical intent-resolution endpoint. Mounted AFTER
+  // mountAIRoutes so the canonical handler (with permission scoping +
+  // audit logging) wins routing for `POST /api/ai/resolve-intent` if any
+  // legacy handler is left in the file.
+  mountResolveIntentRoute(app, opts);
+  // Spec 69 P3 wave 2 — admin read of recent AI traces (`GET /api/ai/traces`),
+  // permission-gated through CommandLayer (`meta.aiObservability`).
+  mountAITracesRoutes(app, opts);
+  // Spec 52 "说→有" first slice — NL utterance → governed `add_rule` ProposalDraft.
+  mountResolveSchemaIntentRoute(app, opts);
+  mountTranslationRoutes(app, opts);
+  mountOnchangeRoutes(app, opts, opts.onchangeEvaluator);
+}

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -54,28 +54,13 @@ import { createRelationDataLoaders } from "./graphql/relation-dataloader";
 import { mountProposalAPI } from "./proposal-api";
 import { mountProposalGraduateAPI } from "./proposal-graduate-api";
 import { mountProposalMaterializeAPI } from "./proposal-materialize-api";
-import { mountActionRoutes } from "./routes/action-api";
-import { mountAdminRoutes } from "./routes/admin-api";
-import { mountAgUiRoutes } from "./routes/agui-api";
-import { mountAIRoutes } from "./routes/ai-api";
-import { mountAIByokRoutes } from "./routes/ai-byok";
-import { mountResolveIntentRoute } from "./routes/ai-resolve-intent";
-import { mountResolveSchemaIntentRoute } from "./routes/ai-resolve-schema-intent";
-import { mountAITracesRoutes } from "./routes/ai-traces-api";
-import { mountApprovalRoutes } from "./routes/approval-api";
-import { mountConfigRoutes } from "./routes/config-api";
-import { mountConfigStoreRoutes } from "./routes/config-store-api";
 import { mountDeployRoutes } from "./routes/deploy-api";
-import { mountEntityRoutes } from "./routes/entity-api";
 import { mountEvolutionCycleRoutes } from "./routes/evolution-cycle-api";
 import { mountEvolutionStatusRoutes } from "./routes/evolution-status-api";
-import { mountHealthRoutes } from "./routes/health";
-import { mountImportRoutes } from "./routes/import-api";
-import { mountOnchangeRoutes } from "./routes/onchange-api";
+import { mountCoreRoutes } from "./routes/mount-core-routes";
 import { mountOverlayRoutes } from "./routes/overlay-api";
 import { ANONYMOUS_ACTOR, NO_AUTH_ACTOR, resolveRequestLocale } from "./routes/shared";
 import { mountSubscriptionRoutes } from "./routes/subscription-api";
-import { mountTranslationRoutes } from "./routes/translation-api";
 
 export interface ServerOptions {
   /** Server port (default: 3001) */
@@ -406,38 +391,11 @@ export function createServer(
   const opts = options ?? {};
 
   // ── Mount route modules ────────────────────────────────────
-  mountAdminRoutes(app, opts, serverStartedAt);
-  // Mounted AFTER admin so the canonical, minimal `/health` (Spec 12 — liveness)
-  // overrides any duplicate handler in admin-api.ts. `/ready` is exclusive to
-  // this module.
-  mountHealthRoutes(app, opts);
-  mountEntityRoutes(app, opts);
-  mountActionRoutes(app, opts);
-  mountImportRoutes(app, opts);
-  mountApprovalRoutes(app, opts);
-  mountConfigRoutes(app, opts);
-  mountConfigStoreRoutes(app, opts);
-  mountAIRoutes(app, opts);
-  // AG-UI protocol run endpoint (#89) — only mounts when cap-adapter-ag-ui
-  // is registered in the capability list. Bridges the same assistant brain
-  // as POST /api/ai/chat onto official AG-UI events over SSE.
-  mountAgUiRoutes(app, opts);
-  // Spec 36 M2+ BYOK + usage endpoints (per-tenant key store + meter).
-  // Mounted alongside the other AI routes; no-ops when the store /
-  // meter are not configured (returns 503 with a structured envelope).
-  mountAIByokRoutes(app, opts);
-  // Spec 52 §2.6 canonical intent-resolution endpoint. Mounted AFTER
-  // mountAIRoutes so the canonical handler (with permission scoping +
-  // audit logging) wins routing for `POST /api/ai/resolve-intent` if any
-  // legacy handler is left in the file.
-  mountResolveIntentRoute(app, opts);
-  // Spec 69 P3 wave 2 — admin read of recent AI traces (`GET /api/ai/traces`),
-  // permission-gated through CommandLayer (`meta.aiObservability`).
-  mountAITracesRoutes(app, opts);
-  // Spec 52 "说→有" first slice — NL utterance → governed `add_rule` ProposalDraft.
-  mountResolveSchemaIntentRoute(app, opts);
-  mountTranslationRoutes(app, opts);
-  mountOnchangeRoutes(app, opts, opts.onchangeEvaluator);
+  // Order-sensitive, closure-free core mounts live in mount-core-routes.ts
+  // (keeps this entrypoint under the 500-line ceiling). The mounts BELOW close
+  // over server-local state (overlay → schema hot-reload, graphql-yoga, deploy,
+  // proposal / evolution / subscription) and stay inline.
+  mountCoreRoutes(app, opts, serverStartedAt);
 
   // Mount overlay management endpoints when overlay registry is available
   if (options?.overlayRegistry) {

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -61,6 +61,7 @@ import { mountAIRoutes } from "./routes/ai-api";
 import { mountAIByokRoutes } from "./routes/ai-byok";
 import { mountResolveIntentRoute } from "./routes/ai-resolve-intent";
 import { mountResolveSchemaIntentRoute } from "./routes/ai-resolve-schema-intent";
+import { mountAITracesRoutes } from "./routes/ai-traces-api";
 import { mountApprovalRoutes } from "./routes/approval-api";
 import { mountConfigRoutes } from "./routes/config-api";
 import { mountConfigStoreRoutes } from "./routes/config-store-api";
@@ -430,6 +431,9 @@ export function createServer(
   // audit logging) wins routing for `POST /api/ai/resolve-intent` if any
   // legacy handler is left in the file.
   mountResolveIntentRoute(app, opts);
+  // Spec 69 P3 wave 2 — admin read of recent AI traces (`GET /api/ai/traces`),
+  // permission-gated through CommandLayer (`meta.aiObservability`).
+  mountAITracesRoutes(app, opts);
   // Spec 52 "说→有" first slice — NL utterance → governed `add_rule` ProposalDraft.
   mountResolveSchemaIntentRoute(app, opts);
   mountTranslationRoutes(app, opts);

--- a/addons/adapter-server/cap-adapter-server/src/wire-ai-trace-sink.ts
+++ b/addons/adapter-server/cap-adapter-server/src/wire-ai-trace-sink.ts
@@ -1,0 +1,107 @@
+/**
+ * AI trace sink boot wiring (Spec 69 Phase 3 wave 2).
+ *
+ * The AI instrumentation (`ai-tracing.ts`) calls `getAITraceSink().recordGeneration(...)`
+ * on EVERY AI call, but until a sink is registered via `setAITraceSink(...)` it writes
+ * to the `NoopAITraceSink` default — every trace is discarded. This helper is the single
+ * place the real server boot paths register a live sink so traces are actually persisted.
+ *
+ * Decision matrix:
+ *  - A Postgres `db` handle is available (DB mode, `DATABASE_URL` set / DrizzleDataProvider
+ *    in use) → register a `DrizzleAITraceStore`: durable PG mirror + a process-local hot view.
+ *  - No db handle (InMemoryStore fallback, no `DATABASE_URL`) → register an
+ *    `InMemoryAITraceStore` so traces are at least queryable in-process this run.
+ *
+ * Idempotent + non-throwing: a sink-wiring failure must NEVER crash boot. Any error is
+ * caught and logged at WARN, leaving whatever sink was previously registered in place
+ * (the noop default at worst). Tests that register their own sink are not fought — this
+ * is only invoked from the real boot entrypoints (`dev.ts` + the http transport).
+ */
+
+import type { DataProvider, Logger } from "@linchkit/core";
+import type { AITraceSink } from "@linchkit/core/server";
+import { consoleLogger, InMemoryAITraceStore, setAITraceSink } from "@linchkit/core/server";
+
+/**
+ * Extract the underlying `PostgresJsDatabase` handle from a DataProvider when it
+ * is a Drizzle-backed provider, reusing the SAME connection pool the data layer
+ * already opened (never opening a second pool).
+ *
+ * The `db` field on `DrizzleDataProvider` is a TypeScript-private (not a runtime
+ * `#private`), so a structural read works at runtime — the same access pattern
+ * `http-transport.ts` already uses to hand the system data provider its db.
+ * Returns `undefined` for `InMemoryStore` (or any provider without a db handle),
+ * which is the signal to fall back to the in-memory trace sink.
+ */
+export function extractDbHandle(
+  dataProvider: DataProvider | undefined,
+): import("drizzle-orm/postgres-js").PostgresJsDatabase | undefined {
+  const candidate = (dataProvider as { db?: unknown } | undefined)?.db;
+  // A DrizzleDataProvider always carries a non-null db; InMemoryStore has none.
+  if (candidate && typeof candidate === "object") {
+    return candidate as import("drizzle-orm/postgres-js").PostgresJsDatabase;
+  }
+  return undefined;
+}
+
+/** Options for {@link wireAITraceSink}. */
+export interface WireAITraceSinkOptions {
+  /**
+   * The boot DataProvider. When it is a Drizzle-backed provider its db handle is
+   * reused for a durable `DrizzleAITraceStore`; otherwise an in-memory sink is wired.
+   */
+  dataProvider?: DataProvider;
+  /** Logger for the wiring summary / failure. Defaults to `consoleLogger`. */
+  logger?: Logger;
+}
+
+/**
+ * Register the live AI trace sink for the running server.
+ *
+ * Returns the sink that was registered (for the boot summary / tests), or
+ * `undefined` if wiring failed and the previous sink was left untouched. Safe to
+ * call from any boot path: it never throws.
+ *
+ * Async because the `DrizzleAITraceStore` lives in `@linchkit/cap-ai-provider`,
+ * loaded lazily so cap-adapter-server keeps only a dev/optional dependency on it
+ * (mirrors how `dev.ts` lazy-imports `createAIService`). The in-memory fallback
+ * needs no async work but the signature stays uniform for both branches.
+ */
+export async function wireAITraceSink(
+  options: WireAITraceSinkOptions = {},
+): Promise<AITraceSink | undefined> {
+  const logger = options.logger ?? consoleLogger;
+  try {
+    const db = extractDbHandle(options.dataProvider);
+    if (db) {
+      // Lazy import so cap-adapter-server does not hard-load cap-ai-provider's
+      // Drizzle store at module-init time (only needed in DB mode).
+      const { DrizzleAITraceStore } = await import("@linchkit/cap-ai-provider");
+      const sink = new DrizzleAITraceStore({ db, logger });
+      setAITraceSink(sink);
+      logger.info(
+        "[ai-trace] persistence ON — traces mirrored to PostgreSQL (DrizzleAITraceStore)",
+      );
+      return sink;
+    }
+
+    // No Postgres handle — register the in-memory store so traces are at least
+    // queryable in-process this run (vs the noop default which discards them).
+    const sink = new InMemoryAITraceStore();
+    setAITraceSink(sink);
+    logger.info(
+      "[ai-trace] persistence OFF (no DATABASE_URL) — traces retained in-memory only for this process (InMemoryAITraceStore)",
+    );
+    return sink;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      logger.warn(
+        `[ai-trace] failed to wire trace sink (traces keep using the previous/noop sink): ${message}`,
+      );
+    } catch {
+      // Logger itself failed — nothing more we can safely do; never crash boot.
+    }
+    return undefined;
+  }
+}

--- a/addons/adapter-server/cap-adapter-server/src/wire-ai-trace-sink.ts
+++ b/addons/adapter-server/cap-adapter-server/src/wire-ai-trace-sink.ts
@@ -20,7 +20,13 @@
 
 import type { DataProvider, Logger } from "@linchkit/core";
 import type { AITraceSink } from "@linchkit/core/server";
-import { consoleLogger, InMemoryAITraceStore, setAITraceSink } from "@linchkit/core/server";
+import {
+  consoleLogger,
+  getAITraceSink,
+  InMemoryAITraceStore,
+  NoopAITraceSink,
+  setAITraceSink,
+} from "@linchkit/core/server";
 
 /**
  * Extract the underlying `PostgresJsDatabase` handle from a DataProvider when it
@@ -72,6 +78,14 @@ export async function wireAITraceSink(
 ): Promise<AITraceSink | undefined> {
   const logger = options.logger ?? consoleLogger;
   try {
+    // Idempotent: if a LIVE sink is already registered (anything other than the
+    // Noop default — a prior wireAITraceSink call, or a test's own
+    // setAITraceSink), leave it in place. Constructing a second sink would
+    // orphan the first and drop its pending mirror writes.
+    const existing = getAITraceSink();
+    if (!(existing instanceof NoopAITraceSink)) {
+      return existing;
+    }
     const db = extractDbHandle(options.dataProvider);
     if (db) {
       // Lazy import so cap-adapter-server does not hard-load cap-ai-provider's

--- a/addons/permission/cap-permission/__tests__/middleware.test.ts
+++ b/addons/permission/cap-permission/__tests__/middleware.test.ts
@@ -381,3 +381,96 @@ describe("permission middleware — meta.onchange target (skipActionSlots dispat
     expect(nextCalled).toBe(true);
   });
 });
+
+/**
+ * Meta-target permission resolution — `meta.aiObservability` (Spec 69 P3 wave 2).
+ *
+ * The AI trace read route (`GET /api/ai/traces`) dispatches with
+ * `skipActionSlots: true`, NO `ctx.action`, and publishes
+ * `meta.aiObservability = { operation }`. The middleware should derive an ACTION
+ * grant target (`grant.ai.actions.<operation>`) — companion to `meta.evolution`.
+ * These tests pin that: a natural grant authorizes, a missing grant denies, the
+ * synthetic command name alone never authorizes, and a stray meta on a real action
+ * dispatch is ignored.
+ */
+describe("permission middleware — meta.aiObservability target (skipActionSlots dispatch)", () => {
+  /** A trace-read-shaped dispatch: synthetic command, no action, meta target. */
+  function readTracesCtx(actor: CommandContext["actor"]): CommandContext {
+    return {
+      command: "ai.read_traces",
+      input: {},
+      channel: "http",
+      actor,
+      meta: { aiObservability: { operation: "read_traces" } },
+      // No `action` — non-action dispatch (skipActionSlots).
+    } as CommandContext;
+  }
+
+  function registryWithAiReadGrant(): PermissionRegistry {
+    const registry = new PermissionRegistry();
+    registry.register(
+      definePermissionGroup({
+        name: "ai_observer",
+        label: "AI Observer",
+        // The NATURAL grant shape a human would author for the read-traces target.
+        grant: { ai: { actions: { read_traces: true } } },
+      }),
+    );
+    return registry;
+  }
+
+  it("authorizes read-traces via grant.ai.actions.read_traces (the documented target)", async () => {
+    const middleware = createPermissionMiddleware({ registry: registryWithAiReadGrant() });
+    const ctx = readTracesCtx({ type: "human", id: "obs_1", groups: ["ai_observer"] });
+    let nextCalled = false;
+
+    await middleware(ctx, async () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+  });
+
+  it("denies read-traces when the actor's groups grant no ai observability target", async () => {
+    const middleware = createPermissionMiddleware({ registry: registryWithAiReadGrant() });
+    const ctx = readTracesCtx({ type: "human", id: "stranger", groups: ["some_unrelated_group"] });
+
+    await expect(middleware(ctx, async () => {})).rejects.toThrow(AuthorizationError);
+  });
+
+  it("denies read-traces when only the synthetic command name was granted (regression)", async () => {
+    // The target is the meta operation, NOT the synthetic command name. Granting
+    // the command name must not authorize — guards against command-name gating.
+    const registry = new PermissionRegistry();
+    registry.register(
+      definePermissionGroup({
+        name: "command_name_only",
+        label: "Command-name grant (wrong shape)",
+        grant: { "ai.read_traces": { actions: { "ai.read_traces": true } } },
+      }),
+    );
+    const middleware = createPermissionMiddleware({ registry });
+    const ctx = readTracesCtx({ type: "human", id: "obs_2", groups: ["command_name_only"] });
+
+    await expect(middleware(ctx, async () => {})).rejects.toThrow(AuthorizationError);
+  });
+
+  it("ignores a stray meta.aiObservability on a real ACTION dispatch (target stays the action)", async () => {
+    // Defensive: meta-target resolution is scoped to non-action dispatches. A real
+    // action carrying meta.aiObservability must still authorize against its action target.
+    const registry = createTestRegistry();
+    const middleware = createPermissionMiddleware({ registry });
+    const ctx = createTestContext({
+      meta: { aiObservability: { operation: "read_traces" } },
+    });
+    let nextCalled = false;
+
+    await middleware(ctx, async () => {
+      nextCalled = true;
+    });
+
+    // `editors` grants the `submit_request` ACTION target — the ai meta was ignored
+    // because `ctx.action` is present.
+    expect(nextCalled).toBe(true);
+  });
+});

--- a/addons/permission/cap-permission/src/middleware/permission-middleware.ts
+++ b/addons/permission/cap-permission/src/middleware/permission-middleware.ts
@@ -88,6 +88,10 @@ type MetaTarget =
  *  - `meta.onchange = { entity }` (Spec 64) → an entity-level READ check. The
  *    onchange route computes form fields for an entity; authorize it as "may this
  *    actor READ this entity" (`grant.<entity>.data.read`), NOT as an action.
+ *  - `meta.aiObservability = { operation }` (Spec 69 P3) → an ACTION grant target.
+ *    Gate AI observability admin reads (e.g. `GET /api/ai/traces`) on a natural
+ *    grant (`grant.ai.actions.<operation>`, e.g. `grant.ai.actions.read_traces`)
+ *    rather than the synthetic command name. Same shape as `meta.evolution`.
  *
  * Returns `null` when no recognised meta target is present, leaving the caller on
  * its normal action-based resolution. Only consulted for non-action dispatches
@@ -102,6 +106,14 @@ function resolveMetaTarget(ctx: CommandContext): MetaTarget | null {
   const onchange = meta?.onchange as { entity?: unknown } | undefined;
   if (onchange && typeof onchange.entity === "string" && onchange.entity.length > 0) {
     return { kind: "read", capability: onchange.entity, entity: onchange.entity };
+  }
+  const aiObservability = meta?.aiObservability as { operation?: unknown } | undefined;
+  if (
+    aiObservability &&
+    typeof aiObservability.operation === "string" &&
+    aiObservability.operation.length > 0
+  ) {
+    return { kind: "action", capability: "ai", action: aiObservability.operation };
   }
   return null;
 }


### PR DESCRIPTION
## Spec 69 P3 wave 2 — make the AI trace sink live + readable

Production ran `NoopAITraceSink` — **every AI trace was silently discarded** because no boot path ever called `setAITraceSink`. The instrumentation (`ai-tracing.ts` → `getAITraceSink().recordGeneration(...)`) fired on every AI call into the void. This wave wires a real sink at both boot paths and adds a permission-gated read endpoint.

### What changed
- **`wire-ai-trace-sink.ts`** — `wireAITraceSink({ dataProvider })`: a Postgres handle reachable → `DrizzleAITraceStore` (durable PG mirror, **reuses the boot DataProvider's existing pool**, never a second pool); no handle → `InMemoryAITraceStore`. Idempotent, non-throwing (catch + WARN, leaves prior sink in place), lazy-imports the Drizzle store so cap-adapter-server keeps only an optional dep on cap-ai-provider. Wired at **both** real entrypoints: `dev.ts` (`bun run dev:server`) and `http-transport.ts` (`createHttpTransport` — the real serving boot). `createDevApp`/tests keep their own sinks.
- **`GET /api/ai/traces`** (`ai-traces-api.ts`, mounted in `server.ts`) — dispatches through CommandLayer with `skipActionSlots` so the **permission/tenant slots still run** (503 fail-closed if no commandLayer; canonical `AUTHZ_DENIED` on 401/403 with the sink **never consulted** when denied). Permission target carried in `meta.aiObservability = { operation: "read_traces" }`, gated on `grant.ai.actions.read_traces`. The tenant slot's resolved `tenantId` always wins over a `?tenantId=` param (no cross-tenant read). `limit`/`origin`/`status` validated + clamped; prefers the durable async `queryTracesPersisted`, falls back to the sync hot view. GET only — never reads the body.
- **`permission-middleware.ts`** — `resolveMetaTarget` recognizes `meta.aiObservability` as an action grant target (`grant.ai.actions.<operation>`), companion to `meta.evolution`/`meta.onchange` (#527/#528).

### Tests
`wire-ai-trace-sink` (no-DB→InMemory, DB-mode→Drizzle skipIf no PG, pool reuse, non-throwing); `ai-traces-api` (most-recent-first, limit, 400s, **403 + AUTHZ_DENIED with sink not consulted**, tenant scoping); permission middleware `meta.aiObservability` authorize/deny block. Full `bun run test` green.

### LIVE end-to-end proof (not just unit tests)
Drove the **shipped** `wireAITraceSink` over a **real** `DrizzleDataProvider` (real Postgres) + a **real** AI completion (zhipu / `glm-4-flash-250414`), then read the row straight out of Postgres:

```
[ai-trace] persistence ON — traces mirrored to PostgreSQL (DrizzleAITraceStore)
wireAITraceSink returned: DrizzleAITraceStore
ai_generations rows BEFORE the AI call: 0
AI replied: "The token linchkit-trace-e2e-0 is used for end-to-end tracing in systems."
usage: { inputTokens: 26, outputTokens: 24, totalTokens: 50 }  model: glm-4-flash-250414  provider: zhipu
whenPersisted() drained the mirror queue
========== PG PROOF ==========
ai_generations rows AFTER the AI call: 1 (was 0)
  • {"id":"151c9798-...","provider":"zhipu","model":"glm-4-flash-250414","input_tokens":26,"output_tokens":24,"status":"ok","started_at":"2026-06-10 15:20:37.545"}
RESULT: PASS — the real AI call persisted a trace row to Postgres.
```

And `GET /api/ai/traces?limit=5` on the running dev server returned `200 {"success":true,"data":{"traces":[],"count":0}}` — route mounted, passes through CommandLayer, reads the live sink.

Closes the "traces are wired but never persisted in production" gap (Spec 69 P3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
