### PR TITLE
docs: root .md honesty — factual fixes + complete capability catalog (31) + real security channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ If a spec exists for the area you're touching → read the spec first. Specs: `d
 | ORM | Drizzle (PostgreSQL via drizzle-kit, InMemoryStore fallback) |
 | Frontend | React 19 + Vite |
 | UI | Shadcn + Radix + Lucide + Tailwind |
-| Flow Engine | Restate (`@restatedev/restate-sdk` v1.11.1) — durable execution |
-| Testing | bun test |
+| Flow Engine | Restate (`@restatedev/restate-sdk` v1.14.5) — durable execution |
+| Testing | bun run test |
 
 ## Constraints
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ Examples of unacceptable behavior:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers privately via [GitHub's report-abuse flow](https://github.com/laofahai/linchkit) (open a private report through the repository, or contact the repository owner directly through GitHub).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately by contacting the repository owner [@laofahai](https://github.com/laofahai) directly (via the contact details on their GitHub profile). The project does not yet operate a dedicated conduct mailbox; reports go straight to the maintainer.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,7 +22,7 @@ Examples of unacceptable behavior:
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **conduct@linchkit.dev**.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers privately via [GitHub's report-abuse flow](https://github.com/laofahai/linchkit) (open a private report through the repository, or contact the repository owner directly through GitHub).
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to LinchKit! This guide will help yo
 
 ```bash
 # Clone the repository
-git clone https://github.com/anthropic-ai/linchkit.git
+git clone https://github.com/laofahai/linchkit.git
 cd linchkit
 
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ addons/ (grouped capabilities — OCA model):
     @linchkit/cap-adapter-mcp        — MCP transport for AI agents
     @linchkit/cap-mcp-ui             — MCP UI components
   adapter-ag-ui/
-    @linchkit/cap-adapter-ag-ui      — AG-UI protocol adapter (agent↔frontend stream)
+    @linchkit/cap-adapter-ag-ui      — AG-UI protocol adapter (agent↔frontend event stream)
   adapter-a2a/
     @linchkit/cap-adapter-a2a        — A2A (agent-to-agent) protocol adapter
   ai-provider/

--- a/README.md
+++ b/README.md
@@ -228,48 +228,105 @@ packages/ (core infrastructure — published to npm):
 
 addons/ (grouped capabilities — OCA model):
   adapter-server/
-    @linchkit/cap-adapter-server  — Elysia + graphql-yoga + REST + CommandLayer
+    @linchkit/cap-adapter-server     — Elysia + graphql-yoga + REST + CommandLayer
   adapter-ui/
-    @linchkit/cap-adapter-ui      — React 19 + Shadcn + TanStack (official UI)
+    @linchkit/cap-adapter-ui         — React 19 + Shadcn + TanStack (official UI)
   adapter-mcp/
-    @linchkit/cap-adapter-mcp     — MCP transport for AI agents
-    @linchkit/cap-mcp-ui          — MCP UI components
-  chatter/
-    @linchkit/cap-chatter         — Timeline: messages, audit log, GraphQL
-    @linchkit/cap-chatter-ui      — Chatter React UI panel
-  auth/
-    @linchkit/cap-auth            — Authentication (JWT, sessions)
-    @linchkit/cap-auth-better-auth — Auth provider (Better Auth)
-  permission/
-    @linchkit/cap-permission      — Permission engine (RBAC)
+    @linchkit/cap-adapter-mcp        — MCP transport for AI agents
+    @linchkit/cap-mcp-ui             — MCP UI components
+  adapter-ag-ui/
+    @linchkit/cap-adapter-ag-ui      — AG-UI protocol adapter (agent↔frontend stream)
+  adapter-a2a/
+    @linchkit/cap-adapter-a2a        — A2A (agent-to-agent) protocol adapter
   ai-provider/
-    @linchkit/cap-ai-provider     — AI SDK (Anthropic, OpenAI, custom)
+    @linchkit/cap-ai-provider        — AI SDK providers (Anthropic, OpenAI, zhipu, …)
+  auth/
+    @linchkit/cap-auth               — Authentication (JWT, sessions)
+    @linchkit/cap-auth-better-auth   — Auth provider (Better Auth)
+  permission/
+    @linchkit/cap-permission         — Permission engine (RBAC)
+  chatter/
+    @linchkit/cap-chatter            — Timeline: messages, audit log, GraphQL
+    @linchkit/cap-chatter-ui         — Chatter React UI panel
+  audit/
+    @linchkit/cap-audit-ui           — Audit-log UI
   flow-restate/
-    @linchkit/cap-flow-restate    — Restate durable execution
+    @linchkit/cap-flow-restate       — Restate durable execution
+  dry-run/
+    @linchkit/cap-dry-run            — Sandboxed execution dry-run runner
+  lock/
+    @linchkit/cap-lock               — Capability/field lock policy (Spec 63)
   migration/
-    @linchkit/cap-migration       — Database migration tooling
+    @linchkit/cap-migration          — Database migration tooling
+  notification/
+    @linchkit/cap-notification       — Notification delivery
+  search/
+    @linchkit/cap-search             — Full-text search
+    @linchkit/cap-search-ui          — Search UI
+  file-storage/
+    @linchkit/cap-file-storage       — File storage
+  cache-redis/
+    @linchkit/cap-cache-redis        — Redis cache provider
+  vector/
+    @linchkit/cap-vector-pgvector    — pgvector vector store
+  observability/
+    @linchkit/cap-observability-otel — OpenTelemetry traces/metrics
+  theme/
+    @linchkit/cap-theme              — Theming
+  keyboard-shortcuts/
+    @linchkit/cap-keyboard-shortcuts — Keyboard shortcuts
+  view-kanban/
+    @linchkit/cap-view-kanban        — Kanban view
+  view-calendar/
+    @linchkit/cap-view-calendar      — Calendar view
+  view-timeline/
+    @linchkit/cap-view-timeline      — Timeline view
   demo/
-    @linchkit/cap-purchase-demo   — Demo: purchase management scenario
+    @linchkit/cap-life-demo          — Life-system (Spec 55) demo
+    @linchkit/cap-purchase-demo      — Purchase management demo (private)
 ```
 
 ---
 
 ## Capability Catalog
 
-Official capabilities available via `linch install`:
+Capabilities in this monorepo (the published ones install via `linch install`; demo and several in-progress capabilities are `private` / not yet on npm — see [VERSIONING.md](VERSIONING.md)):
+
+Type + Category are the OCA values each capability declares (`capability.json` / `package.json#linchkit`).
 
 | Capability | Type | Category | Description |
 |-----------|------|----------|-------------|
-| `@linchkit/cap-adapter-server` | adapter | transport | HTTP/GraphQL server (Elysia + graphql-yoga) |
-| `@linchkit/cap-adapter-ui` | adapter | transport | Official React UI (Shadcn + TanStack) |
-| `@linchkit/cap-adapter-mcp` | adapter | transport | MCP transport for AI agents |
-| `@linchkit/cap-auth` | standard | auth | Authentication (JWT, sessions) |
-| `@linchkit/cap-auth-better-auth` | standard | auth | Auth provider (Better Auth) |
-| `@linchkit/cap-permission` | standard | auth | Permission engine (RBAC) |
-| `@linchkit/cap-chatter` | standard | collaboration | Timeline: messages, audit log |
-| `@linchkit/cap-ai-provider` | standard | ai | AI SDK (Anthropic, OpenAI) |
-| `@linchkit/cap-flow-restate` | standard | workflow | Restate durable execution |
-| `@linchkit/cap-migration` | standard | infrastructure | Database migration tooling |
+| `@linchkit/cap-adapter-server` | adapter | integration | HTTP/GraphQL server (Elysia + graphql-yoga + REST + CommandLayer) |
+| `@linchkit/cap-adapter-ui` | adapter | integration | Official React UI (Shadcn + TanStack) |
+| `@linchkit/cap-adapter-mcp` | adapter | integration | MCP transport for AI agents |
+| `@linchkit/cap-mcp-ui` | standard | system | MCP UI components |
+| `@linchkit/cap-adapter-ag-ui` | adapter | integration | AG-UI protocol adapter (agent↔frontend event stream) |
+| `@linchkit/cap-adapter-a2a` | adapter | integration | A2A (agent-to-agent) protocol adapter |
+| `@linchkit/cap-ai-provider` | adapter | integration | AI SDK providers (Anthropic, OpenAI, zhipu, …) |
+| `@linchkit/cap-auth` | standard | system | Authentication (JWT, sessions) |
+| `@linchkit/cap-auth-better-auth` | adapter | system | Auth provider (Better Auth) |
+| `@linchkit/cap-permission` | standard | system | Permission engine (RBAC) |
+| `@linchkit/cap-chatter` | standard | system | Timeline: messages, audit log, GraphQL |
+| `@linchkit/cap-chatter-ui` | standard | system | Chatter React UI panel |
+| `@linchkit/cap-audit-ui` | standard | system | Audit-log UI |
+| `@linchkit/cap-flow-restate` | standard | infrastructure | Restate durable execution |
+| `@linchkit/cap-dry-run` | adapter | integration | Sandboxed execution dry-run runner |
+| `@linchkit/cap-lock` | standard | system | Capability/field lock policy (Spec 63) |
+| `@linchkit/cap-migration` | standard | system | Database migration tooling |
+| `@linchkit/cap-notification` | standard | system | Notification delivery |
+| `@linchkit/cap-file-storage` | standard | system | File storage |
+| `@linchkit/cap-cache-redis` | standard | system | Redis cache provider |
+| `@linchkit/cap-search` | standard | system | Full-text search |
+| `@linchkit/cap-search-ui` | standard | system | Search UI |
+| `@linchkit/cap-vector-pgvector` | standard | system | pgvector vector store |
+| `@linchkit/cap-observability-otel` | standard | system | OpenTelemetry traces/metrics |
+| `@linchkit/cap-theme` | standard | system | Theming |
+| `@linchkit/cap-keyboard-shortcuts` | standard | system | Keyboard shortcuts |
+| `@linchkit/cap-view-kanban` | standard | view | Kanban view |
+| `@linchkit/cap-view-calendar` | standard | view | Calendar view |
+| `@linchkit/cap-view-timeline` | standard | view | Timeline view |
+| `@linchkit/cap-life-demo` | standard | system | Life-system (Spec 55) demo |
+| `@linchkit/cap-purchase-demo` | standard | business | Purchase management demo (private) |
 
 Third-party capabilities can be contributed via PR to the capability registry.
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ linch publish           # Publish packages
 docker compose up -d    # PostgreSQL + Restate
 
 bun install             # Install dependencies
-bun test                # Run tests
+bun run test            # Run the full test suite (batched runner)
 bun run dev             # Start dev server (server :3001 + UI :3000)
 bun run dev:server      # Server only
 bun run dev:ui          # UI only (proxies API to :3001)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,48 +228,105 @@ packages/ (核心基础设施 — 发布到 npm):
 
 addons/ (能力分组 — OCA 模型):
   adapter-server/
-    @linchkit/cap-adapter-server  — Elysia + graphql-yoga + REST + CommandLayer
+    @linchkit/cap-adapter-server     — Elysia + graphql-yoga + REST + CommandLayer
   adapter-ui/
-    @linchkit/cap-adapter-ui      — React 19 + Shadcn + TanStack（官方 UI）
+    @linchkit/cap-adapter-ui         — React 19 + Shadcn + TanStack（官方 UI）
   adapter-mcp/
-    @linchkit/cap-adapter-mcp     — MCP 传输（AI 代理接入）
-    @linchkit/cap-mcp-ui          — MCP UI 组件
-  chatter/
-    @linchkit/cap-chatter         — 时间线：消息、审计日志、GraphQL
-    @linchkit/cap-chatter-ui      — Chatter React UI 面板
-  auth/
-    @linchkit/cap-auth            — 认证（JWT、sessions）
-    @linchkit/cap-auth-better-auth — Auth provider（Better Auth）
-  permission/
-    @linchkit/cap-permission      — 权限引擎（RBAC）
+    @linchkit/cap-adapter-mcp        — MCP 传输（AI 代理接入）
+    @linchkit/cap-mcp-ui             — MCP UI 组件
+  adapter-ag-ui/
+    @linchkit/cap-adapter-ag-ui      — AG-UI 协议适配器（agent↔前端事件流）
+  adapter-a2a/
+    @linchkit/cap-adapter-a2a        — A2A（agent 间）协议适配器
   ai-provider/
-    @linchkit/cap-ai-provider     — AI SDK（Anthropic、OpenAI、自定义）
+    @linchkit/cap-ai-provider        — AI SDK providers（Anthropic、OpenAI、zhipu…）
+  auth/
+    @linchkit/cap-auth               — 认证（JWT、sessions）
+    @linchkit/cap-auth-better-auth   — Auth provider（Better Auth）
+  permission/
+    @linchkit/cap-permission         — 权限引擎（RBAC）
+  chatter/
+    @linchkit/cap-chatter            — 时间线：消息、审计日志、GraphQL
+    @linchkit/cap-chatter-ui         — Chatter React UI 面板
+  audit/
+    @linchkit/cap-audit-ui           — 审计日志 UI
   flow-restate/
-    @linchkit/cap-flow-restate    — Restate 持久化执行
+    @linchkit/cap-flow-restate       — Restate 持久化执行
+  dry-run/
+    @linchkit/cap-dry-run            — 沙箱化执行 dry-run 运行器
+  lock/
+    @linchkit/cap-lock               — 能力/字段锁策略（Spec 63）
   migration/
-    @linchkit/cap-migration       — 数据库迁移工具
+    @linchkit/cap-migration          — 数据库迁移工具
+  notification/
+    @linchkit/cap-notification       — 通知投递
+  search/
+    @linchkit/cap-search             — 全文检索
+    @linchkit/cap-search-ui          — 检索 UI
+  file-storage/
+    @linchkit/cap-file-storage       — 文件存储
+  cache-redis/
+    @linchkit/cap-cache-redis        — Redis 缓存 provider
+  vector/
+    @linchkit/cap-vector-pgvector    — pgvector 向量存储
+  observability/
+    @linchkit/cap-observability-otel — OpenTelemetry 链路/指标
+  theme/
+    @linchkit/cap-theme              — 主题
+  keyboard-shortcuts/
+    @linchkit/cap-keyboard-shortcuts — 键盘快捷键
+  view-kanban/
+    @linchkit/cap-view-kanban        — 看板视图
+  view-calendar/
+    @linchkit/cap-view-calendar      — 日历视图
+  view-timeline/
+    @linchkit/cap-view-timeline      — 时间线视图
   demo/
-    @linchkit/cap-purchase-demo   — 演示：采购管理场景
+    @linchkit/cap-life-demo          — 生命系统（Spec 55）演示
+    @linchkit/cap-purchase-demo      — 采购管理演示（私有）
 ```
 
 ---
 
 ## 能力目录
 
-通过 `linch install` 安装官方能力：
+本仓库中的能力（已发布的可通过 `linch install` 安装；demo 及若干进行中的能力为 `private`、尚未发布到 npm — 见 [VERSIONING.md](VERSIONING.md)）：
+
+类型 + 分类是各能力在 `capability.json` / `package.json#linchkit` 中声明的 OCA 值。
 
 | 能力 | 类型 | 分类 | 说明 |
 |------|------|------|------|
-| `@linchkit/cap-adapter-server` | adapter | transport | HTTP/GraphQL 服务端（Elysia + graphql-yoga） |
-| `@linchkit/cap-adapter-ui` | adapter | transport | 官方 React UI（Shadcn + TanStack） |
-| `@linchkit/cap-adapter-mcp` | adapter | transport | MCP 传输（AI 代理接入） |
-| `@linchkit/cap-auth` | standard | auth | 认证（JWT、sessions） |
-| `@linchkit/cap-auth-better-auth` | standard | auth | Auth provider（Better Auth） |
-| `@linchkit/cap-permission` | standard | auth | 权限引擎（RBAC） |
-| `@linchkit/cap-chatter` | standard | collaboration | 时间线：消息、审计日志 |
-| `@linchkit/cap-ai-provider` | standard | ai | AI SDK（Anthropic、OpenAI） |
-| `@linchkit/cap-flow-restate` | standard | workflow | Restate 持久化执行 |
-| `@linchkit/cap-migration` | standard | infrastructure | 数据库迁移工具 |
+| `@linchkit/cap-adapter-server` | adapter | integration | HTTP/GraphQL 服务端（Elysia + graphql-yoga + REST + CommandLayer） |
+| `@linchkit/cap-adapter-ui` | adapter | integration | 官方 React UI（Shadcn + TanStack） |
+| `@linchkit/cap-adapter-mcp` | adapter | integration | MCP 传输（AI 代理接入） |
+| `@linchkit/cap-mcp-ui` | standard | system | MCP UI 组件 |
+| `@linchkit/cap-adapter-ag-ui` | adapter | integration | AG-UI 协议适配器（agent↔前端事件流） |
+| `@linchkit/cap-adapter-a2a` | adapter | integration | A2A（agent 间）协议适配器 |
+| `@linchkit/cap-ai-provider` | adapter | integration | AI SDK providers（Anthropic、OpenAI、zhipu…） |
+| `@linchkit/cap-auth` | standard | system | 认证（JWT、sessions） |
+| `@linchkit/cap-auth-better-auth` | adapter | system | Auth provider（Better Auth） |
+| `@linchkit/cap-permission` | standard | system | 权限引擎（RBAC） |
+| `@linchkit/cap-chatter` | standard | system | 时间线：消息、审计日志、GraphQL |
+| `@linchkit/cap-chatter-ui` | standard | system | Chatter React UI 面板 |
+| `@linchkit/cap-audit-ui` | standard | system | 审计日志 UI |
+| `@linchkit/cap-flow-restate` | standard | infrastructure | Restate 持久化执行 |
+| `@linchkit/cap-dry-run` | adapter | integration | 沙箱化执行 dry-run 运行器 |
+| `@linchkit/cap-lock` | standard | system | 能力/字段锁策略（Spec 63） |
+| `@linchkit/cap-migration` | standard | system | 数据库迁移工具 |
+| `@linchkit/cap-notification` | standard | system | 通知投递 |
+| `@linchkit/cap-file-storage` | standard | system | 文件存储 |
+| `@linchkit/cap-cache-redis` | standard | system | Redis 缓存 provider |
+| `@linchkit/cap-search` | standard | system | 全文检索 |
+| `@linchkit/cap-search-ui` | standard | system | 检索 UI |
+| `@linchkit/cap-vector-pgvector` | standard | system | pgvector 向量存储 |
+| `@linchkit/cap-observability-otel` | standard | system | OpenTelemetry 链路/指标 |
+| `@linchkit/cap-theme` | standard | system | 主题 |
+| `@linchkit/cap-keyboard-shortcuts` | standard | system | 键盘快捷键 |
+| `@linchkit/cap-view-kanban` | standard | view | 看板视图 |
+| `@linchkit/cap-view-calendar` | standard | view | 日历视图 |
+| `@linchkit/cap-view-timeline` | standard | view | 时间线视图 |
+| `@linchkit/cap-life-demo` | standard | system | 生命系统（Spec 55）演示 |
+| `@linchkit/cap-purchase-demo` | standard | business | 采购管理演示（私有） |
 
 第三方能力可通过 PR 提交到能力注册表。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -340,7 +340,7 @@ linch publish           # 发布包
 docker compose up -d    # PostgreSQL + Restate
 
 bun install             # 安装依赖
-bun test                # 运行测试
+bun run test            # 运行完整测试套件（批量运行器）
 bun run dev             # 启动开发服务器（服务端 :3001 + UI :3000）
 bun run dev:server      # 仅启动服务端
 bun run dev:ui          # 仅启动 UI（代理 API 到 :3001）

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.2.x   | Yes       |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 
 **Do not report security vulnerabilities through public GitHub issues.**
 
-Please report vulnerabilities by emailing **security@linchkit.dev**.
+Please report vulnerabilities privately via [GitHub Security Advisories](https://github.com/laofahai/linchkit/security/advisories/new) ("Report a vulnerability"). This keeps the report confidential until a fix is released.
 
 Include:
 - Description of the vulnerability

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -156,10 +156,10 @@ must also use `peerDependencies` with caret ranges.
 | `@linchkit/cap-auth` | Authentication capability |
 | `@linchkit/cap-auth-better-auth` | Better Auth provider |
 | `@linchkit/cap-permission` | Permission capability (RBAC) |
-| `@linchkit/cap-chatter` | Record timeline capability |
-| `@linchkit/cap-chatter-ui` | Chatter UI components |
+| `@linchkit/cap-chatter` | Timeline: messages, audit log, GraphQL |
+| `@linchkit/cap-chatter-ui` | Chatter React UI panel |
 | `@linchkit/cap-audit-ui` | Audit-log UI |
-| `@linchkit/cap-flow-restate` | Restate flow engine |
+| `@linchkit/cap-flow-restate` | Restate durable execution |
 | `@linchkit/cap-dry-run` | Sandboxed execution dry-run runner |
 | `@linchkit/cap-lock` | Capability/field lock policy |
 | `@linchkit/cap-migration` | Database migration tooling |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -123,7 +123,7 @@ Each addon package declares its minimum compatible core version. The general rul
 | 1.x.x       | Only addons built for ^1.0.0 |
 
 **Rule**: Addons MUST declare `@linchkit/core` as a `peerDependency` with a
-caret range (e.g., `"@linchkit/core": "^0.1.0"`). This ensures consumers get
+caret range (e.g., `"@linchkit/core": "^0.2.0"`). This ensures consumers get
 clear warnings when versions are incompatible.
 
 ### Cross-Addon Compatibility

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -145,25 +145,43 @@ must also use `peerDependencies` with caret ranges.
 
 | Package | Description |
 |---------|-------------|
-| `@linchkit/cap-adapter-server` | Elysia + GraphQL + REST server |
-| `@linchkit/cap-adapter-ui` | React UI adapter |
+| `@linchkit/cap-adapter-server` | Elysia + graphql-yoga + REST + CommandLayer server |
+| `@linchkit/cap-adapter-ui` | React 19 UI adapter (Shadcn + TanStack) |
 | `@linchkit/ui-kit` | Shared UI components (Shadcn) |
 | `@linchkit/cap-adapter-mcp` | MCP transport adapter |
 | `@linchkit/cap-mcp-ui` | MCP management UI |
+| `@linchkit/cap-adapter-ag-ui` | AG-UI protocol adapter (agent↔frontend stream) |
+| `@linchkit/cap-adapter-a2a` | A2A (agent-to-agent) protocol adapter |
+| `@linchkit/cap-ai-provider` | AI provider capability (Anthropic, OpenAI, zhipu, …) |
 | `@linchkit/cap-auth` | Authentication capability |
 | `@linchkit/cap-auth-better-auth` | Better Auth provider |
-| `@linchkit/cap-permission` | Permission capability |
-| `@linchkit/cap-ai-provider` | AI provider capability |
+| `@linchkit/cap-permission` | Permission capability (RBAC) |
 | `@linchkit/cap-chatter` | Record timeline capability |
 | `@linchkit/cap-chatter-ui` | Chatter UI components |
+| `@linchkit/cap-audit-ui` | Audit-log UI |
 | `@linchkit/cap-flow-restate` | Restate flow engine |
-| `@linchkit/cap-migration` | Legacy system migration |
+| `@linchkit/cap-dry-run` | Sandboxed execution dry-run runner |
+| `@linchkit/cap-lock` | Capability/field lock policy |
+| `@linchkit/cap-migration` | Database migration tooling |
+| `@linchkit/cap-search-ui` | Search UI |
+| `@linchkit/cap-theme` | Theming |
+| `@linchkit/cap-keyboard-shortcuts` | Keyboard shortcuts |
+| `@linchkit/cap-view-kanban` | Kanban view |
+| `@linchkit/cap-view-calendar` | Calendar view |
+| `@linchkit/cap-view-timeline` | Timeline view |
 
 ### Private (not published)
 
 | Package | Description |
 |---------|-------------|
-| `@linchkit/cap-purchase-demo` | Demo capability |
+| `@linchkit/cap-cache-redis` | Redis cache provider |
+| `@linchkit/cap-file-storage` | File storage |
+| `@linchkit/cap-notification` | Notification delivery |
+| `@linchkit/cap-observability-otel` | OpenTelemetry traces/metrics |
+| `@linchkit/cap-search` | Full-text search |
+| `@linchkit/cap-vector-pgvector` | pgvector vector store |
+| `@linchkit/cap-life-demo` | Life-system (Spec 55) demo |
+| `@linchkit/cap-purchase-demo` | Purchase management demo |
 
 ## Migration Guide Template
 


### PR DESCRIPTION
## Root .md honesty pass

Audited every root-level Markdown file against actual repo state. Two commits:

### 1. Factual fixes (objectively-wrong facts)
| File | Was | Now |
|---|---|---|
| `CONTRIBUTING.md` | clone `anthropic-ai/linchkit` | `laofahai/linchkit` (the real remote) |
| `CLAUDE.md` | Restate `v1.11.1` | `v1.14.5` (installed) |
| `CLAUDE.md` / `README.md` / `README.zh-CN.md` | `bun test` | `bun run test` (batched runner; bare `bun test` skips addons) |
| `SECURITY.md` | Supported `0.1.x` | `0.2.x` (core is 0.2.0) |
| `VERSIONING.md` | peerDep example `"^0.1.0"` | `"^0.2.0"` (`^0.1.0` excludes 0.2.0 under caret semver) |

### 2. Owner-approved completeness + corrections
- **Capability catalogs** (README EN/zh + VERSIONING): now list **all 31** `cap-*` packages (was ~13), grouped by addon, tagged with the OCA type/category each declares in `capability.json` / `package.json#linchkit`. Catalog intro corrected — 8 caps are `private` (not on npm), so it no longer claims all install via `linch install`; VERSIONING's published/private tables are now accurate; `cap-migration` description aligned across files.
- **Security/conduct reporting** (`SECURITY.md` / `CODE_OF_CONDUCT.md`): the unverifiable `@linchkit.dev` mailboxes are replaced with GitHub-native private channels (Security Advisories / report-abuse) — a path that actually exists.

A companion PR fixes the `bun test` → `bun run test` **generators** (`agents-md-generator.ts` in core + the CLI templates) that produce AGENTS.md and downstream docs.

No code changed; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
