### PR TITLE
fix(core,cli): emit `bun run test` from doc generators (AGENTS.md + CLI templates)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Key principle: All mutations flow through **Actions** — there is no direct CRU
 | Frontend | React 19 + Vite |
 | Routing | TanStack Router |
 | UI | Shadcn + Radix + Tailwind |
-| Testing | bun test |
+| Testing | bun run test |
 | Code Quality | Biome |
 
 ## Entities
@@ -129,7 +129,7 @@ Organizational department that owns purchase requests
 ```bash
 bun run dev:server    # Start server on :3001
 bun run dev:ui        # Start UI on :3000 (proxies API to :3001)
-bun test              # Run all tests
+bun run test          # Run all tests
 bun run check         # Biome lint + format
 bun run typecheck     # TypeScript check
 bun run db:generate   # Generate migration SQL from schema changes

--- a/packages/cli/src/templates/agent-templates.ts
+++ b/packages/cli/src/templates/agent-templates.ts
@@ -24,7 +24,7 @@ LinchKit AI-Native Software Capability Runtime project.
 \`\`\`bash
 bun install          # Install dependencies
 linch dev            # Start dev server (API on :3001)
-bun run test             # Run tests
+bun run test         # Run tests
 linch db generate    # Generate DB migration from schema changes
 linch db migrate     # Apply pending migrations
 linch create capability <name>  # Scaffold a new capability

--- a/packages/cli/src/templates/agent-templates.ts
+++ b/packages/cli/src/templates/agent-templates.ts
@@ -24,7 +24,7 @@ LinchKit AI-Native Software Capability Runtime project.
 \`\`\`bash
 bun install          # Install dependencies
 linch dev            # Start dev server (API on :3001)
-bun test             # Run tests
+bun run test             # Run tests
 linch db generate    # Generate DB migration from schema changes
 linch db migrate     # Apply pending migrations
 linch create capability <name>  # Scaffold a new capability
@@ -153,7 +153,7 @@ When a user asks you to help set up this project, follow this workflow:
 6. **Register in config** — Add capabilities to \`linchkit.config.ts\`
 7. **Read the relevant spec** — If a spec exists for the area being changed, read it before implementation
 8. **Verify** — Run \`linch dev\` and check that everything works
-9. **Quality gates** — Run \`linch validate\`, \`bun run check\`, \`bun run typecheck\`, \`bun test\`
+9. **Quality gates** — Run \`linch validate\`, \`bun run check\`, \`bun run typecheck\`, \`bun run test\`
 
 Ask one question at a time. Use MCP tools (\`linchkit_list_entities\`, \`linchkit_validate_entity\`, etc.) for project introspection.
 

--- a/packages/cli/src/templates/ai-tool-templates.ts
+++ b/packages/cli/src/templates/ai-tool-templates.ts
@@ -34,7 +34,7 @@ Execution order for AI work:
 - Entity naming: snake_case
 - Action naming: verb_noun
 - Comments in English
-- Run quality gates before committing: \`linch validate && bun run check && bun run typecheck && bun test\`
+- Run quality gates before committing: \`linch validate && bun run check && bun run typecheck && bun run test\`
 `;
 }
 
@@ -52,7 +52,7 @@ Key rules:
 - Runtime: Bun (never Node/npx/npm)
 - TypeScript strict mode
 - All definitions use \`defineXxx()\` functions
-- Quality gates: \`linch validate && bun run check && bun run typecheck && bun test\`
+- Quality gates: \`linch validate && bun run check && bun run typecheck && bun run test\`
 `;
 }
 
@@ -73,7 +73,7 @@ Execution order for AI work:
 - Entity naming: snake_case
 - Action naming: verb_noun
 - Comments in English
-- Run quality gates before committing: \`linch validate && bun run check && bun run typecheck && bun test\`
+- Run quality gates before committing: \`linch validate && bun run check && bun run typecheck && bun run test\`
 `;
 }
 
@@ -100,7 +100,7 @@ This project uses LinchKit, an AI-Native Software Capability Runtime.
 1. \`linch validate\` — capability validation
 2. \`bun run check\` — Biome lint + format
 3. \`bun run typecheck\` — TypeScript strict check
-4. \`bun test\` — all tests green
+4. \`bun run test\` — all tests green
 
 Read AGENTS.md for the full meta-model reference and development workflow.
 `;

--- a/packages/cli/src/templates/skill-templates.ts
+++ b/packages/cli/src/templates/skill-templates.ts
@@ -98,12 +98,12 @@ description: "Full capability development workflow from discovery to quality gat
 2. **Design** — Define the data structures first. Use \`defineEntity()\` for each model, \`defineRelation()\` for connections.
 3. **Validate** — Run \`linch validate\` to check definitions against the meta-model.
 4. **Implement** — Write action handlers, rule effects, and event handlers.
-5. **Test** — Write tests using \`bun test\`. Cover entity CRUD, action execution, rule triggering, and state transitions.
+5. **Test** — Write tests using \`bun run test\`. Cover entity CRUD, action execution, rule triggering, and state transitions.
 6. **Quality Gates** — All four must pass:
    - \`linch validate\`
    - \`bun run check\`
    - \`bun run typecheck\`
-   - \`bun test\`
+   - \`bun run test\`
 
 ## MCP Tools
 
@@ -396,7 +396,7 @@ Runs \`tsc --noEmit\` in strict mode. No \`any\` types allowed.
 
 ## 4. Tests
 \`\`\`bash
-bun test
+bun run test
 \`\`\`
 All tests must pass. Write tests alongside implementation.
 
@@ -512,7 +512,7 @@ All four checks MUST pass:
 linch validate
 bun run check
 bun run typecheck
-bun test
+bun run test
 \`\`\`
 
 ## Guidelines

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -93,7 +93,7 @@ Follow-up commits on unchanged code don't need re-runs; commits after any of the
 linch validate        # Meta-model validation (manual — run when touching definitions)
 bun run check         # Biome lint + format (hook-tracked, fresh-gated)
 bun run typecheck     # TypeScript strict check (hook-tracked, fresh-gated)
-bun test              # Full test suite (hook-tracked, fresh-gated — must be exact \`bun test\`, not filtered)
+bun run test          # Full test suite (hook-tracked, fresh-gated — runs the project's test script)
 \`\`\`
 
 ## Step 5: Cross-Model Review

--- a/packages/core/src/ontology/agents-md-generator.ts
+++ b/packages/core/src/ontology/agents-md-generator.ts
@@ -98,7 +98,7 @@ function renderTechStack(): string {
     "| Frontend | React 19 + Vite |",
     "| Routing | TanStack Router |",
     "| UI | Shadcn + Radix + Tailwind |",
-    "| Testing | bun test |",
+    "| Testing | bun run test |",
     "| Code Quality | Biome |",
   ].join("\n");
 }
@@ -254,7 +254,7 @@ function renderDevCommands(): string {
     "```bash",
     "bun run dev:server    # Start server on :3001",
     "bun run dev:ui        # Start UI on :3000 (proxies API to :3001)",
-    "bun test              # Run all tests",
+    "bun run test          # Run all tests",
     "bun run check         # Biome lint + format",
     "bun run typecheck     # TypeScript check",
     "bun run db:generate   # Generate migration SQL from schema changes",


### PR DESCRIPTION
## Fix the `bun test` → `bun run test` doc generators

Companion to the root-.md honesty pass. The checked-in `AGENTS.md` showed a stale `| Testing | bun test |` row and a `bun test  # Run all tests` line — but `AGENTS.md` is **generated**, so the real fix is in the generators, not a hand-edit that the next `linch agents-md` would clobber.

- **core** — `packages/core/src/ontology/agents-md-generator.ts`: the Tech Stack "Testing" row and the Dev Commands block now emit `bun run test`. (This is the actual source of AGENTS.md's content.)
- **cli templates** — `ai-tool-templates.ts`, `agent-templates.ts`, `workflow-skill-templates.ts`, `skill-templates.ts`: `bun test` → `bun run test` in the downstream-facing CLAUDE.md / skill / agent docs. The workflow-skill template also drops a leaked monorepo-specific note ("must be exact `bun test`, not filtered") that doesn't apply to downstream projects.
- **AGENTS.md** — the two affected lines are hand-applied so the checked-in artifact matches the fixed generator now (a future full `linch agents-md` produces the same).

`bun run test` is correct both here (the monorepo's batched runner — a bare `bun test` crashes mid-run and skips addons) and downstream (it runs the project's own `test` script). `project-templates.ts` intentionally keeps `"test": "bun test"` as the scaffolded downstream package.json script body — a single downstream package needs no batched runner, and `bun run test` invokes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
