### PR TITLE
feat(adapter-server,ai-provider): record traces on streaming chat + AG-UI runner (Spec 69 P3 / #350)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/ai/agui-runner.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/agui-runner.ts
@@ -290,7 +290,9 @@ export function createAssistantAgUiRunner(options: ServerOptions): AgUiAgentRunn
 
     // Lazy imports — mirrors ai-api.ts so heavy deps load on first use only.
     const { streamText, stepCountIs, jsonSchema } = await import("ai");
-    const { resolveLanguageModel } = await import("@linchkit/cap-ai-provider");
+    const { resolveLanguageModel, resolveModel, instrumentRawStream } = await import(
+      "@linchkit/cap-ai-provider"
+    );
     const { createTenantAwareDataProvider } = await import("@linchkit/core/server");
     const { buildSystemPrompt, extractLocale } = await import("./system-prompt");
     const { buildTools } = await import("./tools");
@@ -350,21 +352,48 @@ export function createAssistantAgUiRunner(options: ServerOptions): AgUiAgentRunn
       toSchema: jsonSchema,
     });
 
-    const result = streamText({
-      model,
-      system: systemPrompt,
-      messages: toModelMessagesFromAgUi(input.messages),
-      tools: { ...frontendTools, ...tools },
-      stopWhen: stepCountIs(assistantConfig?.maxSteps ?? 5),
-      temperature: assistantConfig?.temperature ?? 0.3,
-      abortSignal: signal,
+    // Record this streaming generation to the AI trace sink. The runner owns
+    // the `streamText` call (tools + multi-step + fullStream translation), so
+    // it spreads the SDK's non-throwing onFinish/onError/onAbort callbacks to
+    // land the generation in the SAME sink as `completeStream`. See #350.
+    const modelAlias = assistantConfig?.model ?? "fast";
+    const { provider, modelId } = resolveModel(aiConfig, undefined, modelAlias);
+    const temperature = assistantConfig?.temperature ?? 0.3;
+    const modelMessages = toModelMessagesFromAgUi(input.messages);
+    const trace = instrumentRawStream({
+      trace: { name: "assistant-agui", model: modelAlias, tenantId, actorId: actor?.id },
+      provider,
+      model: modelId,
+      messages: modelMessages,
+      temperature,
     });
 
-    for await (const part of result.fullStream) {
-      if (signal?.aborted) break; // client went away — stop consuming
-      for (const event of streamPartToAgUiEvents(part)) {
-        emit(event);
+    // Guard construction + iteration so any throw still finalizes the trace
+    // (`fail`) instead of leaking the parent opened above. An async stream error
+    // already fired `onError` (settling the latch), so `fail` is then a no-op.
+    try {
+      const result = streamText({
+        model,
+        system: systemPrompt,
+        messages: modelMessages,
+        tools: { ...frontendTools, ...tools },
+        stopWhen: stepCountIs(assistantConfig?.maxSteps ?? 5),
+        temperature,
+        abortSignal: signal,
+        onFinish: trace.onFinish,
+        onError: trace.onError,
+        onAbort: trace.onAbort,
+      });
+
+      for await (const part of result.fullStream) {
+        if (signal?.aborted) break; // client went away — stop consuming
+        for (const event of streamPartToAgUiEvents(part)) {
+          emit(event);
+        }
       }
+    } catch (streamErr) {
+      trace.fail(streamErr);
+      throw streamErr;
     }
   };
 }

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-api.ts
@@ -477,7 +477,9 @@ Only include fields where you have genuine confidence. Omit fields where you wou
 
       try {
         const { streamText, stepCountIs, convertToModelMessages } = await import("ai");
-        const { resolveLanguageModel } = await import("@linchkit/cap-ai-provider");
+        const { resolveLanguageModel, resolveModel, instrumentRawStream } = await import(
+          "@linchkit/cap-ai-provider"
+        );
         const { createTenantAwareDataProvider } = await import("@linchkit/core/server");
         const { buildSystemPrompt } = await import("../ai/system-prompt");
         const { buildTools } = await import("../ai/tools");
@@ -545,20 +547,47 @@ Only include fields where you have genuine confidence. Omit fields where you wou
         // useChat sends messages in UI format (with parts array), but streamText expects model format
         const modelMessages = await convertToModelMessages(messages, { tools });
 
-        // Use Vercel AI SDK streamText with tools and multi-step support
-        const result = streamText({
-          model,
-          system: systemPrompt,
+        // Record this streaming generation to the AI trace sink. The endpoint
+        // owns the `streamText` call (tools + multi-step + UI message stream),
+        // so it cannot route through the instrumented `completeStream`; instead
+        // it spreads the SDK's onFinish/onError/onAbort callbacks (non-throwing,
+        // one-shot) so the generation lands in the SAME sink. See Spec 69 P3 / #350.
+        const modelAlias = assistantConfig?.model ?? "fast";
+        const { provider, modelId } = resolveModel(aiConfig, undefined, modelAlias);
+        const temperature = assistantConfig?.temperature ?? 0.3;
+        const trace = instrumentRawStream({
+          trace: { name: "assistant-chat", model: modelAlias, tenantId, actorId: actor?.id },
+          provider,
+          model: modelId,
           messages: modelMessages,
-          tools,
-          stopWhen: stepCountIs(assistantConfig?.maxSteps ?? 5),
-          temperature: assistantConfig?.temperature ?? 0.3,
-          abortSignal: request.signal,
+          temperature,
         });
 
-        // Return standard Vercel AI SDK UI message stream response
-        // Compatible with @ai-sdk/react useChat hook
-        return result.toUIMessageStreamResponse();
+        // Use Vercel AI SDK streamText with tools and multi-step support.
+        // Guard the synchronous construction so a sync throw still finalizes the
+        // trace (`fail`) instead of leaking the parent opened above; async stream
+        // errors go through `onError` and never reach here.
+        try {
+          const result = streamText({
+            model,
+            system: systemPrompt,
+            messages: modelMessages,
+            tools,
+            stopWhen: stepCountIs(assistantConfig?.maxSteps ?? 5),
+            temperature,
+            abortSignal: request.signal,
+            onFinish: trace.onFinish,
+            onError: trace.onError,
+            onAbort: trace.onAbort,
+          });
+
+          // Return standard Vercel AI SDK UI message stream response
+          // Compatible with @ai-sdk/react useChat hook
+          return result.toUIMessageStreamResponse();
+        } catch (streamErr) {
+          trace.fail(streamErr);
+          throw streamErr;
+        }
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : "AI chat failed";
         set.status = 500;

--- a/addons/ai-provider/cap-ai-provider/__tests__/stream-instrumentation.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/stream-instrumentation.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests for {@link instrumentRawStream} — the onFinish/onError/onAbort
+ * trace callbacks the streaming chat endpoint + AG-UI runner attach to their
+ * caller-owned `streamText` calls.
+ *
+ * Strategy: install an {@link InMemoryAITraceStore} sink, invoke the returned
+ * callbacks with SDK-shaped events, and assert exactly one (or zero, for abort)
+ * generation lands with the right model/provider/tokens/status. Each callback
+ * is asserted non-throwing — they run inside the SDK stream machinery, where a
+ * throw would break the consumer's stream.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  type AITraceSink,
+  InMemoryAITraceStore,
+  resetAITraceSink,
+  setAITraceSink,
+} from "@linchkit/core/server";
+import { CostEstimator } from "../src/cost-estimator";
+import { instrumentRawStream } from "../src/stream-instrumentation";
+
+let sink: InMemoryAITraceStore;
+
+beforeEach(() => {
+  sink = new InMemoryAITraceStore();
+  setAITraceSink(sink);
+});
+
+afterEach(() => {
+  resetAITraceSink();
+});
+
+const BASE = {
+  provider: "zhipu",
+  model: "glm-4-flash",
+  messages: [{ role: "user", content: "hello" }],
+  temperature: 0.3,
+} as const;
+
+describe("instrumentRawStream", () => {
+  it("onFinish records one ok generation with tokens + cost + model/provider", () => {
+    // Inject pricing for the test model so cost is a concrete number (the
+    // default estimator has no glm-4-flash pricing → cost would be undefined).
+    const costEstimator = new CostEstimator({
+      "glm-4-flash": { inputPerToken: 1 / 1_000_000, outputPerToken: 2 / 1_000_000 },
+    });
+    const trace = instrumentRawStream({
+      ...BASE,
+      costEstimator,
+      trace: { name: "assistant-chat" },
+    });
+
+    expect(() =>
+      trace.onFinish({
+        text: "hi there",
+        totalUsage: { inputTokens: 12, outputTokens: 7 },
+      }),
+    ).not.toThrow();
+
+    const gens = sink.query();
+    expect(gens).toHaveLength(1);
+    const gen = gens[0];
+    expect(gen?.status).toBe("ok");
+    expect(gen?.partial).toBe(false);
+    expect(gen?.model).toBe("glm-4-flash");
+    expect(gen?.provider).toBe("zhipu");
+    expect(gen?.inputTokens).toBe(12);
+    expect(gen?.outputTokens).toBe(7);
+    // 12 * 1e-6 + 7 * 2e-6 = 2.6e-5
+    expect(gen?.cost).toBeCloseTo(2.6e-5, 10);
+    expect(gen?.responseFormat).toBe("text");
+  });
+
+  it("onFinish tolerates a missing usage object (records zero tokens, still ok)", () => {
+    const trace = instrumentRawStream(BASE);
+    expect(() => trace.onFinish({ text: "no usage" })).not.toThrow();
+
+    const gen = sink.query()[0];
+    expect(gen?.status).toBe("ok");
+    expect(gen?.inputTokens).toBe(0);
+    expect(gen?.outputTokens).toBe(0);
+  });
+
+  it("onError records one partial/error generation with zero tokens", () => {
+    const trace = instrumentRawStream(BASE);
+
+    expect(() => trace.onError({ error: new Error("provider exploded") })).not.toThrow();
+
+    const gens = sink.query();
+    expect(gens).toHaveLength(1);
+    const gen = gens[0];
+    expect(gen?.status).toBe("error");
+    expect(gen?.partial).toBe(true);
+    expect(gen?.inputTokens).toBe(0);
+    expect(gen?.outputTokens).toBe(0);
+    // The error message is stored but REDACTED by the sink (masked), so assert
+    // it is captured (non-empty) rather than matching the raw text.
+    expect(typeof gen?.error).toBe("string");
+    expect(gen?.error?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("onAbort records NO generation but does not throw", () => {
+    const trace = instrumentRawStream(BASE);
+
+    expect(() => trace.onAbort()).not.toThrow();
+    expect(sink.query()).toHaveLength(0);
+  });
+
+  it("fail records one partial/error generation (synchronous streamText throw)", () => {
+    const trace = instrumentRawStream(BASE);
+
+    expect(() => trace.fail(new Error("streamText threw synchronously"))).not.toThrow();
+
+    const gens = sink.query();
+    expect(gens).toHaveLength(1);
+    expect(gens[0]?.status).toBe("error");
+    expect(gens[0]?.partial).toBe(true);
+  });
+
+  it("fail is a no-op once a terminal callback already settled the trace", () => {
+    const trace = instrumentRawStream(BASE);
+
+    trace.onFinish({ text: "done", totalUsage: { inputTokens: 4, outputTokens: 2 } });
+    trace.fail(new Error("late sync throw"));
+
+    const gens = sink.query();
+    expect(gens).toHaveLength(1);
+    expect(gens[0]?.status).toBe("ok");
+  });
+
+  it("is one-shot: the first terminal callback wins, later ones are ignored", () => {
+    const trace = instrumentRawStream(BASE);
+
+    trace.onFinish({ text: "done", totalUsage: { inputTokens: 5, outputTokens: 3 } });
+    // A late error after a clean finish must NOT add a second record.
+    trace.onError({ error: new Error("late") });
+    trace.onAbort();
+
+    const gens = sink.query();
+    expect(gens).toHaveLength(1);
+    expect(gens[0]?.status).toBe("ok");
+  });
+
+  it("one-shot also holds when onError fires first", () => {
+    const trace = instrumentRawStream(BASE);
+
+    trace.onError({ error: new Error("first") });
+    trace.onFinish({ text: "too late", totalUsage: { inputTokens: 9, outputTokens: 9 } });
+
+    const gens = sink.query();
+    expect(gens).toHaveLength(1);
+    expect(gens[0]?.status).toBe("error");
+  });
+
+  it("stringifies non-string error values without throwing", () => {
+    const trace = instrumentRawStream(BASE);
+    expect(() => trace.onError({ error: { code: 500 } })).not.toThrow();
+    expect(sink.query()[0]?.status).toBe("error");
+  });
+
+  it("never throws even when the sink itself throws", () => {
+    const throwingSink: AITraceSink = {
+      startTrace: () => {
+        throw new Error("sink down");
+      },
+      endTrace: () => {
+        throw new Error("sink down");
+      },
+      recordGeneration: () => {
+        throw new Error("sink down");
+      },
+      query: () => [],
+      queryTraces: () => [],
+      size: 0,
+      clear: () => {},
+    };
+    setAITraceSink(throwingSink);
+
+    const trace = instrumentRawStream(BASE);
+    expect(() =>
+      trace.onFinish({ text: "x", totalUsage: { inputTokens: 1, outputTokens: 1 } }),
+    ).not.toThrow();
+    expect(() => trace.onError({ error: new Error("y") })).not.toThrow();
+  });
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/stream-instrumentation.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/stream-instrumentation.test.ts
@@ -107,6 +107,21 @@ describe("instrumentRawStream", () => {
     expect(sink.query()).toHaveLength(0);
   });
 
+  it("coerces message roles to the stored union (developer→system, tool→assistant)", () => {
+    const trace = instrumentRawStream({
+      ...BASE,
+      messages: [
+        { role: "developer", content: "system-ish instructions" },
+        { role: "tool", content: "tool result" },
+        { role: "user", content: "hi" },
+      ],
+    });
+    trace.onFinish({ text: "ok", totalUsage: { inputTokens: 1, outputTokens: 1 } });
+
+    const gen = sink.query()[0];
+    expect(gen?.messages.map((m) => m.role)).toEqual(["system", "assistant", "user"]);
+  });
+
   it("fail records one partial/error generation (synchronous streamText throw)", () => {
     const trace = instrumentRawStream(BASE);
 
@@ -177,10 +192,20 @@ describe("instrumentRawStream", () => {
     };
     setAITraceSink(throwingSink);
 
-    const trace = instrumentRawStream(BASE);
+    // onFinish's recording path swallows a throwing sink.
     expect(() =>
-      trace.onFinish({ text: "x", totalUsage: { inputTokens: 1, outputTokens: 1 } }),
+      instrumentRawStream(BASE).onFinish({
+        text: "x",
+        totalUsage: { inputTokens: 1, outputTokens: 1 },
+      }),
     ).not.toThrow();
-    expect(() => trace.onError({ error: new Error("y") })).not.toThrow();
+
+    // onError's recording path (recordError + its `finally { parent.end }`) must
+    // ALSO swallow a throwing sink. Use a FRESH instance so the one-shot latch
+    // doesn't short-circuit onError before it enters recordError.
+    expect(() => instrumentRawStream(BASE).onError({ error: new Error("y") })).not.toThrow();
+
+    // And the synchronous fail() path shares recordError — verify it too.
+    expect(() => instrumentRawStream(BASE).fail(new Error("z"))).not.toThrow();
   });
 });

--- a/addons/ai-provider/cap-ai-provider/__tests__/stream-instrumentation.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/stream-instrumentation.test.ts
@@ -82,6 +82,28 @@ describe("instrumentRawStream", () => {
     expect(gen?.outputTokens).toBe(0);
   });
 
+  it("a throwing cost estimator on success still records ok and never flips the trace to error", () => {
+    const throwingEstimator = {
+      estimateCost: () => {
+        throw new Error("pricing boom");
+      },
+    } as unknown as CostEstimator;
+    const trace = instrumentRawStream({ ...BASE, costEstimator: throwingEstimator });
+
+    expect(() =>
+      trace.onFinish({ text: "ok", totalUsage: { inputTokens: 10, outputTokens: 5 } }),
+    ).not.toThrow();
+
+    // The generation is still recorded as a success — a thrown estimator drops
+    // only the cost, not the record.
+    const gen = sink.query()[0];
+    expect(gen?.status).toBe("ok");
+    expect(gen?.cost).toBeUndefined();
+    // And the parent trace stays "ok" — onFinish fired because the AI call
+    // succeeded; a tracing/estimation failure must not report it as errored.
+    expect(sink.queryTraces()[0]?.status).toBe("ok");
+  });
+
   it("onError records one partial/error generation with zero tokens", () => {
     const trace = instrumentRawStream(BASE);
 

--- a/addons/ai-provider/cap-ai-provider/src/index.ts
+++ b/addons/ai-provider/cap-ai-provider/src/index.ts
@@ -87,6 +87,16 @@ export type {
 export { PatternDetector } from "./pattern-detector";
 // Response Cache
 export { AIResponseCache } from "./response-cache";
+// Raw-stream trace instrumentation — onFinish/onError/onAbort callbacks for
+// caller-owned `streamText` calls (streaming chat endpoint + AG-UI runner) so
+// transport-layer assistant traffic records to the same trace sink as
+// `completeStream`. See ./stream-instrumentation.ts.
+export type {
+  InstrumentRawStreamOptions,
+  RawStreamInstrumentation,
+  RawStreamMessage,
+} from "./stream-instrumentation";
+export { instrumentRawStream } from "./stream-instrumentation";
 // Watcher Engine (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
 export {
   createWatcherEngine,

--- a/addons/ai-provider/cap-ai-provider/src/stream-instrumentation.ts
+++ b/addons/ai-provider/cap-ai-provider/src/stream-instrumentation.ts
@@ -95,9 +95,15 @@ export interface RawStreamInstrumentation {
   readonly fail: (error: unknown) => void;
 }
 
-/** Coerce an arbitrary role to the strict union the sink stores (default assistant). */
+/**
+ * Coerce an arbitrary model-message role to the strict union the sink stores.
+ * `"developer"` (newer OpenAI / Vercel AI SDK system-equivalent role) maps to
+ * `"system"` to preserve its meaning; any other non-standard role (e.g. `"tool"`)
+ * falls back to `"assistant"`.
+ */
 function coerceRole(role: string): AIMessage["role"] {
-  return role === "system" || role === "user" || role === "assistant" ? role : "assistant";
+  if (role === "system" || role === "developer") return "system";
+  return role === "user" || role === "assistant" ? role : "assistant";
 }
 
 /** Coerce arbitrary model-message content to the string shape the sink stores. */

--- a/addons/ai-provider/cap-ai-provider/src/stream-instrumentation.ts
+++ b/addons/ai-provider/cap-ai-provider/src/stream-instrumentation.ts
@@ -191,6 +191,14 @@ export function instrumentRawStream(opts: InstrumentRawStreamOptions): RawStream
       const inputTokens = usage?.inputTokens ?? 0;
       const outputTokens = usage?.outputTokens ?? 0;
       const completion = typeof event.text === "string" ? event.text : "";
+      // Estimate cost defensively — a throwing custom estimator must NOT cost us
+      // the whole generation record (and must not flip the parent to "error").
+      let cost: number | undefined;
+      try {
+        cost = costEstimator.estimateCost(opts.model, inputTokens, outputTokens);
+      } catch (err) {
+        logTracingError("raw-stream-cost", err);
+      }
       recordGeneration({
         traceId: parent.traceId,
         context: opts.trace,
@@ -200,7 +208,7 @@ export function instrumentRawStream(opts: InstrumentRawStreamOptions): RawStream
         completion,
         inputTokens,
         outputTokens,
-        cost: costEstimator.estimateCost(opts.model, inputTokens, outputTokens),
+        cost,
         latencyMs: endedAt - startTime,
         temperature: opts.temperature,
         responseFormat: "text",
@@ -211,12 +219,14 @@ export function instrumentRawStream(opts: InstrumentRawStreamOptions): RawStream
         sampling: opts.sampling,
         forcedSampled: parent.sampled,
       });
-      parent.end("ok");
     } catch (err) {
-      // recordGeneration is itself non-throwing; this guards estimateCost and
-      // keeps the SDK callback from ever throwing into the consumer's stream.
+      // recordGeneration is itself non-throwing; this guards any other sync
+      // throw and keeps the SDK callback from throwing into the consumer's stream.
       logTracingError("raw-stream-finish", err);
-      parent.end("error");
+    } finally {
+      // `onFinish` only fires on a SUCCESSFUL stream — a tracing/estimation
+      // failure must NOT flip the parent trace to "error". End "ok" exactly once.
+      parent.end("ok");
     }
   };
 

--- a/addons/ai-provider/cap-ai-provider/src/stream-instrumentation.ts
+++ b/addons/ai-provider/cap-ai-provider/src/stream-instrumentation.ts
@@ -1,0 +1,239 @@
+/**
+ * Trace instrumentation for caller-owned raw `streamText` calls.
+ *
+ * The {@link createAIService} `completeStream` path instruments its stream by
+ * WRAPPING the SDK `textStream` (it owns iteration, so it records after a clean
+ * drain). But the transport-layer assistant paths — the streaming `/api/ai/chat`
+ * endpoint and the AG-UI agent runner — call the Vercel AI SDK `streamText`
+ * DIRECTLY (they need tools, multi-step, `fullStream`, and
+ * `toUIMessageStreamResponse()`), so wrapping `textStream` is not an option:
+ * the HTTP response / AG-UI translator consumes the stream, not our code.
+ *
+ * The SDK exposes the terminal callbacks `onFinish` / `onError` / `onAbort`
+ * instead. {@link instrumentRawStream} opens ONE parent trace and returns those
+ * callbacks (plus a {@link RawStreamInstrumentation.fail} escape hatch for a
+ * synchronous `streamText` throw) pre-wired to {@link recordGeneration}, so a
+ * caller spreads them straight into its own `streamText({ ... })` call and the
+ * generation lands in the SAME trace sink as `completeStream` — without
+ * altering the stream's content, ordering, or timing.
+ *
+ * Every callback is STRICTLY non-throwing: it runs inside the SDK's stream
+ * machinery, so a throw could break the consumer's stream. A one-shot `settled`
+ * latch guarantees AT MOST one terminal callback records.
+ */
+
+import type { AIMessage, AITraceContext, AITraceSamplingConfig } from "@linchkit/core";
+import {
+  logTracingError,
+  openParentTrace,
+  type ParentTraceHandle,
+  recordGeneration,
+} from "./ai-tracing";
+import { type CostEstimator, defaultCostEstimator } from "./cost-estimator";
+
+/** A prompt message in the shape the tracer records (role + stringifiable content). */
+export interface RawStreamMessage {
+  readonly role: string;
+  readonly content: unknown;
+}
+
+/** Options for {@link instrumentRawStream}. */
+export interface InstrumentRawStreamOptions {
+  /**
+   * Trace context. `origin` defaults to `"production"`; `name` is a
+   * human-readable label (e.g. `"assistant-chat"`); `tenantId` / `actorId`
+   * forward isolation + provenance to the sink.
+   */
+  readonly trace?: AITraceContext;
+  /** Resolved provider name (e.g. `"zhipu"`). */
+  readonly provider: string;
+  /** Resolved model id (e.g. `"glm-4-flash"`). */
+  readonly model: string;
+  /** Prompt messages sent to the model (recorded raw, redacted by the sink). */
+  readonly messages: readonly RawStreamMessage[];
+  readonly temperature?: number;
+  /** Cost estimator. Defaults to the shared {@link defaultCostEstimator}. */
+  readonly costEstimator?: CostEstimator;
+  /** Sampling config — rolled ONCE for the parent trace and threaded down. */
+  readonly sampling?: AITraceSamplingConfig;
+}
+
+/** Aggregated token usage, as exposed on the SDK `streamText` finish event. */
+interface StreamUsageLike {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+}
+
+/**
+ * The subset of the SDK `streamText` `onFinish` event this module reads. Kept
+ * structurally minimal (all optional) so the real `OnFinishEvent<TOOLS>` — which
+ * has these fields and more — is assignable to it, letting the callback spread
+ * into `streamText({ onFinish })` without an `any` cast.
+ */
+interface StreamFinishEventLike {
+  readonly text?: string;
+  /** Usage aggregated across all steps (preferred). */
+  readonly totalUsage?: StreamUsageLike;
+  /** Single-step usage (fallback when `totalUsage` is absent). */
+  readonly usage?: StreamUsageLike;
+}
+
+/**
+ * The terminal callbacks the caller spreads into `streamText`, plus `fail` for
+ * a synchronous `streamText` throw (before any callback can fire).
+ */
+export interface RawStreamInstrumentation {
+  readonly onFinish: (event: StreamFinishEventLike) => void;
+  readonly onError: (event: { error: unknown }) => void;
+  readonly onAbort: () => void;
+  /**
+   * Finalize as errored when the caller's `streamText` throws SYNCHRONOUSLY,
+   * before any terminal callback can fire — otherwise the parent trace opened
+   * at construction would leak open. One-shot (no-op once settled), so it is
+   * safe to call from a catch that also overlaps a fired callback.
+   */
+  readonly fail: (error: unknown) => void;
+}
+
+/** Coerce an arbitrary role to the strict union the sink stores (default assistant). */
+function coerceRole(role: string): AIMessage["role"] {
+  return role === "system" || role === "user" || role === "assistant" ? role : "assistant";
+}
+
+/** Coerce arbitrary model-message content to the string shape the sink stores. */
+function coerceMessages(messages: readonly RawStreamMessage[]): AIMessage[] {
+  return messages.map((m) => ({
+    role: coerceRole(m.role),
+    content: typeof m.content === "string" ? m.content : safeStringify(m.content),
+  }));
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Build the terminal callbacks for a caller-owned raw `streamText` call so it
+ * records ONE generation to the active trace sink.
+ *
+ * - `onFinish(event)` — clean completion. Reads `event.totalUsage` (aggregated
+ *   across steps) + `event.text` and records `partial: false` / `status: "ok"`
+ *   with cost computed by the SAME estimator the completion path uses.
+ * - `onError({ error })` / `fail(error)` — stream error (async) or a
+ *   synchronous `streamText` throw. Records `partial: true` / `status: "error"`
+ *   with zero tokens (usage is unknown), mirroring the completion error path.
+ * - `onAbort()` — consumer aborted (client disconnect). Usage never resolves on
+ *   a non-drained stream, so NO generation is recorded; the parent trace is
+ *   finalized so it is never left open (mirrors `completeStream`'s abandon path).
+ *
+ * A one-shot `settled` latch ensures at most one callback records, and every
+ * callback swallows its own errors so tracing can never break the stream.
+ */
+export function instrumentRawStream(opts: InstrumentRawStreamOptions): RawStreamInstrumentation {
+  const startTime = Date.now();
+  const costEstimator = opts.costEstimator ?? defaultCostEstimator;
+  const messages = coerceMessages(opts.messages);
+  // Open the parent trace ONCE so the generation lands under a parent and the
+  // sampling decision rolls a single die (threaded down via `forcedSampled`).
+  // Non-throwing — returns an inert handle on failure.
+  const parent: ParentTraceHandle = openParentTrace(opts.trace, { sampling: opts.sampling });
+  let settled = false;
+
+  // Record a partial/error generation (shared by the async onError and the
+  // synchronous fail path). Strictly non-throwing — `parent.end` finalizes even
+  // if the (already non-throwing) recordGeneration or estimator misbehaves.
+  const recordError = (error: unknown): void => {
+    try {
+      const endedAt = Date.now();
+      recordGeneration({
+        traceId: parent.traceId,
+        context: opts.trace,
+        model: opts.model,
+        provider: opts.provider,
+        messages,
+        completion: "",
+        inputTokens: 0,
+        outputTokens: 0,
+        latencyMs: endedAt - startTime,
+        temperature: opts.temperature,
+        responseFormat: "text",
+        partial: true,
+        status: "error",
+        error: error instanceof Error ? error.message : String(error),
+        startedAt: startTime,
+        endedAt,
+        sampling: opts.sampling,
+        forcedSampled: parent.sampled,
+      });
+    } catch (err) {
+      logTracingError("raw-stream-error", err);
+    } finally {
+      parent.end("error");
+    }
+  };
+
+  const onFinish = (event: StreamFinishEventLike): void => {
+    if (settled) return;
+    settled = true;
+    try {
+      const endedAt = Date.now();
+      const usage = event.totalUsage ?? event.usage;
+      const inputTokens = usage?.inputTokens ?? 0;
+      const outputTokens = usage?.outputTokens ?? 0;
+      const completion = typeof event.text === "string" ? event.text : "";
+      recordGeneration({
+        traceId: parent.traceId,
+        context: opts.trace,
+        model: opts.model,
+        provider: opts.provider,
+        messages,
+        completion,
+        inputTokens,
+        outputTokens,
+        cost: costEstimator.estimateCost(opts.model, inputTokens, outputTokens),
+        latencyMs: endedAt - startTime,
+        temperature: opts.temperature,
+        responseFormat: "text",
+        partial: false,
+        status: "ok",
+        startedAt: startTime,
+        endedAt,
+        sampling: opts.sampling,
+        forcedSampled: parent.sampled,
+      });
+      parent.end("ok");
+    } catch (err) {
+      // recordGeneration is itself non-throwing; this guards estimateCost and
+      // keeps the SDK callback from ever throwing into the consumer's stream.
+      logTracingError("raw-stream-finish", err);
+      parent.end("error");
+    }
+  };
+
+  const onError = (event: { error: unknown }): void => {
+    if (settled) return;
+    settled = true;
+    recordError(event.error);
+  };
+
+  const onAbort = (): void => {
+    if (settled) return;
+    settled = true;
+    // Usage / text never resolve on a non-drained stream, so do NOT record a
+    // generation (awaiting them could hang the recorder). Just finalize the
+    // parent so a started trace is never left without a matching end.
+    parent.end("ok");
+  };
+
+  const fail = (error: unknown): void => {
+    if (settled) return;
+    settled = true;
+    recordError(error);
+  };
+
+  return { onFinish, onError, onAbort, fail };
+}


### PR DESCRIPTION
## What

Closes the trace-coverage gap left by #557 (Spec 69 P3 wave 2 / #350): the AI
trace sink was wired at boot and proven to persist, **but the two live assistant
serving paths produced ZERO traces** because they call the Vercel AI SDK
`streamText` DIRECTLY (they need tools, multi-step, `fullStream`, and
`toUIMessageStreamResponse()`), bypassing `createAIService`'s instrumentation:

- streaming `POST /api/ai/chat`
- the AG-UI assistant agent runner (`agui-runner.ts`)

So real user chat traffic recorded nothing — only the non-streaming
`aiService.complete()` callers (auto-fill, intent resolution, eval, code-gen)
were traced.

## How

`instrumentRawStream(opts)` (new, in `cap-ai-provider`) opens ONE parent trace
and returns the SDK's terminal callbacks pre-wired to `recordGeneration`:

- `onFinish` → `partial:false / status:ok` with aggregated tokens + cost (same
  estimator as the completion path).
- `onError` → `partial:true / status:error`, zero tokens (usage unknown).
- `onAbort` → no generation (usage never resolves on a non-drained stream);
  parent finalized so it never leaks — mirrors `completeStream`'s abandon path.
- `fail(error)` → escape hatch for a SYNCHRONOUS `streamText` throw, so the
  parent opened at construction can't leak before any callback fires.

A one-shot `settled` latch guarantees AT MOST one terminal callback records, and
every callback swallows its own errors (they run inside the SDK stream machinery
— a throw would break the consumer's stream). Both serving paths resolve
`{ provider, modelId }` via `resolveModel` and spread the callbacks into their
existing `streamText({ ... })`, wrapped in a `try/catch` that calls `fail` on a
sync throw. Stream content/ordering/timing are unchanged.

## Verification

- **Live e2e through the SHIPPED wiring** (real `glm-4-flash` streaming call via
  `server.handle(POST /api/ai/chat)` with an InMemory sink installed exactly as
  `wireAITraceSink` does at boot): trace generations **0 → 1**, recorded
  `provider=zhipu, model=glm-4-flash-250414, status=ok, partial=false,
  in=690/out=3 tokens, latency≈0.6s`. Re-proven on the final hardened code.
- 10 unit tests for `instrumentRawStream` (ok / error / abort / fail / one-shot
  latch idempotency / non-string error / sink-throws-but-callback-never-throws).
- `bun run typecheck`, `bun run check`, `bun run test` all green.

## Review notes

CLI cross-model review (gemini) flagged and was addressed: parent-trace leak on
sync throw → `fail()` + caller `try/catch`; `as any` on message role → removed
all `any` (typed SDK-event interfaces + `coerceRole` to the valid union). A
flagged "import typo" was a false positive (pipe-mangled diff; the actual import
is clean — typecheck passes). `coerceRole` maps non-standard roles (e.g. `tool`)
to `assistant`; widening the core `AIMessage`/`AITraceMessage` role union for
richer fidelity is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
