### PR TITLE
feat(adapter-server): GET /api/ai/traces/:id/generations — per-call drill-down (Spec 69 P3 / #350)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-generations-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-traces-generations-api.test.ts
@@ -1,0 +1,284 @@
+/**
+ * AI trace generation drill-down tests — GET /api/ai/traces/:id/generations
+ * (issue #350, content drill-down).
+ *
+ * Pins the per-call read side of trace persistence:
+ *   - generations under one parent trace are surfaced (most-recent-first),
+ *   - an unknown trace id returns an empty list (not a 404),
+ *   - query-param validation rejects an empty :id and a bad ?limit=,
+ *   - the CommandLayer permission slot is NEVER skipped: a denying layer 403s
+ *     with the canonical AUTHZ_DENIED envelope and the sink is not consulted,
+ *   - the tenant slot's resolved tenantId scopes the query (a scoped operator
+ *     cannot read another tenant's generations).
+ *
+ * Endpoint dispatch is via `app.handle(new Request(...))` (in-process, port-free).
+ * `app.listen(PORT)` is intentionally avoided — a bound socket per suite SEGFAULTS
+ * the batched addons run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { CommandLayer } from "@linchkit/core";
+import {
+  getAITraceSink,
+  InMemoryAITraceStore,
+  resetAITraceSink,
+  setAITraceSink,
+} from "@linchkit/core/server";
+import { Elysia } from "elysia";
+import { mountAITracesRoutes } from "../src/routes/ai-traces-api";
+import type { ServerOptions } from "../src/server";
+
+const BASE = "http://local.test";
+
+interface GenerationsJson {
+  success: boolean;
+  data?: {
+    generations?: Array<{ id: string; traceId: string; model: string }>;
+    count?: number;
+  };
+  error?: { code?: string; message?: string };
+}
+
+/** Permissive command layer; `data` carries the synthetic tenant slot result. */
+function passLayer(data: Record<string, unknown> = {}): CommandLayer {
+  return { execute: async () => ({ success: true, data }) } as unknown as CommandLayer;
+}
+
+/**
+ * Denying command layer — mirrors the REAL permission-slot rejection shape:
+ * createPermissionMiddleware throws AuthorizationError({ code:"authz.action.denied" }),
+ * which CommandLayer propagates as `{ success:false, data:{ code:"authz.action.denied" } }`.
+ */
+function denyLayer(): CommandLayer {
+  return {
+    execute: async () => ({
+      success: false,
+      data: { code: "authz.action.denied", error: "not allowed" },
+    }),
+  } as unknown as CommandLayer;
+}
+
+/** Records each dispatch so we can prove the sink is NOT consulted when denied. */
+function spyLayer(): { layer: CommandLayer; calls: number } {
+  const state = { calls: 0 };
+  const layer = {
+    execute: async () => {
+      state.calls += 1;
+      return {
+        success: false as const,
+        data: { code: "authz.action.denied", error: "not allowed" },
+      };
+    },
+  } as unknown as CommandLayer;
+  return {
+    layer,
+    get calls() {
+      return state.calls;
+    },
+  };
+}
+
+/**
+ * Replace the active sink's READ methods with traps that count + throw, so a
+ * denied request that wrongly consulted the sink is provable: queryCalls would
+ * be > 0 AND the response would become 500 (the throw) instead of the asserted
+ * 403. Proves the permission slot gates BEFORE any sink access.
+ */
+function trapSinkQueries(): { queryCalls: number } {
+  const sink = getAITraceSink() as unknown as {
+    query: (...a: unknown[]) => unknown;
+    queryPersisted?: (...a: unknown[]) => unknown;
+  };
+  const state = { queryCalls: 0 };
+  sink.query = () => {
+    state.queryCalls += 1;
+    throw new Error("sink.query must not be reached on a denied request");
+  };
+  sink.queryPersisted = () => {
+    state.queryCalls += 1;
+    throw new Error("sink.queryPersisted must not be reached on a denied request");
+  };
+  return state;
+}
+
+function mountApp(opts: { commandLayer?: CommandLayer }): Elysia {
+  const app = new Elysia();
+  mountAITracesRoutes(app, { commandLayer: opts.commandLayer } as unknown as ServerOptions);
+  return app;
+}
+
+async function getGenerations(
+  app: Elysia,
+  traceId: string,
+  qs = "",
+): Promise<{ status: number; json: GenerationsJson }> {
+  const res = await app.handle(new Request(`${BASE}/api/ai/traces/${traceId}/generations${qs}`));
+  return { status: res.status, json: (await res.json()) as GenerationsJson };
+}
+
+/** Seed a single generation under the given trace id. */
+function seedGeneration(opts: { traceId: string; tenantId?: string; model?: string }): void {
+  const sink = getAITraceSink();
+  const now = Date.now();
+  sink.startTrace({ traceId: opts.traceId, name: opts.model ?? "fast", tenantId: opts.tenantId });
+  sink.recordGeneration({
+    traceId: opts.traceId,
+    model: opts.model ?? "fast",
+    provider: "test",
+    messages: [{ role: "user", content: "hi" }],
+    completion: "hello",
+    inputTokens: 3,
+    outputTokens: 5,
+    latencyMs: 12,
+    status: "ok",
+    startedAt: now,
+    endedAt: now + 12,
+    tenantId: opts.tenantId,
+    redaction: { mode: "none" },
+  });
+}
+
+describe("GET /api/ai/traces/:id/generations", () => {
+  beforeEach(() => {
+    // Fresh in-memory sink per test so seeded data doesn't leak across cases or
+    // across the batched addons run (which shares the module singleton).
+    setAITraceSink(new InMemoryAITraceStore());
+  });
+
+  afterEach(() => {
+    resetAITraceSink();
+  });
+
+  test("returns only the generations under the requested trace", async () => {
+    // 2 generations under t1, 1 under t2 — the drill-down for t1 must return
+    // exactly the 2 t1 generations and never the t2 one.
+    seedGeneration({ traceId: "t1" });
+    seedGeneration({ traceId: "t1" });
+    seedGeneration({ traceId: "t2" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getGenerations(app, "t1");
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.count).toBe(2);
+    expect(json.data?.generations?.every((g) => g.traceId === "t1")).toBe(true);
+  });
+
+  test("returns an empty list for an unknown trace id (not a 404)", async () => {
+    seedGeneration({ traceId: "t1" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getGenerations(app, "does-not-exist");
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data?.generations).toEqual([]);
+    expect(json.data?.count).toBe(0);
+  });
+
+  test("honours ?limit= (caps the result set)", async () => {
+    seedGeneration({ traceId: "t1" });
+    seedGeneration({ traceId: "t1" });
+    seedGeneration({ traceId: "t1" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getGenerations(app, "t1", "?limit=2");
+
+    expect(status).toBe(200);
+    expect(json.data?.count).toBe(2);
+  });
+
+  test("rejects an invalid ?limit= with 400", async () => {
+    const app = mountApp({ commandLayer: passLayer() });
+    const { status, json } = await getGenerations(app, "t1", "?limit=-1");
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
+  test("rejects ?limit=0 with 400 (must be positive, never silently zero rows)", async () => {
+    seedGeneration({ traceId: "t1" });
+    const app = mountApp({ commandLayer: passLayer() });
+    const { status, json } = await getGenerations(app, "t1", "?limit=0");
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
+  test("treats an empty ?limit= as 'use the default' (not 0)", async () => {
+    seedGeneration({ traceId: "t1" });
+    seedGeneration({ traceId: "t1" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getGenerations(app, "t1", "?limit=");
+
+    expect(status).toBe(200);
+    expect(json.data?.count).toBe(2);
+  });
+
+  test("command layer absent → 503 (cannot authorize, fail closed)", async () => {
+    seedGeneration({ traceId: "t1" });
+    const app = mountApp({ commandLayer: undefined });
+    const { status, json } = await getGenerations(app, "t1");
+    expect(status).toBe(503);
+    expect(json.success).toBe(false);
+  });
+
+  test("unauthorized caller → 403 canonical AUTHZ_DENIED; sink NOT consulted", async () => {
+    seedGeneration({ traceId: "secret" });
+    const trap = trapSinkQueries();
+    const spy = spyLayer();
+    const app = mountApp({ commandLayer: spy.layer });
+
+    const { status, json } = await getGenerations(app, "secret");
+
+    expect(status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+    // No generation data leaked in the denied response.
+    expect(json.data).toBeUndefined();
+    // Permission slot ran (and denied) — exactly one dispatch.
+    expect(spy.calls).toBe(1);
+    // The sink's read methods were never reached on the denied path (a query
+    // would have counted here AND turned the 403 into a 500 via the trap throw).
+    expect(trap.queryCalls).toBe(0);
+  });
+
+  test("denying layer just blocks (separate denyLayer helper) → 403", async () => {
+    seedGeneration({ traceId: "t1" });
+    const app = mountApp({ commandLayer: denyLayer() });
+    const { status, json } = await getGenerations(app, "t1");
+    expect(status).toBe(403);
+    expect(json.error?.code).toBe("AUTHZ_DENIED");
+  });
+
+  test("tenant slot's resolved tenantId scopes the query (no cross-tenant read)", async () => {
+    // Same trace id used across two tenants would be unusual, so use distinct
+    // ids; the scope filter must exclude the foreign-tenant generation even when
+    // the :id is asked for explicitly.
+    seedGeneration({ traceId: "shared-a", tenantId: "tenant-a" });
+    seedGeneration({ traceId: "shared-b", tenantId: "tenant-b" });
+    // The tenant slot pinned tenant-a; a scoped operator must see only tenant-a's.
+    const app = mountApp({ commandLayer: passLayer({ tenantId: "tenant-a" }) });
+
+    // Asking for tenant-b's trace under a tenant-a-scoped actor → no rows.
+    const denied = await getGenerations(app, "shared-b");
+    expect(denied.status).toBe(200);
+    expect(denied.json.data?.count).toBe(0);
+
+    // Asking for tenant-a's own trace → the row is returned.
+    const allowed = await getGenerations(app, "shared-a");
+    expect(allowed.status).toBe(200);
+    expect(allowed.json.data?.count).toBe(1);
+    expect(allowed.json.data?.generations?.[0]?.traceId).toBe("shared-a");
+  });
+
+  test("unscoped (admin) caller sees generations across tenants", async () => {
+    seedGeneration({ traceId: "ua", tenantId: "tenant-a" });
+    const app = mountApp({ commandLayer: passLayer() });
+
+    const { status, json } = await getGenerations(app, "ua");
+
+    expect(status).toBe(200);
+    expect(json.data?.count).toBe(1);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-traces-api.ts
@@ -25,9 +25,21 @@
  * Reads through the sink's DURABLE async query when available (the Drizzle store
  * exposes `queryTracesPersisted`, serving history that survived a restart) and falls
  * back to the synchronous process-local hot view (`queryTraces`) otherwise.
+ *
+ * GET /api/ai/traces/:id/generations — the per-call GENERATIONS under one parent
+ * trace (the "content drill-down", issue #350). Same permission gate, same tenant
+ * scoping, same durable-vs-hot read seam (the Drizzle store exposes the async
+ * `queryPersisted`, the in-memory sink the sync `query`). The sink already REDACTS
+ * `messages` / `completion` at record time, so this endpoint returns them as-is.
  */
 
-import type { AITrace, AITraceOrigin, AITraceQueryOptions, AITraceStatus } from "@linchkit/core";
+import type {
+  AIGeneration,
+  AITrace,
+  AITraceOrigin,
+  AITraceQueryOptions,
+  AITraceStatus,
+} from "@linchkit/core";
 import { consoleLogger, getAITraceSink } from "@linchkit/core/server";
 import type { Elysia } from "elysia";
 import type { ServerOptions } from "../server";
@@ -60,6 +72,33 @@ const VALID_ORIGINS: ReadonlySet<string> = new Set<AITraceOrigin>(["production",
 const VALID_STATUSES: ReadonlySet<string> = new Set<AITraceStatus>(["ok", "error", "partial"]);
 
 /**
+ * Result of {@link parseLimitParam}: either a validated/clamped limit or a flag
+ * that the supplied `?limit=` value was invalid (the route renders a 400).
+ */
+type ParsedLimit = { ok: true; limit: number } | { ok: false };
+
+/**
+ * Validate + clamp a `?limit=` query param against {@link DEFAULT_TRACE_LIMIT} /
+ * {@link MAX_TRACE_LIMIT}. Shared by the traces + generations routes so the
+ * default / cap / "empty means default" rules stay identical.
+ *
+ * Treats an absent OR empty (`?limit=` / bare `?limit`) param as "use the
+ * default". A provided value must be a POSITIVE integer: `limit < 1` is rejected
+ * — including `?limit=0`, which would otherwise pass and silently return zero
+ * rows (Number("") is also 0, already short-circuited by the empty-string check).
+ */
+function parseLimitParam(raw: unknown): ParsedLimit {
+  if (raw === undefined || String(raw).trim() === "") {
+    return { ok: true, limit: DEFAULT_TRACE_LIMIT };
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1) {
+    return { ok: false };
+  }
+  return { ok: true, limit: Math.min(parsed, MAX_TRACE_LIMIT) };
+}
+
+/**
  * A sink that additionally exposes the async durable trace query (the Drizzle
  * store). Structural — we don't import the concrete class so cap-adapter-server
  * keeps only a lazy dependency on cap-ai-provider.
@@ -77,13 +116,32 @@ function hasPersistedReader(sink: unknown): sink is PersistedTraceReader {
 }
 
 /**
- * Mount `GET /api/ai/traces` onto the given Elysia app.
+ * A sink that additionally exposes the async durable GENERATION query (the
+ * Drizzle store's `queryPersisted`). Structural for the same reason as
+ * {@link PersistedTraceReader}.
+ */
+interface PersistedGenerationReader {
+  queryPersisted(options?: AITraceQueryOptions): Promise<AIGeneration[]>;
+}
+
+function hasPersistedGenerationReader(sink: unknown): sink is PersistedGenerationReader {
+  return (
+    typeof sink === "object" &&
+    sink !== null &&
+    typeof (sink as { queryPersisted?: unknown }).queryPersisted === "function"
+  );
+}
+
+/**
+ * Mount the AI-trace admin read routes onto the given Elysia app:
+ *   - `GET /api/ai/traces`                    — rolled-up parent traces.
+ *   - `GET /api/ai/traces/:id/generations`    — per-call generations under a trace.
  *
- * Behavior summary:
- *   400 — invalid `?limit=` / `?origin=` / `?status=` query param.
+ * Behavior summary (both routes):
+ *   400 — invalid `?limit=` / `?origin=` / `?status=` param, or empty `:id`.
  *   503 — command layer not configured (cannot run the permission slot, fail closed).
  *   401/403 — caller failed the CommandLayer permission slot (canonical envelope).
- *   200 — `{ success: true, data: { traces, count } }` (most-recent-first).
+ *   200 — `{ success: true, data: { traces|generations, count } }` (most-recent-first).
  */
 export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
   const { commandLayer } = options;
@@ -101,19 +159,11 @@ export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
     // ── Validate + clamp query params BEFORE auth-touching work ──────────
     // (cheap input validation; nothing is leaked because we 400 the same way
     // regardless of authorization — the values aren't tenant data.)
-    let limit = DEFAULT_TRACE_LIMIT;
-    // Treat an absent OR empty (`?limit=` / bare `?limit`) param as "use the
-    // default". A provided value must be a POSITIVE integer: `limit < 1` is
-    // rejected (400) — including `?limit=0`, which would otherwise pass and
-    // silently return zero traces (Number("") is also 0, already short-circuited
-    // by the empty-string check above).
-    if (query.limit !== undefined && String(query.limit).trim() !== "") {
-      const parsed = Number(query.limit);
-      if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 1) {
-        return badRequest(set, "Invalid 'limit' — must be a positive integer.");
-      }
-      limit = Math.min(parsed, MAX_TRACE_LIMIT);
+    const parsedLimit = parseLimitParam(query.limit);
+    if (!parsedLimit.ok) {
+      return badRequest(set, "Invalid 'limit' — must be a positive integer.");
     }
+    const limit = parsedLimit.limit;
 
     const origin = query.origin as string | undefined;
     if (origin !== undefined && !VALID_ORIGINS.has(origin)) {
@@ -203,6 +253,112 @@ export function mountAITracesRoutes(app: Elysia, options: ServerOptions): void {
       const message =
         process.env.NODE_ENV === "production"
           ? "Failed to query AI traces."
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      set.status = 500;
+      return { success: false, error: { message } };
+    }
+  });
+
+  // ── GET /api/ai/traces/:id/generations — content drill-down (#350) ──────
+  // Returns the per-call GENERATIONS under one parent trace. SAME permission
+  // gate as the parent-list route above (same command, same `meta.aiObservability`
+  // operation, same `skipActionSlots`): someone who cannot read traces cannot read
+  // generations. The sink already REDACTS `messages` / `completion` at record time
+  // — they are returned as-is (no extra redaction here).
+  app.get("/api/ai/traces/:id/generations", async ({ params, query, set, request }) => {
+    if (!commandLayer) {
+      // The permission slot lives in CommandLayer; without it we cannot authorize
+      // the read, so fail closed rather than skipping the slot.
+      return serviceUnavailable(
+        set,
+        "Command layer is not configured — cannot authorize the AI trace read.",
+      );
+    }
+
+    // ── Validate path + query params BEFORE auth-touching work ───────────
+    // The :id path param is the parent trace id; it must be a non-empty string.
+    const traceId = typeof params.id === "string" ? params.id.trim() : "";
+    if (traceId.length === 0) {
+      return badRequest(set, "Invalid trace id — must be a non-empty string.");
+    }
+    const parsedLimit = parseLimitParam(query.limit);
+    if (!parsedLimit.ok) {
+      return badRequest(set, "Invalid 'limit' — must be a positive integer.");
+    }
+    const limit = parsedLimit.limit;
+
+    // ── Permission slot (CommandLayer, skipActionSlots) ──────────────────
+    // Run auth / permission / tenant BEFORE touching the sink so an unauthorized
+    // caller learns nothing about which generations exist.
+    const actor = await resolveActor(request, options.resolveRequestActor);
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+    const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
+
+    const commandResult = await commandLayer.execute({
+      command: READ_TRACES_COMMAND_NAME,
+      input: {},
+      actor,
+      channel: "http",
+      headers,
+      traceId: incomingTraceId,
+      meta: {
+        // IDENTICAL gate to GET /api/ai/traces — generations are not separately
+        // grantable; the parent-trace read permission governs both.
+        aiObservability: { operation: READ_TRACES_OPERATION },
+      },
+      skipActionSlots: true,
+    });
+
+    if (!commandResult.success) {
+      const statusCode = resolveStatusCode(commandResult);
+      set.status = statusCode;
+      if (statusCode === 401 || statusCode === 403) {
+        return AUTHZ_DENIED_BODY;
+      }
+      const errData = commandResult.data as Record<string, unknown> | undefined;
+      const middlewareMessage = (errData?.error as string) ?? "AI trace read blocked";
+      const middlewareCode = (errData?.code as string) ?? "AI.READ_TRACES.BLOCKED";
+      return { success: false, error: { code: middlewareCode, message: middlewareMessage } };
+    }
+
+    // ── Resolve tenant scope from the tenant slot ────────────────────────
+    // The tenant slot's pin always wins (a scoped operator can never read another
+    // tenant's generations); an unscoped (admin) caller sees all tenants. There is
+    // no `?tenantId=` override here — the drill-down is keyed solely on :id.
+    const resolvedTenantId = (commandResult.data as { tenantId?: string } | undefined)?.tenantId;
+
+    // ── Query the sink for generations under this trace ──────────────────
+    const queryOptions: AITraceQueryOptions = {
+      limit,
+      traceId,
+      ...(resolvedTenantId !== undefined ? { tenantId: resolvedTenantId } : {}),
+    };
+
+    try {
+      const sink = getAITraceSink();
+      // Prefer the durable async generation query (Drizzle store's `queryPersisted`)
+      // so the drill-down serves history that survived a restart; fall back to the
+      // sync process-local hot view (`query`) for the in-memory / noop sinks. The
+      // `tenantId` filter is applied IN the query (both readers resolve it via the
+      // parent trace), so a scoped operator never receives a foreign generation.
+      const generations = hasPersistedGenerationReader(sink)
+        ? await sink.queryPersisted(queryOptions)
+        : sink.query(queryOptions);
+      return { success: true, data: { generations, count: generations.length } };
+    } catch (err) {
+      // Always log the real error server-side; only the CLIENT-facing message is
+      // redacted in production (the raw text could leak query/schema detail).
+      consoleLogger.error(
+        `[ai-traces] generation query failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Failed to query AI generations."
           : err instanceof Error
             ? err.message
             : String(err);


### PR DESCRIPTION
## What

`GET /api/ai/traces` (#557) returns rolled-up **parent** traces only — name,
origin, status, aggregate tokens/cost. The actual per-call **content** (model,
per-generation tokens/cost/status, and the redacted prompt/completion messages)
lives on the child `AIGeneration` records and had no read path. This is the
question the trace UI couldn't yet answer: *"调用追踪内容呢？"* (where's the
call content?).

This adds the per-call drill-down endpoint:

```
GET /api/ai/traces/:id/generations  →  { success: true, data: { generations, count } }
```

It's the server foundation for the content drill-down UI (row-click → show the
model, token split, and masked messages for each generation under a trace).
Companion to #562 (streaming/AG-UI trace recording) and #563 (the traces list page).

## How

- **`mountAITracesRoutes`** (`routes/ai-traces-api.ts`) — new route returning
  the `AIGeneration[]` for a trace id, scoped to the resolved `tenantId` (no
  cross-tenant read). Same CommandLayer permission slot as the list route
  (`meta.aiObservability = { operation: "read_traces" }` → canonical
  `AUTHZ_DENIED` envelope on denial; the sink is never consulted when denied).
- **Durable-first read** — `hasPersistedGenerationReader(sink)` checks for a
  `queryPersisted` reader (Drizzle store) and prefers it; falls back to the
  in-memory hot view otherwise. Same pattern the list route uses.
- **`parseLimitParam`** — extracted as a tagged-union `ParsedLimit` so an empty
  `?limit=` means "use the default" while `?limit=0` is a hard 400 (never
  silently zero rows). Server hard-caps the limit.

## Tests

11 in-process (`app.handle`) tests in `ai-traces-generations-api.test.ts`:
canonical-deny + sink-never-read, happy path (2 generations under tenant t1, 1
under t2), empty trace, tenant scoping (scoped vs unscoped admin), and the full
limit-validation matrix (0 → 400, empty → default, command-layer-absent → 503
fail-closed). `bun run typecheck`, `bun run check`, `bun run test` (298) green.

## Review

Codex review (`origin/main..HEAD`): clean — *"No actionable correctness issues…
preserves authorization, tenant scoping, validation, and sink selection patterns
consistent with the existing traces API."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GET `/api/ai/traces/:id/generations` endpoint to retrieve generation records for a specific trace.
  * Implemented `limit` query parameter with validation to control result size.
  * Enforced authorization checks and tenant scoping on the new endpoint.

* **Tests**
  * Added comprehensive test suite covering endpoint behavior, permission validation, tenant isolation, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->