### PR TITLE
feat(adapter-ui): AI traces admin page — view recent generations (Spec 69 P3 / #350)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/capability.ts
+++ b/addons/adapter-server/cap-adapter-server/src/capability.ts
@@ -64,7 +64,7 @@ export const capAdapterServer = defineCapability({
         path: "/admin/ai-traces",
         icon: "Activity",
         section: "admin",
-        order: 100,
+        order: 110,
       },
     ],
     commands: [

--- a/addons/adapter-server/cap-adapter-server/src/capability.ts
+++ b/addons/adapter-server/cap-adapter-server/src/capability.ts
@@ -58,6 +58,14 @@ export const capAdapterServer = defineCapability({
         section: "admin",
         order: 95,
       },
+      {
+        id: "ai-traces",
+        label: "t:aiTraces.title",
+        path: "/admin/ai-traces",
+        icon: "Activity",
+        section: "admin",
+        order: 100,
+      },
     ],
     commands: [
       {

--- a/addons/adapter-ui/cap-adapter-ui/src/app.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/app.tsx
@@ -26,6 +26,7 @@ import { CenteredLayout } from "./layouts/centered";
 import { FullscreenLayout } from "./layouts/fullscreen";
 import { ShellLayout } from "./layouts/shell";
 import { type AppConfig, fetchAppConfig } from "./lib/api";
+import { AITracesPage } from "./pages/ai-traces";
 import { ConfigCenterPage } from "./pages/config-center";
 import { DashboardPage } from "./pages/dashboard";
 import { EntityFormPage } from "./pages/entity-form";
@@ -230,6 +231,14 @@ function buildRouter(appConfig: AppConfig) {
     beforeLoad: buildPageBeforeLoad("required", "/login", authEnabled),
   });
 
+  // Read-only AI trace observability surface (Spec 69 / issue #350).
+  const aiTracesRoute = createRoute({
+    getParentRoute: () => shellRoute,
+    path: "/admin/ai-traces",
+    component: AITracesPage,
+    beforeLoad: buildPageBeforeLoad("required", "/login", authEnabled),
+  });
+
   // Real human-gated proposal review surface — list / approve / reject / graduate.
   const proposalReviewRoute = createRoute({
     getParentRoute: () => shellRoute,
@@ -264,6 +273,7 @@ function buildRouter(appConfig: AppConfig) {
       configCenterRoute,
       relationGraphRoute,
       metricsDashboardRoute,
+      aiTracesRoute,
       proposalReviewRoute,
       proposalReviewDemoRoute,
       ...pageRegistrations

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -175,6 +175,27 @@
     "stateTransition": "State Transition",
     "rulesEvaluated": "Rules Evaluated"
   },
+  "aiTraces": {
+    "title": "AI Traces",
+    "subtitle": "Recent AI generations — audit cost, tokens, and outcomes.",
+    "refresh": "Refresh",
+    "allStatuses": "All Statuses",
+    "statusLabel": "Status",
+    "status": {
+      "ok": "OK",
+      "error": "Error",
+      "partial": "Partial"
+    },
+    "time": "Time",
+    "name": "Name",
+    "origin": "Origin",
+    "tokens": "Tokens (in / out)",
+    "cost": "Cost",
+    "traceId": "Trace ID",
+    "empty": "No AI traces recorded yet",
+    "denied": "You don't have permission to view AI traces.",
+    "fetchError": "Failed to load AI traces"
+  },
   "viewTabs": {
     "newView": "New View",
     "saveView": "Save current filters as view",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -175,6 +175,27 @@
     "stateTransition": "状态变更",
     "rulesEvaluated": "规则评估"
   },
+  "aiTraces": {
+    "title": "AI 调用追踪",
+    "subtitle": "近期 AI 生成记录 — 审计成本、token 与结果。",
+    "refresh": "刷新",
+    "allStatuses": "全部状态",
+    "statusLabel": "状态",
+    "status": {
+      "ok": "成功",
+      "error": "错误",
+      "partial": "部分"
+    },
+    "time": "时间",
+    "name": "名称",
+    "origin": "来源",
+    "tokens": "Token（输入 / 输出）",
+    "cost": "成本",
+    "traceId": "追踪 ID",
+    "empty": "暂无 AI 调用追踪记录",
+    "denied": "您没有查看 AI 调用追踪的权限。",
+    "fetchError": "加载 AI 调用追踪失败"
+  },
   "viewTabs": {
     "newView": "新视图",
     "saveView": "将当前筛选条件保存为视图",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/fetch-ai-traces.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/fetch-ai-traces.test.ts
@@ -32,8 +32,8 @@ if (typeof globalThis.localStorage === "undefined") {
   });
 }
 
-const { fetchAITraces } = await import("../api");
-type AITrace = import("../api").AITrace;
+const { fetchAITraces } = await import("../ai-traces-client");
+type AITrace = import("../ai-traces-client").AITrace;
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -132,5 +132,36 @@ describe("fetchAITraces", () => {
     expect(result.kind).toBe("error");
     if (result.kind !== "error") throw new Error("expected error");
     expect(result.message).toBe("network down");
+  });
+
+  // ── query-string construction (contract) ──────────────────
+
+  test("builds the request URL with limit + status query params", async () => {
+    let captured = "";
+    const capturingFetch = (async (url: string) => {
+      captured = url;
+      return new Response(JSON.stringify({ success: true, data: { traces: [], count: 0 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await fetchAITraces({ limit: 100, status: "error", fetchImpl: capturingFetch });
+    expect(captured).toBe("/api/ai/traces?limit=100&status=error");
+
+    await fetchAITraces({ fetchImpl: capturingFetch });
+    expect(captured).toBe("/api/ai/traces");
+  });
+
+  // ── denied: non-JSON 403 body (proxy / gateway) ───────────
+
+  test("maps a 403 with a non-JSON body to { kind: 'denied' }", async () => {
+    const nonJsonFetch = (async () =>
+      new Response("Forbidden", {
+        status: 403,
+        headers: { "Content-Type": "text/plain" },
+      })) as unknown as typeof fetch;
+    const result = await fetchAITraces({ fetchImpl: nonJsonFetch });
+    expect(result.kind).toBe("denied");
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/fetch-ai-traces.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/fetch-ai-traces.test.ts
@@ -1,0 +1,136 @@
+/**
+ * fetchAITraces wire-mapping tests.
+ *
+ * Pure logic-only (no jsdom): the `fetch` seam is replaced by an injected stub
+ * (dependency injection — never a global fetch mock), and the discriminated
+ * `AITracesResult` arms are asserted against the `GET /api/ai/traces` envelope.
+ * These cover the same three states the page renders: a populated table
+ * (`ok` + traces), the empty state (`ok` + no traces), and the
+ * permission-denied state (`denied`).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+// `api.ts` reads the auth token from `localStorage` via `getAuthHeaders()`.
+// Under the pure-logic (no-jsdom) test runner that global is absent, so install
+// a minimal in-memory stub BEFORE importing the module under test. This is a
+// browser-API shim, not a network/fetch mock — the fetch seam is still injected.
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, String(value)),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+}
+
+const { fetchAITraces } = await import("../api");
+type AITrace = import("../api").AITrace;
+
+// ── Helpers ─────────────────────────────────────────────────
+
+/** Build a stub `fetch` returning the given JSON body + HTTP status. */
+function stubFetch(body: unknown, init: { status?: number } = {}): typeof fetch {
+  const status = init.status ?? 200;
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+const SAMPLE_TRACE: AITrace = {
+  traceId: "trace-abcdef123456",
+  name: "generate_object",
+  scenario: "auto_fill",
+  origin: "production",
+  status: "ok",
+  startedAt: 1_700_000_000_000,
+  endedAt: 1_700_000_000_420,
+  inputTokens: 120,
+  outputTokens: 45,
+  cost: 0.000026,
+};
+
+// ── ok: populated ───────────────────────────────────────────
+
+describe("fetchAITraces", () => {
+  test("maps a successful envelope to { kind: 'ok' } with traces", async () => {
+    const result = await fetchAITraces({
+      fetchImpl: stubFetch({ success: true, data: { traces: [SAMPLE_TRACE], count: 1 } }),
+    });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.count).toBe(1);
+    expect(result.traces).toHaveLength(1);
+    expect(result.traces[0]?.traceId).toBe("trace-abcdef123456");
+  });
+
+  // ── ok: empty ─────────────────────────────────────────────
+
+  test("maps an empty data envelope to { kind: 'ok' } with no traces", async () => {
+    const result = await fetchAITraces({
+      fetchImpl: stubFetch({ success: true, data: { traces: [], count: 0 } }),
+    });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.traces).toHaveLength(0);
+    expect(result.count).toBe(0);
+  });
+
+  // ── denied ────────────────────────────────────────────────
+
+  test("maps a 403 AUTHZ_DENIED envelope to { kind: 'denied' }", async () => {
+    const result = await fetchAITraces({
+      fetchImpl: stubFetch(
+        { success: false, error: { code: "AUTHZ_DENIED", message: "Access denied" } },
+        { status: 403 },
+      ),
+    });
+    expect(result.kind).toBe("denied");
+    if (result.kind !== "denied") throw new Error("expected denied");
+    expect(result.message).toBe("Access denied");
+  });
+
+  test("maps an AI.READ_TRACES.BLOCKED code to { kind: 'denied' } regardless of status", async () => {
+    const result = await fetchAITraces({
+      fetchImpl: stubFetch({
+        success: false,
+        error: { code: "AI.READ_TRACES.BLOCKED", message: "blocked" },
+      }),
+    });
+    expect(result.kind).toBe("denied");
+  });
+
+  // ── error ─────────────────────────────────────────────────
+
+  test("maps a non-authz failure to { kind: 'error' }", async () => {
+    const result = await fetchAITraces({
+      fetchImpl: stubFetch(
+        { success: false, error: { code: "INTERNAL", message: "boom" } },
+        { status: 500 },
+      ),
+    });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("expected error");
+    expect(result.message).toBe("boom");
+  });
+
+  test("maps a transport throw to { kind: 'error' }", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const result = await fetchAITraces({ fetchImpl: throwingFetch });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("expected error");
+    expect(result.message).toBe("network down");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/ai-traces-client.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/ai-traces-client.ts
@@ -1,0 +1,134 @@
+/**
+ * AI Traces client (Spec 69 — "Langfuse-class observability", issue #350).
+ *
+ * Thin typed wrapper over `GET /api/ai/traces` for the admin AI-traces page.
+ * Split out of `api.ts` to keep that file within the file-size cap; reuses the
+ * shared `getAuthHeaders` / `handleUnauthorized` helpers.
+ */
+
+import { getAuthHeaders, handleUnauthorized } from "./api";
+
+/** Origin discriminator for an AI trace (mirrors `@linchkit/core` AITrace). */
+export type AITraceOrigin = "production" | "eval";
+
+/** Roll-up status for an AI trace. */
+export type AITraceStatus = "ok" | "error" | "partial";
+
+/**
+ * A single rolled-up AI trace as returned by `GET /api/ai/traces`.
+ *
+ * Local mirror of the `@linchkit/core` `AITrace` type — the UI must not import
+ * from `@linchkit/core/server` (module boundary), so this shape is kept in sync
+ * with the server's wire response. `startedAt` / `endedAt` are epoch milliseconds.
+ */
+export interface AITrace {
+  traceId: string;
+  name: string;
+  scenario?: string;
+  origin: AITraceOrigin;
+  status: AITraceStatus;
+  startedAt: number;
+  endedAt?: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+  tenantId?: string;
+  actorId?: string;
+  tags?: string[];
+}
+
+/**
+ * Discriminated result of `fetchAITraces` so the caller can distinguish a
+ * successful read from an authorization denial (which needs a friendlier
+ * "no permission" UI rather than a raw error banner).
+ *
+ *  - `{ kind: "ok" }` — traces returned (most-recent-first).
+ *  - `{ kind: "denied" }` — authenticated but the permission slot rejected the read (403).
+ *  - `{ kind: "error" }` — a transport / server error; surface `message`.
+ *
+ * Note: a 401 (unauthenticated) is handled upstream by `handleUnauthorized`,
+ * which clears the token and redirects to `/login` — so it never reaches the
+ * `denied` arm here.
+ */
+export type AITracesResult =
+  | { kind: "ok"; traces: AITrace[]; count: number }
+  | { kind: "denied"; message: string }
+  | { kind: "error"; message: string };
+
+/** Error codes the trace endpoint returns for an authorization denial. */
+const AI_TRACE_DENIED_CODES: ReadonlySet<string> = new Set([
+  "AUTHZ_DENIED",
+  "AI.READ_TRACES.BLOCKED",
+]);
+
+const DENIED_MESSAGE = "You don't have permission to view AI traces.";
+
+/**
+ * Fetch recent AI traces from `GET /api/ai/traces`.
+ *
+ * The endpoint returns `{ success: true, data: { traces, count } }` on success
+ * and `{ success: false, error: { code, message } }` on an authorization
+ * failure (HTTP 403). This helper maps an authz denial to a distinct
+ * `{ kind: "denied" }` arm so the page can render a permission-specific message
+ * — even when the 403 body is empty / non-JSON (e.g. from a proxy or gateway).
+ *
+ * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
+ * global mock across the batched suite (same DI pattern as `resolveSchemaIntent`).
+ */
+export async function fetchAITraces(
+  options: {
+    limit?: number;
+    status?: AITraceStatus;
+    signal?: AbortSignal;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<AITracesResult> {
+  const doFetch = options.fetchImpl ?? fetch;
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.status !== undefined) params.set("status", options.status);
+  const qs = params.toString();
+  const url = `/api/ai/traces${qs ? `?${qs}` : ""}`;
+
+  let res: Response;
+  try {
+    res = await doFetch(url, { headers: getAuthHeaders(), signal: options.signal });
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : "Failed to load AI traces",
+    };
+  }
+  // 401 → clears the token and redirects to /login (when auth is enabled).
+  handleUnauthorized(res);
+
+  let json: {
+    success?: boolean;
+    data?: { traces?: AITrace[]; count?: number };
+    error?: { code?: string; message?: string };
+  };
+  try {
+    json = await res.json();
+  } catch {
+    // Empty / non-JSON body (proxy, gateway, 204). A 403 is still a denial —
+    // map it before falling back to a generic error so the friendly state shows.
+    if (res.status === 403) return { kind: "denied", message: DENIED_MESSAGE };
+    return { kind: "error", message: "AI traces endpoint returned an invalid response" };
+  }
+
+  if (json.success && json.data) {
+    return {
+      kind: "ok",
+      traces: json.data.traces ?? [],
+      count: json.data.count ?? json.data.traces?.length ?? 0,
+    };
+  }
+
+  const code = json.error?.code ?? "";
+  const message = json.error?.message ?? "Failed to load AI traces";
+  // Permission denied (authenticated): 403 status, or the canonical authz code.
+  if (res.status === 403 || AI_TRACE_DENIED_CODES.has(code)) {
+    return { kind: "denied", message: message || DENIED_MESSAGE };
+  }
+  return { kind: "error", message };
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -9,7 +9,7 @@ import { getTenantHeaders } from "./tenant";
 
 // ── Auth header helper ──────────────────────────────────
 
-function getAuthHeaders(): Record<string, string> {
+export function getAuthHeaders(): Record<string, string> {
   const token = localStorage.getItem("linchkit:token");
   const tenantHeaders = getTenantHeaders();
   if (token) {
@@ -18,7 +18,7 @@ function getAuthHeaders(): Record<string, string> {
   return { ...tenantHeaders };
 }
 
-function handleUnauthorized(res: Response): void {
+export function handleUnauthorized(res: Response): void {
   if (res.status === 401) {
     localStorage.removeItem("linchkit:token");
     localStorage.removeItem("linchkit:authenticated");
@@ -1113,120 +1113,9 @@ export async function queryExecutionLogs(options: {
   return { items, total: raw.total };
 }
 
-// ── AI Traces (Spec 69 — Langfuse-class observability) ──
-
-/** Origin discriminator for an AI trace (mirrors `@linchkit/core` AITrace). */
-export type AITraceOrigin = "production" | "eval";
-
-/** Roll-up status for an AI trace. */
-export type AITraceStatus = "ok" | "error" | "partial";
-
-/**
- * A single rolled-up AI trace as returned by `GET /api/ai/traces`.
- *
- * Local mirror of the `@linchkit/core` `AITrace` type — the UI must not import
- * from `@linchkit/core/server` (module boundary), so this shape is kept in sync
- * with the server's wire response. `startedAt` / `endedAt` are epoch milliseconds.
- */
-export interface AITrace {
-  traceId: string;
-  name: string;
-  scenario?: string;
-  origin: AITraceOrigin;
-  status: AITraceStatus;
-  startedAt: number;
-  endedAt?: number;
-  inputTokens: number;
-  outputTokens: number;
-  cost: number;
-  tenantId?: string;
-  actorId?: string;
-  tags?: string[];
-}
-
-/**
- * Discriminated result of `fetchAITraces` so the caller can distinguish a
- * successful read from an authorization denial (which needs a friendlier
- * "no permission" UI rather than a raw error banner).
- *
- *  - `{ kind: "ok" }` — traces returned (most-recent-first).
- *  - `{ kind: "denied" }` — the CommandLayer permission slot rejected the read.
- *  - `{ kind: "error" }` — a transport / server error; surface `message`.
- */
-export type AITracesResult =
-  | { kind: "ok"; traces: AITrace[]; count: number }
-  | { kind: "denied"; message: string }
-  | { kind: "error"; message: string };
-
-/** Error codes the trace endpoint returns for an authorization denial. */
-const AI_TRACE_DENIED_CODES: ReadonlySet<string> = new Set([
-  "AUTHZ_DENIED",
-  "AI.READ_TRACES.BLOCKED",
-]);
-
-/**
- * Fetch recent AI traces from `GET /api/ai/traces`.
- *
- * The endpoint returns `{ success: true, data: { traces, count } }` on success
- * and `{ success: false, error: { code, message } }` on an authorization
- * failure (HTTP 401/403). This helper maps an authz denial to a distinct
- * `{ kind: "denied" }` arm so the page can render a permission-specific message.
- *
- * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
- * global mock across the batched suite (same DI pattern as `resolveSchemaIntent`).
- */
-export async function fetchAITraces(
-  options: {
-    limit?: number;
-    status?: AITraceStatus;
-    signal?: AbortSignal;
-    fetchImpl?: typeof fetch;
-  } = {},
-): Promise<AITracesResult> {
-  const doFetch = options.fetchImpl ?? fetch;
-  const params = new URLSearchParams();
-  if (options.limit !== undefined) params.set("limit", String(options.limit));
-  if (options.status !== undefined) params.set("status", options.status);
-  const qs = params.toString();
-  const url = `/api/ai/traces${qs ? `?${qs}` : ""}`;
-
-  let res: Response;
-  try {
-    res = await doFetch(url, { headers: getAuthHeaders(), signal: options.signal });
-  } catch (err) {
-    return {
-      kind: "error",
-      message: err instanceof Error ? err.message : "Failed to load AI traces",
-    };
-  }
-  handleUnauthorized(res);
-
-  let json: {
-    success?: boolean;
-    data?: { traces?: AITrace[]; count?: number };
-    error?: { code?: string; message?: string };
-  };
-  try {
-    json = await res.json();
-  } catch {
-    return { kind: "error", message: "AI traces endpoint returned an invalid response" };
-  }
-
-  if (json.success && json.data) {
-    return {
-      kind: "ok",
-      traces: json.data.traces ?? [],
-      count: json.data.count ?? json.data.traces?.length ?? 0,
-    };
-  }
-
-  const code = json.error?.code ?? "";
-  const message = json.error?.message ?? "Failed to load AI traces";
-  if (res.status === 401 || res.status === 403 || AI_TRACE_DENIED_CODES.has(code)) {
-    return { kind: "denied", message };
-  }
-  return { kind: "error", message };
-}
+// AI Traces client (Spec 69 — Langfuse-class observability) lives in
+// `./ai-traces-client.ts` to keep this file within the file-size cap. It reuses
+// the exported `getAuthHeaders` / `handleUnauthorized` helpers above.
 
 // ── State Transition History ────────────────────────────
 

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -1113,6 +1113,121 @@ export async function queryExecutionLogs(options: {
   return { items, total: raw.total };
 }
 
+// ── AI Traces (Spec 69 — Langfuse-class observability) ──
+
+/** Origin discriminator for an AI trace (mirrors `@linchkit/core` AITrace). */
+export type AITraceOrigin = "production" | "eval";
+
+/** Roll-up status for an AI trace. */
+export type AITraceStatus = "ok" | "error" | "partial";
+
+/**
+ * A single rolled-up AI trace as returned by `GET /api/ai/traces`.
+ *
+ * Local mirror of the `@linchkit/core` `AITrace` type — the UI must not import
+ * from `@linchkit/core/server` (module boundary), so this shape is kept in sync
+ * with the server's wire response. `startedAt` / `endedAt` are epoch milliseconds.
+ */
+export interface AITrace {
+  traceId: string;
+  name: string;
+  scenario?: string;
+  origin: AITraceOrigin;
+  status: AITraceStatus;
+  startedAt: number;
+  endedAt?: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+  tenantId?: string;
+  actorId?: string;
+  tags?: string[];
+}
+
+/**
+ * Discriminated result of `fetchAITraces` so the caller can distinguish a
+ * successful read from an authorization denial (which needs a friendlier
+ * "no permission" UI rather than a raw error banner).
+ *
+ *  - `{ kind: "ok" }` — traces returned (most-recent-first).
+ *  - `{ kind: "denied" }` — the CommandLayer permission slot rejected the read.
+ *  - `{ kind: "error" }` — a transport / server error; surface `message`.
+ */
+export type AITracesResult =
+  | { kind: "ok"; traces: AITrace[]; count: number }
+  | { kind: "denied"; message: string }
+  | { kind: "error"; message: string };
+
+/** Error codes the trace endpoint returns for an authorization denial. */
+const AI_TRACE_DENIED_CODES: ReadonlySet<string> = new Set([
+  "AUTHZ_DENIED",
+  "AI.READ_TRACES.BLOCKED",
+]);
+
+/**
+ * Fetch recent AI traces from `GET /api/ai/traces`.
+ *
+ * The endpoint returns `{ success: true, data: { traces, count } }` on success
+ * and `{ success: false, error: { code, message } }` on an authorization
+ * failure (HTTP 401/403). This helper maps an authz denial to a distinct
+ * `{ kind: "denied" }` arm so the page can render a permission-specific message.
+ *
+ * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
+ * global mock across the batched suite (same DI pattern as `resolveSchemaIntent`).
+ */
+export async function fetchAITraces(
+  options: {
+    limit?: number;
+    status?: AITraceStatus;
+    signal?: AbortSignal;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<AITracesResult> {
+  const doFetch = options.fetchImpl ?? fetch;
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.status !== undefined) params.set("status", options.status);
+  const qs = params.toString();
+  const url = `/api/ai/traces${qs ? `?${qs}` : ""}`;
+
+  let res: Response;
+  try {
+    res = await doFetch(url, { headers: getAuthHeaders(), signal: options.signal });
+  } catch (err) {
+    return {
+      kind: "error",
+      message: err instanceof Error ? err.message : "Failed to load AI traces",
+    };
+  }
+  handleUnauthorized(res);
+
+  let json: {
+    success?: boolean;
+    data?: { traces?: AITrace[]; count?: number };
+    error?: { code?: string; message?: string };
+  };
+  try {
+    json = await res.json();
+  } catch {
+    return { kind: "error", message: "AI traces endpoint returned an invalid response" };
+  }
+
+  if (json.success && json.data) {
+    return {
+      kind: "ok",
+      traces: json.data.traces ?? [],
+      count: json.data.count ?? json.data.traces?.length ?? 0,
+    };
+  }
+
+  const code = json.error?.code ?? "";
+  const message = json.error?.message ?? "Failed to load AI traces";
+  if (res.status === 401 || res.status === 403 || AI_TRACE_DENIED_CODES.has(code)) {
+    return { kind: "denied", message };
+  }
+  return { kind: "error", message };
+}
+
 // ── State Transition History ────────────────────────────
 
 export interface StateTransitionEntry {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/builtin-admin-routes.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/builtin-admin-routes.ts
@@ -16,3 +16,13 @@ registerAdminRoute({
   component: () =>
     import("../pages/execution-logs").then((m) => ({ default: m.ExecutionLogsPage })),
 });
+
+registerAdminRoute({
+  id: "ai-traces",
+  capability: "__builtin__",
+  path: "/admin/ai-traces",
+  label: "aiTraces.title",
+  icon: "Activity",
+  order: 110,
+  component: () => import("../pages/ai-traces").then((m) => ({ default: m.AITracesPage })),
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -31,7 +31,12 @@ import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import { ActivityIcon, RefreshCwIcon, ShieldOffIcon, XCircleIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { type AITrace, type AITraceStatus, type AITracesResult, fetchAITraces } from "../lib/api";
+import {
+  type AITrace,
+  type AITraceStatus,
+  type AITracesResult,
+  fetchAITraces,
+} from "../lib/ai-traces-client";
 
 // ── Constants ────────────────────────────────────────────
 
@@ -63,9 +68,10 @@ function statusBadgeClass(status: AITraceStatus): string {
 
 /** Format trace duration (endedAt - startedAt) in ms, or "" when unfinished. */
 function formatTraceDuration(trace: AITrace): string {
-  if (trace.endedAt === undefined) return "";
+  // `== null` covers both null (common in JSON) and undefined (open trace).
+  if (trace.endedAt == null) return "";
   const ms = trace.endedAt - trace.startedAt;
-  if (ms < 0) return "";
+  if (!Number.isFinite(ms) || ms < 0) return "";
   if (ms < 1000) return `${Math.round(ms)}ms`;
   return `${(ms / 1000).toFixed(2)}s`;
 }
@@ -97,10 +103,16 @@ function LoadingSkeleton() {
 function TraceRow({ trace }: { trace: AITrace }) {
   const { t } = useTranslation();
   const duration = formatTraceDuration(trace);
+  // Guard against a missing / invalid `startedAt` — `new Date(NaN).toISOString()`
+  // throws `RangeError`, which would crash the whole table.
+  const started = new Date(trace.startedAt);
+  const startedLabel = Number.isNaN(started.getTime())
+    ? "—"
+    : formatRelativeTime(started.toISOString(), t);
   return (
     <TableRow>
       <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
-        <div>{formatRelativeTime(new Date(trace.startedAt).toISOString(), t)}</div>
+        <div>{startedLabel}</div>
         {duration && <div className="text-[10px] opacity-70">{duration}</div>}
       </TableCell>
       <TableCell>
@@ -114,7 +126,7 @@ function TraceRow({ trace }: { trace: AITrace }) {
         </Badge>
       </TableCell>
       <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
-        {trace.inputTokens.toLocaleString()} / {trace.outputTokens.toLocaleString()}
+        {(trace.inputTokens ?? 0).toLocaleString()} / {(trace.outputTokens ?? 0).toLocaleString()}
       </TableCell>
       <TableCell className="whitespace-nowrap font-mono text-xs">
         {formatCost(trace.cost)}
@@ -147,8 +159,9 @@ export function AITracesPage() {
         status: statusFilter === "__all__" ? undefined : statusFilter,
         signal,
       });
-      // Drop a stale response superseded by a newer load (incl. an aborted one).
-      if (seq !== reqSeq.current) return;
+      // Drop a stale response superseded by a newer load, or one whose request
+      // was aborted (e.g. the component unmounted) — avoid setState-after-unmount.
+      if (seq !== reqSeq.current || signal?.aborted) return;
       setResult(next);
       setLoading(false);
     },

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -1,0 +1,256 @@
+/**
+ * AITracesPage — /admin/ai-traces
+ *
+ * Read-only admin surface for recent AI traces (Spec 69 — "Langfuse-class
+ * observability", issue #350). Consumes `GET /api/ai/traces` via the
+ * {@link fetchAITraces} helper and renders a most-recent-first table.
+ *
+ * Data source audit:
+ * - All data: DYNAMIC — fetched from GET /api/ai/traces, served by the active
+ *   AI trace sink (Drizzle durable store, or the in-memory hot view fallback).
+ * - Refetches on mount and whenever the status filter changes.
+ */
+
+import {
+  Badge,
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@linchkit/ui-kit/components";
+import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
+import { ActivityIcon, RefreshCwIcon, ShieldOffIcon, XCircleIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { type AITrace, type AITraceStatus, type AITracesResult, fetchAITraces } from "../lib/api";
+
+// ── Constants ────────────────────────────────────────────
+
+/** Page size requested from the endpoint (server hard-caps at 500). */
+const TRACE_LIMIT = 100;
+
+/** Status filter options surfaced in the Select. `__all__` clears the filter. */
+const STATUS_OPTIONS: ReadonlyArray<AITraceStatus | "__all__"> = [
+  "__all__",
+  "ok",
+  "error",
+  "partial",
+];
+
+// ── Helpers ──────────────────────────────────────────────
+
+/** Map a trace status to a Badge variant (ok=green, error=red, partial=amber). */
+function statusBadgeClass(status: AITraceStatus): string {
+  switch (status) {
+    case "ok":
+      return "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400";
+    case "error":
+      return "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400";
+    default:
+      // partial
+      return "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400";
+  }
+}
+
+/** Format trace duration (endedAt - startedAt) in ms, or "" when unfinished. */
+function formatTraceDuration(trace: AITrace): string {
+  if (trace.endedAt === undefined) return "";
+  const ms = trace.endedAt - trace.startedAt;
+  if (ms < 0) return "";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+/** Format a USD cost, or "—" when zero (per spec — `$0.000026`, `—` when 0). */
+function formatCost(cost: number): string {
+  if (!cost) return "—";
+  return `$${cost.toFixed(6)}`;
+}
+
+/** Truncate a trace id for compact monospace display. */
+function truncateTraceId(traceId: string): string {
+  return traceId.length > 12 ? `${traceId.slice(0, 12)}…` : traceId;
+}
+
+// ── Sub-components ───────────────────────────────────────
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 8 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}
+
+function TraceRow({ trace }: { trace: AITrace }) {
+  const { t } = useTranslation();
+  const duration = formatTraceDuration(trace);
+  return (
+    <TableRow>
+      <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+        <div>{formatRelativeTime(new Date(trace.startedAt).toISOString(), t)}</div>
+        {duration && <div className="text-[10px] opacity-70">{duration}</div>}
+      </TableCell>
+      <TableCell>
+        <div className="font-medium text-sm">{trace.name}</div>
+        {trace.scenario && <div className="text-xs text-muted-foreground">{trace.scenario}</div>}
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">{trace.origin}</TableCell>
+      <TableCell>
+        <Badge variant="secondary" className={`text-[10px] ${statusBadgeClass(trace.status)}`}>
+          {t(`aiTraces.status.${trace.status}`, trace.status)}
+        </Badge>
+      </TableCell>
+      <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+        {trace.inputTokens.toLocaleString()} / {trace.outputTokens.toLocaleString()}
+      </TableCell>
+      <TableCell className="whitespace-nowrap font-mono text-xs">
+        {formatCost(trace.cost)}
+      </TableCell>
+      <TableCell className="font-mono text-xs text-muted-foreground" title={trace.traceId}>
+        {truncateTraceId(trace.traceId)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+// ── Main component ───────────────────────────────────────
+
+export function AITracesPage() {
+  const { t } = useTranslation();
+  const [result, setResult] = useState<AITracesResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<AITraceStatus | "__all__">("__all__");
+
+  // Monotonic request token: a slow in-flight fetch (e.g. an older status
+  // filter) must not overwrite the result of a newer one that already resolved.
+  const reqSeq = useRef(0);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      const seq = ++reqSeq.current;
+      setLoading(true);
+      const next = await fetchAITraces({
+        limit: TRACE_LIMIT,
+        status: statusFilter === "__all__" ? undefined : statusFilter,
+        signal,
+      });
+      // Drop a stale response superseded by a newer load (incl. an aborted one).
+      if (seq !== reqSeq.current) return;
+      setResult(next);
+      setLoading(false);
+    },
+    [statusFilter],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const traces = result?.kind === "ok" ? result.traces : [];
+
+  return (
+    <div className="w-full p-4 space-y-4">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <ActivityIcon className="size-5 text-muted-foreground" />
+            <h1 className="text-lg font-semibold">{t("aiTraces.title", "AI Traces")}</h1>
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {t("aiTraces.subtitle", "Recent AI generations — audit cost, tokens, and outcomes.")}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Select
+            value={statusFilter}
+            onValueChange={(v) => setStatusFilter(v as AITraceStatus | "__all__")}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_OPTIONS.map((opt) => (
+                <SelectItem key={opt} value={opt}>
+                  {opt === "__all__"
+                    ? t("aiTraces.allStatuses", "All Statuses")
+                    : t(`aiTraces.status.${opt}`, opt)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={() => load()} disabled={loading}>
+            <RefreshCwIcon className={`size-4 mr-1 ${loading ? "animate-spin" : ""}`} />
+            {t("aiTraces.refresh", "Refresh")}
+          </Button>
+        </div>
+      </div>
+
+      {/* Permission-denied state */}
+      {result?.kind === "denied" && (
+        <div className="flex flex-col items-center justify-center py-16 gap-3 text-muted-foreground">
+          <ShieldOffIcon className="size-10 opacity-30" />
+          <p className="text-sm">
+            {t("aiTraces.denied", "You don't have permission to view AI traces.")}
+          </p>
+        </div>
+      )}
+
+      {/* Error banner */}
+      {result?.kind === "error" && (
+        <div className="rounded-lg p-4 bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+          <XCircleIcon className="size-4 shrink-0" />
+          {t("aiTraces.fetchError", "Failed to load AI traces")}: {result.message}
+        </div>
+      )}
+
+      {/* Loading skeleton (only before first result) */}
+      {loading && !result && <LoadingSkeleton />}
+
+      {/* Empty state */}
+      {result?.kind === "ok" && traces.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 gap-3 text-muted-foreground">
+          <ActivityIcon className="size-10 opacity-30" />
+          <p className="text-sm">{t("aiTraces.empty", "No AI traces recorded yet")}</p>
+        </div>
+      )}
+
+      {/* Traces table */}
+      {result?.kind === "ok" && traces.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-xs">{t("aiTraces.time", "Time")}</TableHead>
+              <TableHead className="text-xs">{t("aiTraces.name", "Name")}</TableHead>
+              <TableHead className="text-xs">{t("aiTraces.origin", "Origin")}</TableHead>
+              <TableHead className="text-xs">{t("aiTraces.statusLabel", "Status")}</TableHead>
+              <TableHead className="text-xs">{t("aiTraces.tokens", "Tokens (in / out)")}</TableHead>
+              <TableHead className="text-xs">{t("aiTraces.cost", "Cost")}</TableHead>
+              <TableHead className="text-xs">{t("aiTraces.traceId", "Trace ID")}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {traces.map((trace) => (
+              <TraceRow key={trace.traceId} trace={trace} />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -149,6 +149,9 @@ export function AITracesPage() {
   // Monotonic request token: a slow in-flight fetch (e.g. an older status
   // filter) must not overwrite the result of a newer one that already resolved.
   const reqSeq = useRef(0);
+  // Controller for the manual Refresh fetch — tracked separately from the
+  // effect's controller so an in-flight Refresh is also aborted on unmount.
+  const manualCtrlRef = useRef<AbortController | null>(null);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
@@ -171,7 +174,10 @@ export function AITracesPage() {
   useEffect(() => {
     const controller = new AbortController();
     load(controller.signal);
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      manualCtrlRef.current?.abort();
+    };
   }, [load]);
 
   const traces = result?.kind === "ok" ? result.traces : [];
@@ -207,7 +213,17 @@ export function AITracesPage() {
               ))}
             </SelectContent>
           </Select>
-          <Button variant="outline" size="sm" onClick={() => load()} disabled={loading}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              manualCtrlRef.current?.abort();
+              const ctrl = new AbortController();
+              manualCtrlRef.current = ctrl;
+              load(ctrl.signal);
+            }}
+            disabled={loading}
+          >
             <RefreshCwIcon className={`size-4 mr-1 ${loading ? "animate-spin" : ""}`} />
             {t("aiTraces.refresh", "Refresh")}
           </Button>

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -152,6 +152,10 @@ export function AITracesPage() {
   // Controller for the manual Refresh fetch — tracked separately from the
   // effect's controller so an in-flight Refresh is also aborted on unmount.
   const manualCtrlRef = useRef<AbortController | null>(null);
+  // Controller for the effect's auto-fetch — exposed via a ref so the manual
+  // Refresh handler can abort a still-running auto-fetch (not just discard
+  // its stale result via reqSeq).
+  const effectCtrlRef = useRef<AbortController | null>(null);
 
   const load = useCallback(
     async (signal?: AbortSignal) => {
@@ -173,6 +177,7 @@ export function AITracesPage() {
 
   useEffect(() => {
     const controller = new AbortController();
+    effectCtrlRef.current = controller;
     load(controller.signal);
     return () => {
       controller.abort();
@@ -217,6 +222,7 @@ export function AITracesPage() {
             variant="outline"
             size="sm"
             onClick={() => {
+              effectCtrlRef.current?.abort();
               manualCtrlRef.current?.abort();
               const ctrl = new AbortController();
               manualCtrlRef.current = ctrl;


### PR DESCRIPTION
## What

The `GET /api/ai/traces` read endpoint (#557) had **no human-viewable consumer** —
"Langfuse-class observability" (#350) with no way to actually browse the traces.
This adds a read-only admin page at `/admin/ai-traces` listing recent AI traces
(most-recent-first). Companion to #562 (which made the streaming assistant paths
record traces in the first place).

## How

- **`fetchAITraces()`** (`lib/api.ts`) — typed wire helper returning a
  discriminated `{ ok | denied | error }` result. Maps the 401/403 +
  `AUTHZ_DENIED` envelope to a distinct `denied` arm so the page shows a
  permission-specific message instead of a raw error banner. Injectable
  `fetchImpl` for tests (no global fetch mock — same DI seam as
  `resolveSchemaIntent`).
- **`AITracesPage`** (`pages/ai-traces.tsx`) — columns: Time (+duration), Name
  (+scenario), Origin, Status (colored badge), Tokens (in/out), Cost, Trace ID.
  Status filter + Refresh. Loading / empty / denied / error states. A monotonic
  request token drops stale in-flight responses so a slow older-filter fetch
  can't overwrite a newer one. Reuses the ui-kit `Table`/`Badge`/`Select` (no
  new deps). Under 500 lines.
- **Discovery wired three ways**: the server capability `menuItems` (the actual
  sidebar Administration source, served via `/api/app-config`), the UI route
  registry, and the live `app.tsx` router. en + zh-CN i18n keys.

## Tests

6 data-layer tests for `fetchAITraces` (ok / empty / denied / error / transport).
`adapter-ui` has no render-test harness anywhere, so the page is covered at the
helper seam (the established DI-test pattern) rather than via a new jsdom setup.
`bun run typecheck`, `bun run check`, `bun run test` all green.

## Review notes

Codex review flagged two P2s, both fixed in this PR:
- **Sidebar discoverability** — registering only in the UI route registry left
  the page reachable by URL but absent from the sidebar (which is built from the
  server `menuItems`); added the `menuItems` entry.
- **Stale-fetch race** — rapid status-filter changes could let an older response
  overwrite a newer one; added the monotonic request token + `AbortController`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI Traces admin page (/admin/ai-traces) to view and filter trace data with status filtering and detailed rows (time, duration, name, origin, tokens, cost, trace ID).
* **Localization**
  * Added English and Simplified Chinese translations for the AI Traces UI.
* **Tests**
  * Added client tests validating fetching, error/denied handling, and query param behavior for the AI Traces API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->