### PR TITLE
feat(adapter-server,adapter-ui): dev-mode role switching via x-dev-role (Spec 72 P2)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
@@ -103,6 +103,17 @@ describe("resolveDevRoleActor (unit)", () => {
     }).toThrow();
     expect(admin.groups).not.toContain("evil");
   });
+
+  it("the NO_AUTH_ACTOR fallback is deep-frozen too (same shared-reference invariant)", () => {
+    for (const actor of [resolveDevRoleActor(req()), resolveDevRoleActor(req("garbage"))]) {
+      expect(Object.isFrozen(actor)).toBe(true);
+      expect(Object.isFrozen(actor.groups)).toBe(true);
+      expect(() => {
+        (actor.groups as string[]).push("evil");
+      }).toThrow();
+      expect(actor.groups).not.toContain("evil");
+    }
+  });
 });
 
 // ── In-process HTTP: dev wiring default ───────────────────

--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Dev-mode role switching — `x-dev-role` header → actor resolution.
+ *
+ * Two layers, both against the REAL implementation the dev wiring uses
+ * (`src/dev-actor-resolver.ts` is imported by `dev.ts` AND defaulted by
+ * `createDevApp`, so there is exactly one resolver to drift):
+ *
+ * 1. Unit: `resolveDevRoleActor(request)` maps recognized roles to their
+ *    synthetic actors and falls back to the elevated `NO_AUTH_ACTOR` for
+ *    absent/unrecognized values (back-compat with the historical no-resolver
+ *    dev mode).
+ *
+ * 2. In-process HTTP: `createDevApp(...)` WITHOUT a caller-supplied resolver —
+ *    i.e. the actual dev default — driven via `app.handle(new Request(...))`
+ *    (port-free, never `app.listen`). A synthetic `reveal_actor` action echoes
+ *    `ctx.actor` so the test observes exactly which actor the CommandLayer
+ *    pipeline executed with, through both the REST action path and GraphQL.
+ */
+
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { ActionDefinition, CapabilityDefinition, EntityDefinition } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { DEV_ROLE_ACTORS, DEV_ROLE_HEADER, resolveDevRoleActor } from "../src/dev-actor-resolver";
+import { createDevApp } from "../src/dev-app";
+import { NO_AUTH_ACTOR } from "../src/routes/shared";
+
+// ── Unit: resolver function ────────────────────────────────
+
+/** Build an in-process Request carrying an optional x-dev-role header. */
+function req(role?: string): Request {
+  const headers: Record<string, string> = {};
+  if (role !== undefined) headers[DEV_ROLE_HEADER] = role;
+  return new Request("http://local.test/api/actions/anything", { method: "POST", headers });
+}
+
+describe("resolveDevRoleActor (unit)", () => {
+  it("maps x-dev-role: user to the restricted purchase_user actor", () => {
+    const actor = resolveDevRoleActor(req("user"));
+    expect(actor).toEqual({
+      type: "human",
+      id: "dev-user",
+      name: "Dev User",
+      groups: ["purchase_user", "user"],
+    });
+  });
+
+  it("maps x-dev-role: manager to the purchase_manager actor", () => {
+    const actor = resolveDevRoleActor(req("manager"));
+    expect(actor).toEqual({
+      type: "human",
+      id: "dev-manager",
+      name: "Dev Manager",
+      groups: ["purchase_manager", "manager", "user"],
+    });
+  });
+
+  it("maps x-dev-role: admin to the elevated dev-admin actor", () => {
+    const actor = resolveDevRoleActor(req("admin"));
+    expect(actor).toEqual({
+      type: "human",
+      id: "dev-admin",
+      name: "Dev Admin",
+      groups: ["admin", "manager", "user"],
+    });
+  });
+
+  it("is case-insensitive and whitespace-tolerant", () => {
+    expect(resolveDevRoleActor(req(" Manager "))).toBe(DEV_ROLE_ACTORS.manager);
+    expect(resolveDevRoleActor(req("USER"))).toBe(DEV_ROLE_ACTORS.user);
+  });
+
+  it("falls back to the elevated NO_AUTH_ACTOR when the header is absent (back-compat)", () => {
+    expect(resolveDevRoleActor(req())).toBe(NO_AUTH_ACTOR);
+  });
+
+  it("falls back to the elevated NO_AUTH_ACTOR for unrecognized values (back-compat)", () => {
+    for (const value of ["superadmin", "", "  ", "manager;admin"]) {
+      expect(resolveDevRoleActor(req(value))).toBe(NO_AUTH_ACTOR);
+    }
+  });
+
+  it("never returns undefined — the ANONYMOUS downgrade fallback cannot trigger", () => {
+    expect(resolveDevRoleActor(req("garbage"))).toBeDefined();
+    expect(resolveDevRoleActor(req())).toBeDefined();
+  });
+});
+
+// ── In-process HTTP: dev wiring default ───────────────────
+
+/** Minimal entity so the capability assembles a non-empty GraphQL schema. */
+const probeEntity: EntityDefinition = {
+  name: "probe",
+  label: "Probe",
+  description: "Synthetic entity for dev-role resolver e2e",
+  fields: {
+    note: { type: "string", label: "Note" },
+  },
+};
+
+/**
+ * Echoes the actor the CommandLayer pipeline resolved for this execution —
+ * the observable seam for "which role did this request run as?".
+ */
+const revealActorAction: ActionDefinition = {
+  name: "reveal_actor",
+  entity: "probe",
+  label: "Reveal Actor",
+  description: "Echo the executing actor (dev-role resolver test probe)",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => ({ actor: ctx.actor }),
+};
+
+const capProbe: CapabilityDefinition = defineCapability({
+  name: "cap-dev-role-probe",
+  label: "Dev Role Probe",
+  description: "Synthetic capability exposing an actor-echo action",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [probeEntity],
+  actions: [revealActorAction],
+});
+
+// In-process, port-free: the URL only supplies a path to `new Request(...)`
+// for `app.handle` — no socket is bound (NEVER app.listen in tests).
+const REST_URL = "http://local.test/api/actions/reveal_actor";
+const GQL_URL = "http://local.test/graphql";
+
+let app: ReturnType<typeof createDevApp>["app"];
+
+beforeAll(() => {
+  // No resolveRequestActor passed — this exercises the createDevApp DEFAULT,
+  // which is the same `resolveDevRoleActor` that dev.ts wires for
+  // `bun run dev:server`.
+  app = createDevApp([capProbe], { cors: false }).app;
+});
+
+interface EchoedActor {
+  type: string;
+  id: string;
+  name?: string;
+  groups: string[];
+}
+
+async function revealViaRest(role?: string): Promise<EchoedActor> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (role !== undefined) headers[DEV_ROLE_HEADER] = role;
+  const res = await app.handle(new Request(REST_URL, { method: "POST", headers, body: "{}" }));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { success: boolean; data: { actor: EchoedActor } };
+  expect(body.success).toBe(true);
+  return body.data.actor;
+}
+
+describe("x-dev-role over in-process HTTP (createDevApp default wiring)", () => {
+  it("REST: x-dev-role: user executes as the purchase_user actor", async () => {
+    const actor = await revealViaRest("user");
+    expect(actor.id).toBe("dev-user");
+    expect(actor.type).toBe("human");
+    expect(actor.groups).toEqual(["purchase_user", "user"]);
+  });
+
+  it("REST: x-dev-role: manager executes as the purchase_manager actor", async () => {
+    const actor = await revealViaRest("manager");
+    expect(actor.id).toBe("dev-manager");
+    expect(actor.groups).toEqual(["purchase_manager", "manager", "user"]);
+  });
+
+  it("REST: x-dev-role: admin executes as the elevated dev-admin actor", async () => {
+    const actor = await revealViaRest("admin");
+    expect(actor.id).toBe("dev-admin");
+    expect(actor.groups).toEqual(["admin", "manager", "user"]);
+  });
+
+  it("REST: no header keeps today's elevated no-auth default (back-compat)", async () => {
+    const actor = await revealViaRest();
+    expect(actor.id).toBe("anonymous");
+    expect(actor.groups).toEqual(["admin", "manager", "user"]);
+  });
+
+  it("REST: unrecognized role keeps today's elevated no-auth default (back-compat)", async () => {
+    const actor = await revealViaRest("root");
+    expect(actor.id).toBe("anonymous");
+    expect(actor.groups).toEqual(["admin", "manager", "user"]);
+  });
+
+  it("GraphQL: the same header drives the action-mutation channel", async () => {
+    // The generic executeAction mutation returns JSON-encoded result data,
+    // which lets the probe action's echoed actor cross the GraphQL boundary.
+    const res = await app.handle(
+      new Request(GQL_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json", [DEV_ROLE_HEADER]: "manager" },
+        body: JSON.stringify({
+          query: `mutation { executeAction(name: "reveal_actor", input: "{}") { success data } }`,
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data?: { executeAction?: { success: boolean; data: string | null } };
+      errors?: Array<{ message: string }>;
+    };
+    expect(body.errors).toBeUndefined();
+    expect(body.data?.executeAction?.success).toBe(true);
+    const payload = JSON.parse(body.data?.executeAction?.data ?? "{}") as { actor?: EchoedActor };
+    expect(payload.actor?.id).toBe("dev-manager");
+    expect(payload.actor?.groups).toEqual(["purchase_manager", "manager", "user"]);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
@@ -60,7 +60,7 @@ describe("resolveDevRoleActor (unit)", () => {
       type: "human",
       id: "dev-admin",
       name: "Dev Admin",
-      groups: ["admin", "manager", "user"],
+      groups: ["purchase_manager", "purchase_user", "admin", "manager", "user"],
     });
   });
 
@@ -170,7 +170,7 @@ describe("x-dev-role over in-process HTTP (createDevApp default wiring)", () => 
   it("REST: x-dev-role: admin executes as the elevated dev-admin actor", async () => {
     const actor = await revealViaRest("admin");
     expect(actor.id).toBe("dev-admin");
-    expect(actor.groups).toEqual(["admin", "manager", "user"]);
+    expect(actor.groups).toEqual(["purchase_manager", "purchase_user", "admin", "manager", "user"]);
   });
 
   it("REST: no header keeps today's elevated no-auth default (back-compat)", async () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-role-resolver.test.ts
@@ -83,6 +83,26 @@ describe("resolveDevRoleActor (unit)", () => {
     expect(resolveDevRoleActor(req("garbage"))).toBeDefined();
     expect(resolveDevRoleActor(req())).toBeDefined();
   });
+
+  it("prototype-chain header values resolve to the safe fallback, not Object members", () => {
+    // Without an own-property guard, `x-dev-role: constructor` would look up
+    // Object.prototype.constructor and hand back a FUNCTION as the actor.
+    for (const value of ["constructor", "toString", "__proto__", "hasOwnProperty"]) {
+      const actor = resolveDevRoleActor(req(value));
+      expect(actor).toBe(NO_AUTH_ACTOR);
+      expect(typeof actor).toBe("object");
+    }
+  });
+
+  it("actors are deep-frozen — shared references cannot be mutated downstream", () => {
+    const admin = resolveDevRoleActor(req("admin"));
+    expect(Object.isFrozen(admin)).toBe(true);
+    expect(Object.isFrozen(admin.groups)).toBe(true);
+    expect(() => {
+      (admin.groups as string[]).push("evil");
+    }).toThrow();
+    expect(admin.groups).not.toContain("evil");
+  });
 });
 
 // ── In-process HTTP: dev wiring default ───────────────────

--- a/addons/adapter-server/cap-adapter-server/src/dev-actor-resolver.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-actor-resolver.ts
@@ -54,7 +54,12 @@ export const DEV_ROLE_ACTORS: Readonly<Record<string, Actor>> = Object.freeze({
     type: "human",
     id: "dev-admin",
     name: "Dev Admin",
-    groups: ["admin", "manager", "user"],
+    // Cumulative: includes the capability-specific groups too. Permission
+    // grants key on EXACT group names (e.g. cap-purchase-demo grants
+    // approve_purchase_request to `purchase_manager`, not to `admin`), so an
+    // "elevated" admin without them would be LESS capable than manager once
+    // cap-permission is enabled (codex P2 on this branch).
+    groups: ["purchase_manager", "purchase_user", "admin", "manager", "user"],
   },
 });
 

--- a/addons/adapter-server/cap-adapter-server/src/dev-actor-resolver.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-actor-resolver.ts
@@ -37,20 +37,30 @@ export const DEV_ROLE_HEADER = "x-dev-role";
  * role-gated demo behavior ("only managers may approve large purchases") is
  * demonstrable out of the box.
  */
+/**
+ * Deep-freeze an actor: `Object.freeze` is shallow, and the resolver hands out
+ * these SHARED references — a downstream `actor.groups.push(...)` would
+ * otherwise silently corrupt the actor for every later request in-process.
+ */
+function freezeActor(actor: Actor): Actor {
+  Object.freeze(actor.groups);
+  return Object.freeze(actor);
+}
+
 export const DEV_ROLE_ACTORS: Readonly<Record<string, Actor>> = Object.freeze({
-  user: {
+  user: freezeActor({
     type: "human",
     id: "dev-user",
     name: "Dev User",
     groups: ["purchase_user", "user"],
-  },
-  manager: {
+  }),
+  manager: freezeActor({
     type: "human",
     id: "dev-manager",
     name: "Dev Manager",
     groups: ["purchase_manager", "manager", "user"],
-  },
-  admin: {
+  }),
+  admin: freezeActor({
     type: "human",
     id: "dev-admin",
     name: "Dev Admin",
@@ -60,7 +70,7 @@ export const DEV_ROLE_ACTORS: Readonly<Record<string, Actor>> = Object.freeze({
     // "elevated" admin without them would be LESS capable than manager once
     // cap-permission is enabled (codex P2 on this branch).
     groups: ["purchase_manager", "purchase_user", "admin", "manager", "user"],
-  },
+  }),
 });
 
 /**
@@ -73,8 +83,14 @@ export const DEV_ROLE_ACTORS: Readonly<Record<string, Actor>> = Object.freeze({
 export function resolveDevRoleActor(request: Request): Actor {
   const raw = request.headers.get(DEV_ROLE_HEADER);
   if (raw) {
-    const actor = DEV_ROLE_ACTORS[raw.trim().toLowerCase()];
-    if (actor) return actor;
+    const key = raw.trim().toLowerCase();
+    // Object.hasOwn guards against prototype-chain lookups: a header like
+    // `x-dev-role: constructor` would otherwise resolve to Object.prototype
+    // members and crash downstream when `.groups` / `.id` are read.
+    if (Object.hasOwn(DEV_ROLE_ACTORS, key)) {
+      const actor = DEV_ROLE_ACTORS[key];
+      if (actor) return actor;
+    }
   }
   // Back-compat: same elevated default as the historical no-resolver dev mode.
   return NO_AUTH_ACTOR;

--- a/addons/adapter-server/cap-adapter-server/src/dev-actor-resolver.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-actor-resolver.ts
@@ -1,0 +1,76 @@
+/**
+ * Dev-only role-switching actor resolver (`x-dev-role` header).
+ *
+ * DEVELOPMENT AFFORDANCE, NOT AN AUTH MECHANISM. This resolver lets a live
+ * demo walk the same app as different roles (purchase_user vs purchase_manager
+ * vs admin) from every channel — browser UI, REST, MCP, AI agents — by sending
+ * an `x-dev-role` header. It trusts the header blindly, so it must ONLY ever
+ * be wired into the no-auth dev entry points (`dev.ts` / `createDevApp`),
+ * never into `createServer` defaults and never alongside a real auth resolver
+ * (when an auth capability configures `resolveRequestActor`, that resolver is
+ * passed instead and this module stays out of the request path entirely).
+ *
+ * Contract:
+ * - `x-dev-role: user`    → restricted purchase_user actor
+ * - `x-dev-role: manager` → purchase_manager actor
+ * - `x-dev-role: admin`   → elevated dev-admin actor
+ * - absent / unrecognized → `NO_AUTH_ACTOR`, the SAME elevated default the
+ *   no-auth dev server resolved before this module existed — existing REST
+ *   scripts, flows, and AI endpoints keep working unchanged.
+ *
+ * The resolver always returns an Actor (never `undefined`) so the server's
+ * `?? ANONYMOUS_ACTOR` fallback — which would DOWNGRADE privileges relative to
+ * the historical no-resolver behavior — can never trigger on the dev path.
+ */
+
+import type { Actor } from "@linchkit/core";
+import { NO_AUTH_ACTOR } from "./routes/shared";
+
+/** Header carrying the requested dev role. Lowercase (HTTP headers are case-insensitive). */
+export const DEV_ROLE_HEADER = "x-dev-role";
+
+/**
+ * Recognized dev roles and the synthetic actors they resolve to.
+ *
+ * Group sets are cumulative supersets (user ⊂ manager ⊂ admin) and include the
+ * purchase-demo permission groups (`purchase_user` / `purchase_manager`) so
+ * role-gated demo behavior ("only managers may approve large purchases") is
+ * demonstrable out of the box.
+ */
+export const DEV_ROLE_ACTORS: Readonly<Record<string, Actor>> = Object.freeze({
+  user: {
+    type: "human",
+    id: "dev-user",
+    name: "Dev User",
+    groups: ["purchase_user", "user"],
+  },
+  manager: {
+    type: "human",
+    id: "dev-manager",
+    name: "Dev Manager",
+    groups: ["purchase_manager", "manager", "user"],
+  },
+  admin: {
+    type: "human",
+    id: "dev-admin",
+    name: "Dev Admin",
+    groups: ["admin", "manager", "user"],
+  },
+});
+
+/**
+ * Resolve the request actor from the `x-dev-role` header (dev wiring only).
+ *
+ * Matching is case-insensitive and whitespace-tolerant. Absent or unrecognized
+ * values fall back to the elevated {@link NO_AUTH_ACTOR} — identical to the
+ * pre-existing no-resolver dev behavior, so this is strictly additive.
+ */
+export function resolveDevRoleActor(request: Request): Actor {
+  const raw = request.headers.get(DEV_ROLE_HEADER);
+  if (raw) {
+    const actor = DEV_ROLE_ACTORS[raw.trim().toLowerCase()];
+    if (actor) return actor;
+  }
+  // Back-compat: same elevated default as the historical no-resolver dev mode.
+  return NO_AUTH_ACTOR;
+}

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -45,6 +45,7 @@ import {
   type AssembledDevSchema,
   assembleDevSchema,
 } from "./assemble-schema";
+import { resolveDevRoleActor } from "./dev-actor-resolver";
 import { createServer, type ServerOptions } from "./server";
 
 /**
@@ -303,6 +304,13 @@ export function createDevApp(
   // share one wiring path.
   const app = createServer(schema, {
     ...serverOverrides,
+    // Dev-only role switching (`x-dev-role` header) — mirrors dev.ts so the
+    // boot smoke test and the real dev server share one wiring path. A caller-
+    // supplied resolver (e.g. an auth integration test) takes precedence; this
+    // default is a development affordance, NOT an auth mechanism, and never
+    // ships as a `createServer` default. Header absent/unrecognized → same
+    // elevated no-auth actor as before, so existing tests are unaffected.
+    resolveRequestActor: serverOverrides.resolveRequestActor ?? resolveDevRoleActor,
     executor: runtime.executor,
     commandLayer: runtime.commandLayer,
     approvalEngine: runtime.approvalEngine,

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -10,6 +10,7 @@ import { resolve } from "node:path";
 import { consoleLogger } from "@linchkit/core/server";
 import { assembleDevSchema } from "./assemble-schema";
 import { loadConfig } from "./config-loader";
+import { resolveDevRoleActor } from "./dev-actor-resolver";
 import { buildDevEvolutionRuntime, buildDevOntologyRegistry } from "./dev-app";
 import { createServer } from "./server";
 import { wireAITraceSink } from "./wire-ai-trace-sink";
@@ -162,6 +163,11 @@ const server = createServer(graphqlSchema, {
   linchKitConfig: config,
   states: capContributions.states,
   flows: [],
+  // Dev-only role switching (`x-dev-role` header) — a development affordance,
+  // NOT an auth mechanism. Lives in this dev entry wiring only; absent or
+  // unrecognized header resolves to the same elevated no-auth actor as before,
+  // so every existing channel (REST scripts, flows, AI endpoints) is unchanged.
+  resolveRequestActor: resolveDevRoleActor,
   dataProvider: runtime.dataProvider,
   onchangeEvaluator,
   ontologyRegistry,

--- a/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
@@ -20,11 +20,16 @@ export const ANONYMOUS_ACTOR: Actor = {
  * so all actions (including permission-gated ones) can be executed
  * during development and demo scenarios.
  */
-export const NO_AUTH_ACTOR: Actor = {
+// Deep-frozen: this shared reference is handed to every no-auth request (and
+// is the dev role resolver's fallback) — a downstream `groups.push(...)`
+// would otherwise silently corrupt the actor process-wide. Same invariant as
+// DEV_ROLE_ACTORS in dev-actor-resolver.ts.
+export const NO_AUTH_ACTOR: Actor = Object.freeze({
   type: "human",
   id: "anonymous",
   groups: ["admin", "manager", "user"],
-};
+});
+Object.freeze(NO_AUTH_ACTOR.groups);
 
 /**
  * Shape of the synthetic data carried by a successful `skipActionSlots`

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/dev-role.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/dev-role.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  DEFAULT_DEV_ROLE,
+  DEV_ROLE_HEADER,
+  DEV_ROLES,
+  getDevRole,
+  getDevRoleHeaders,
+  getStoredDevRole,
+  setDevRole,
+} from "../src/lib/dev-role";
+
+// Minimal localStorage shim for bun test (no DOM environment) — same pattern
+// as tenant.test.ts.
+const store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+      key: (index: number) => [...store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+describe("dev-role utilities", () => {
+  beforeEach(() => {
+    // Clear via the live shim (another test file may have installed its own).
+    localStorage.clear();
+  });
+
+  describe("contract constants", () => {
+    test("header name matches the dev server resolver", () => {
+      expect(DEV_ROLE_HEADER).toBe("x-dev-role");
+    });
+
+    test("roles match the dev server's recognized set, default is admin", () => {
+      expect(DEV_ROLES).toEqual(["user", "manager", "admin"]);
+      expect(DEFAULT_DEV_ROLE).toBe("admin");
+    });
+  });
+
+  describe("getStoredDevRole", () => {
+    test("returns null when nothing is stored", () => {
+      expect(getStoredDevRole()).toBeNull();
+    });
+
+    test("returns the stored role", () => {
+      localStorage.setItem("linchkit:dev-role", "manager");
+      expect(getStoredDevRole()).toBe("manager");
+    });
+
+    test("treats an unrecognized stored value as no choice", () => {
+      localStorage.setItem("linchkit:dev-role", "superadmin");
+      expect(getStoredDevRole()).toBeNull();
+    });
+  });
+
+  describe("getDevRole", () => {
+    test("defaults to admin (= today's elevated no-auth behavior)", () => {
+      expect(getDevRole()).toBe("admin");
+    });
+
+    test("returns the stored choice", () => {
+      setDevRole("user");
+      expect(getDevRole()).toBe("user");
+    });
+  });
+
+  describe("setDevRole", () => {
+    test("stores the role under linchkit:dev-role", () => {
+      setDevRole("manager");
+      expect(localStorage.getItem("linchkit:dev-role")).toBe("manager");
+    });
+
+    test("clears the choice when null is passed", () => {
+      setDevRole("manager");
+      setDevRole(null);
+      expect(localStorage.getItem("linchkit:dev-role")).toBeNull();
+      expect(getDevRole()).toBe("admin");
+    });
+  });
+
+  describe("getDevRoleHeaders", () => {
+    test("returns empty object when no explicit choice exists (no header sent)", () => {
+      expect(getDevRoleHeaders()).toEqual({});
+    });
+
+    test("returns the x-dev-role header for an explicit choice", () => {
+      setDevRole("user");
+      expect(getDevRoleHeaders()).toEqual({ "x-dev-role": "user" });
+    });
+
+    test("sends the header even for an explicit admin choice", () => {
+      setDevRole("admin");
+      expect(getDevRoleHeaders()).toEqual({ "x-dev-role": "admin" });
+    });
+
+    test("returns empty object after the choice is cleared", () => {
+      setDevRole("manager");
+      setDevRole(null);
+      expect(getDevRoleHeaders()).toEqual({});
+    });
+
+    test("ignores a corrupted stored value (back-compat: no header sent)", () => {
+      localStorage.setItem("linchkit:dev-role", "root");
+      expect(getDevRoleHeaders()).toEqual({});
+    });
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
@@ -29,11 +29,16 @@ import { CheckIcon, UserCogIcon } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { isAuthEnabled } from "@/lib/api";
-import { DEV_ROLES, type DevRole, getDevRole, setDevRole } from "@/lib/dev-role";
+import { DEV_ROLES, type DevRole, getStoredDevRole, setDevRole } from "@/lib/dev-role";
 
 export function DevRoleSwitcher() {
   const { t } = useTranslation();
-  const activeRole = getDevRole();
+  // The STORED choice (null when none): with no choice, NO header is sent and
+  // the server resolves the anonymous no-auth default — which is NOT the same
+  // actor as an explicit "admin" selection. Displaying "Admin" there would
+  // claim an identity the server isn't using, so the trigger shows a distinct
+  // "Default" label and no role gets a check mark until one is chosen.
+  const activeRole = getStoredDevRole();
 
   const handleSelect = useCallback((role: DevRole) => {
     setDevRole(role);
@@ -54,7 +59,7 @@ export function DevRoleSwitcher() {
             <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-muted-foreground">
               <UserCogIcon className="size-4" />
               <span className="hidden text-xs sm:inline-flex max-w-[120px] truncate">
-                {t(`devRole.roles.${activeRole}`)}
+                {activeRole ? t(`devRole.roles.${activeRole}`) : t("devRole.roles.default")}
               </span>
             </Button>
           </DropdownMenuTrigger>

--- a/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
@@ -40,10 +40,11 @@ export function DevRoleSwitcher() {
   // "Default" label and no role gets a check mark until one is chosen.
   const activeRole = getStoredDevRole();
 
-  const handleSelect = useCallback((role: DevRole) => {
+  const handleSelect = useCallback((role: DevRole | null) => {
+    // null clears the stored choice → back to the "Default (anonymous)" state
+    // (no header sent). Reload so every page refetches with the new role
+    // context — same strategy as TenantSwitcher.
     setDevRole(role);
-    // Reload so every page refetches with the new role context — same
-    // strategy as TenantSwitcher.
     window.location.reload();
   }, []);
 
@@ -71,6 +72,13 @@ export function DevRoleSwitcher() {
           {t("devRole.selectRole")}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        {/* "Default (anonymous)" clears the stored choice — without it a user
+            could never return to the no-header state from the UI. */}
+        <DropdownMenuItem onClick={() => handleSelect(null)} className="gap-2">
+          <UserCogIcon className="size-4 text-muted-foreground" />
+          <span className="flex-1">{t("devRole.roles.default")}</span>
+          {activeRole === null && <CheckIcon className="size-4 text-primary" />}
+        </DropdownMenuItem>
         {DEV_ROLES.map((role) => (
           <DropdownMenuItem key={role} onClick={() => handleSelect(role)} className="gap-2">
             <UserCogIcon className="size-4 text-muted-foreground" />

--- a/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
@@ -9,8 +9,9 @@
  *
  * Visibility: rendered only in Vite dev builds (`import.meta.env.DEV` is
  * statically replaced, so production builds tree-shake this out) AND only
- * when no real auth capability is active (`isAuthEnabled()` from
- * /api/app-config) — with real auth, identities come from login, not headers.
+ * once /api/app-config has resolved with `authEnabled: false` (fail-closed:
+ * hidden until resolved) — with real auth, identities come from login, not
+ * headers.
  */
 
 import {
@@ -26,13 +27,39 @@ import {
   TooltipTrigger,
 } from "@linchkit/ui-kit/components";
 import { CheckIcon, UserCogIcon } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { isAuthEnabled } from "@/lib/api";
+import { fetchAppConfig } from "@/lib/api";
 import { DEV_ROLES, type DevRole, getStoredDevRole, setDevRole } from "@/lib/dev-role";
+
+/**
+ * Resolve `authEnabled` from the (cached) app-config fetch reactively.
+ * The module-level cache behind `isAuthEnabled()` is null until the first
+ * fetch resolves, and React gets no re-render signal when it does — a plain
+ * synchronous read here would return false on first render even when auth is
+ * enabled. Tri-state: null = not resolved yet (FAIL-CLOSED: treat as "may be
+ * enabled" and render nothing).
+ */
+function useAuthEnabled(): boolean | null {
+  const [authEnabled, setAuthEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Reuses the cached fetch — resolves instantly after the app shell loaded.
+    fetchAppConfig().then((config) => {
+      if (!cancelled) setAuthEnabled(config.authEnabled);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return authEnabled;
+}
 
 export function DevRoleSwitcher() {
   const { t } = useTranslation();
+  const authEnabled = useAuthEnabled();
   // The STORED choice (null when none): with no choice, NO header is sent and
   // the server resolves the anonymous no-auth default — which is NOT the same
   // actor as an explicit "admin" selection. Displaying "Admin" there would
@@ -49,8 +76,9 @@ export function DevRoleSwitcher() {
   }, []);
 
   // Dev builds only (statically eliminated in production), and never when a
-  // real auth capability provides actual identities.
-  if (!import.meta.env.DEV || isAuthEnabled()) return null;
+  // real auth capability provides actual identities. FAIL-CLOSED: stays
+  // hidden until the app config has resolved to authEnabled === false.
+  if (!import.meta.env.DEV || authEnabled !== false) return null;
 
   return (
     <DropdownMenu>

--- a/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/dev-role-switcher.tsx
@@ -1,0 +1,83 @@
+/**
+ * DevRoleSwitcher — dev-only dropdown to walk the app as different roles.
+ *
+ * DEVELOPMENT AFFORDANCE, NOT AN AUTH MECHANISM. Persists the choice to
+ * localStorage (`linchkit:dev-role`); `getAuthHeaders()` then attaches it as
+ * the `x-dev-role` header, which the no-auth dev server's actor resolver maps
+ * to a demo actor (user / manager / admin). Mirrors TenantSwitcher's style
+ * and reload-on-change behavior.
+ *
+ * Visibility: rendered only in Vite dev builds (`import.meta.env.DEV` is
+ * statically replaced, so production builds tree-shake this out) AND only
+ * when no real auth capability is active (`isAuthEnabled()` from
+ * /api/app-config) — with real auth, identities come from login, not headers.
+ */
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@linchkit/ui-kit/components";
+import { CheckIcon, UserCogIcon } from "lucide-react";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { isAuthEnabled } from "@/lib/api";
+import { DEV_ROLES, type DevRole, getDevRole, setDevRole } from "@/lib/dev-role";
+
+export function DevRoleSwitcher() {
+  const { t } = useTranslation();
+  const activeRole = getDevRole();
+
+  const handleSelect = useCallback((role: DevRole) => {
+    setDevRole(role);
+    // Reload so every page refetches with the new role context — same
+    // strategy as TenantSwitcher.
+    window.location.reload();
+  }, []);
+
+  // Dev builds only (statically eliminated in production), and never when a
+  // real auth capability provides actual identities.
+  if (!import.meta.env.DEV || isAuthEnabled()) return null;
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-muted-foreground">
+              <UserCogIcon className="size-4" />
+              <span className="hidden text-xs sm:inline-flex max-w-[120px] truncate">
+                {t(`devRole.roles.${activeRole}`)}
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{t("devRole.switchRole")}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="min-w-[180px]">
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("devRole.selectRole")}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {DEV_ROLES.map((role) => (
+          <DropdownMenuItem key={role} onClick={() => handleSelect(role)} className="gap-2">
+            <UserCogIcon className="size-4 text-muted-foreground" />
+            <span className="flex-1">{t(`devRole.roles.${role}`)}</span>
+            {role === activeRole && <CheckIcon className="size-4 text-primary" />}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <div className="px-2 py-1.5 text-[10px] leading-tight text-muted-foreground">
+          {t("devRole.devOnlyHint")}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/header-actions.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/header-actions.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@linchkit/ui-kit/hooks";
 import { GlobeIcon, MonitorIcon, MoonIcon, SearchIcon, SparklesIcon, SunIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { changeLanguage, languageNames, type SupportedLanguage, supportedLanguages } from "@/i18n";
+import { DevRoleSwitcher } from "./dev-role-switcher";
 import { NotificationCenter } from "./notification-center";
 import { TenantSwitcher } from "./tenant-switcher";
 
@@ -42,6 +43,9 @@ export function HeaderActions({
 
   return (
     <div className="flex items-center gap-1">
+      {/* Dev-only role switcher (renders nothing in production builds / with real auth) */}
+      <DevRoleSwitcher />
+
       {/* Tenant switcher */}
       <TenantSwitcher />
 

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -262,6 +262,16 @@
     "selectTenant": "Select tenant",
     "clearTenant": "Clear tenant"
   },
+  "devRole": {
+    "switchRole": "Switch dev role",
+    "selectRole": "View as role (dev only)",
+    "devOnlyHint": "Development affordance — not an auth mechanism.",
+    "roles": {
+      "user": "User",
+      "manager": "Manager",
+      "admin": "Admin"
+    }
+  },
   "language": {
     "label": "Language",
     "en": "English",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -269,7 +269,8 @@
     "roles": {
       "user": "User",
       "manager": "Manager",
-      "admin": "Admin"
+      "admin": "Admin",
+      "default": "Default (anonymous)"
     }
   },
   "language": {

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -269,7 +269,8 @@
     "roles": {
       "user": "普通用户",
       "manager": "经理",
-      "admin": "管理员"
+      "admin": "管理员",
+      "default": "默认（匿名）"
     }
   },
   "language": {

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -262,6 +262,16 @@
     "selectTenant": "选择租户",
     "clearTenant": "清除租户"
   },
+  "devRole": {
+    "switchRole": "切换开发角色",
+    "selectRole": "以角色查看（仅开发模式）",
+    "devOnlyHint": "开发辅助功能，不是认证机制。",
+    "roles": {
+      "user": "普通用户",
+      "manager": "经理",
+      "admin": "管理员"
+    }
+  },
   "language": {
     "label": "语言",
     "en": "English",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/agui-chat-transport.ts
@@ -32,6 +32,7 @@ import type {
 import { EventType, HttpAgent } from "@ag-ui/client";
 import type { ChatTransport, UIMessage, UIMessageChunk } from "ai";
 import { getToolName, isToolUIPart } from "ai";
+import { getDevRoleHeaders } from "./dev-role";
 
 // ── Event source seam ────────────────────────────────────────
 
@@ -71,6 +72,10 @@ function createHttpRunAgent(url: string): AgUiRunAgentFn {
     const agent = new HttpAgent({
       url,
       threadId: input.threadId,
+      // Dev-only role switching: empty unless an explicit dev role was chosen
+      // in the switcher, so the AI-assistant channel runs as the same actor as
+      // REST/GraphQL. Ignored by servers with a real auth resolver.
+      headers: getDevRoleHeaders(),
       fetch: (req, init) => globalThis.fetch(req, init),
     });
     if (abortSignal) {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -5,6 +5,7 @@
  * Uses plain fetch — no external GraphQL client library needed.
  */
 
+import { getDevRoleHeaders } from "./dev-role";
 import { getTenantHeaders } from "./tenant";
 
 // ── Auth header helper ──────────────────────────────────
@@ -12,10 +13,13 @@ import { getTenantHeaders } from "./tenant";
 function getAuthHeaders(): Record<string, string> {
   const token = localStorage.getItem("linchkit:token");
   const tenantHeaders = getTenantHeaders();
+  // Dev-only role switching: empty unless an explicit choice was stored,
+  // and ignored by servers with a real auth resolver.
+  const devRoleHeaders = getDevRoleHeaders();
   if (token) {
-    return { Authorization: `Bearer ${token}`, ...tenantHeaders };
+    return { Authorization: `Bearer ${token}`, ...tenantHeaders, ...devRoleHeaders };
   }
-  return { ...tenantHeaders };
+  return { ...tenantHeaders, ...devRoleHeaders };
 }
 
 function handleUnauthorized(res: Response): void {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/batch-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/batch-actions.ts
@@ -16,6 +16,7 @@ import type {
   BatchActionsResult,
   BatchTransactionStrategy,
 } from "@linchkit/core/types";
+import { getDevRoleHeaders } from "./dev-role";
 import { getTenantHeaders } from "./tenant";
 
 /**
@@ -89,14 +90,15 @@ export function aggregateBatchResults(results: BatchActionsResult[]): BatchActio
 
 // ── Fetch ──────────────────────────────────────────────────
 
-/** Auth/tenant headers — mirrors api.ts to keep wire conventions identical. */
+/** Auth/tenant/dev-role headers — mirrors api.ts to keep wire conventions identical. */
 function getAuthHeaders(): Record<string, string> {
   const token = typeof localStorage !== "undefined" ? localStorage.getItem("linchkit:token") : null;
   const tenantHeaders = getTenantHeaders();
+  const devRoleHeaders = getDevRoleHeaders();
   if (token) {
-    return { Authorization: `Bearer ${token}`, ...tenantHeaders };
+    return { Authorization: `Bearer ${token}`, ...tenantHeaders, ...devRoleHeaders };
   }
-  return { ...tenantHeaders };
+  return { ...tenantHeaders, ...devRoleHeaders };
 }
 
 /** Build a synthetic failed item for transport errors so callers see them inline. */

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/dev-role.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/dev-role.ts
@@ -1,0 +1,74 @@
+/**
+ * Dev-mode role switching — stores and retrieves the selected dev role.
+ *
+ * DEVELOPMENT AFFORDANCE, NOT AN AUTH MECHANISM. The selected role is sent as
+ * the `x-dev-role` header on all API requests so the no-auth dev server
+ * (`dev-actor-resolver.ts` in cap-adapter-server) resolves the request to the
+ * matching demo actor (user / manager / admin). Persisted to localStorage so
+ * it survives page reloads — mirrors `tenant.ts`.
+ *
+ * Production servers configure a real auth resolver and never read this
+ * header, so a stale stored value is inert outside dev.
+ */
+
+const STORAGE_KEY = "linchkit:dev-role";
+
+/** Header recognized by the dev server's role-switching actor resolver. */
+export const DEV_ROLE_HEADER = "x-dev-role";
+
+/** Roles understood by the dev server, least to most privileged. */
+export const DEV_ROLES = ["user", "manager", "admin"] as const;
+
+export type DevRole = (typeof DEV_ROLES)[number];
+
+/** Default role — matches the elevated no-auth actor the dev server resolves without the header. */
+export const DEFAULT_DEV_ROLE: DevRole = "admin";
+
+function isDevRole(value: string | null): value is DevRole {
+  return value !== null && (DEV_ROLES as readonly string[]).includes(value);
+}
+
+/**
+ * Get the explicitly stored dev role choice, or null when none was made
+ * (or the stored value is not a recognized role).
+ */
+export function getStoredDevRole(): DevRole | null {
+  if (typeof localStorage === "undefined") return null;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return isDevRole(stored) ? stored : null;
+}
+
+/**
+ * Get the effective dev role: the stored choice, falling back to `admin`
+ * (= today's elevated no-auth behavior when no header is sent).
+ */
+export function getDevRole(): DevRole {
+  return getStoredDevRole() ?? DEFAULT_DEV_ROLE;
+}
+
+/**
+ * Set the dev role. Pass null to clear the explicit choice (the effective
+ * role then falls back to the `admin` default and no header is sent).
+ */
+export function setDevRole(role: DevRole | null): void {
+  if (typeof localStorage === "undefined") return;
+  if (role) {
+    localStorage.setItem(STORAGE_KEY, role);
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+/**
+ * Build dev-role request headers.
+ * Returns an empty object when no explicit choice was made — requests then
+ * carry no `x-dev-role` header and the dev server keeps its elevated default,
+ * so setups that never touch the switcher behave exactly as before.
+ */
+export function getDevRoleHeaders(): Record<string, string> {
+  const role = getStoredDevRole();
+  if (role) {
+    return { [DEV_ROLE_HEADER]: role };
+  }
+  return {};
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/dev-role.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/dev-role.ts
@@ -66,6 +66,13 @@ export function setDevRole(role: DevRole | null): void {
  * so setups that never touch the switcher behave exactly as before.
  */
 export function getDevRoleHeaders(): Record<string, string> {
+  // Production guard: the switcher UI is dev-only, but this helper is called
+  // from the always-bundled API modules — without the gate, a stale
+  // localStorage value from a dev session would silently downgrade (or alter)
+  // the caller's identity on a production deployment. `import.meta.env.PROD`
+  // is statically replaced by Vite, so production builds compile this to an
+  // unconditional empty return.
+  if (import.meta.env.PROD) return {};
   const role = getStoredDevRole();
   if (role) {
     return { [DEV_ROLE_HEADER]: role };

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/evolution-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/evolution-api.ts
@@ -8,6 +8,8 @@
  * catching thrown errors. Mirrors the conventions in `lib/proposal-api.ts`.
  */
 
+import { getDevRoleHeaders } from "./dev-role";
+
 // ── Auth header helper (reuse from api.ts / proposal-api.ts pattern) ──────
 
 function getAuthHeaders(): Record<string, string> {
@@ -17,10 +19,12 @@ function getAuthHeaders(): Record<string, string> {
     return {};
   }
   const token = localStorage.getItem("linchkit:token");
+  // Dev-only role switching header — empty unless explicitly chosen.
+  const devRoleHeaders = getDevRoleHeaders();
   if (token) {
-    return { Authorization: `Bearer ${token}` };
+    return { Authorization: `Bearer ${token}`, ...devRoleHeaders };
   }
-  return {};
+  return { ...devRoleHeaders };
 }
 
 // ── Wire type ──────────────────────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/proposal-api.ts
@@ -5,15 +5,18 @@
 // Type-only import (erased at compile time — no core runtime reaches the UI),
 // mirroring proposal-impact-preview.tsx which renders this same shape.
 import type { ProposalPreAnalysisResult } from "@linchkit/core";
+import { getDevRoleHeaders } from "./dev-role";
 
 // ── Auth header helper (reuse from api.ts pattern) ──────
 
 function getAuthHeaders(): Record<string, string> {
   const token = localStorage.getItem("linchkit:token");
+  // Dev-only role switching header — empty unless explicitly chosen.
+  const devRoleHeaders = getDevRoleHeaders();
   if (token) {
-    return { Authorization: `Bearer ${token}` };
+    return { Authorization: `Bearer ${token}`, ...devRoleHeaders };
   }
-  return {};
+  return { ...devRoleHeaders };
 }
 
 // ── Types ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

Live demos must walk the SAME app as different roles (purchase_user vs purchase_manager vs admin) from every channel — but the no-auth dev server resolves every request to one elevated actor, so role-gated behavior (e.g. "only managers approve large purchases", #567) could never be demonstrated. This is the Phase-2 enabler for the procurement north-star scenario (Spec 72, issue #565).

## How

- **Server** — new `dev-actor-resolver.ts` (wired in `dev.ts` / `dev-app.ts` ONLY; `createServer` untouched, no default): `x-dev-role: user|manager|admin` → deterministic dev actors. Absent/unrecognized header → `NO_AUTH_ACTOR`, byte-identical to today (zero behavior change for existing scripts/flows/tests). A caller-supplied resolver always wins in `dev-app.ts`.
- **UI** — dev-only role switcher in the header (DropdownMenu, TenantSwitcher style); choice persisted in `localStorage` (`linchkit:dev-role`); `getAuthHeaders()` in all four API modules + the AG-UI chat transport attach the header, so REST, GraphQL and the AI-assistant channel all act as the chosen role. Hidden in production builds (`import.meta.env.DEV` statically eliminated) and whenever real auth is enabled.
- **Explicitly a development affordance, not an auth mechanism** (doc-commented in both layers + a hint in the dropdown footer).

## Review

Codex (`origin/main..HEAD`) found 1 P2 — the "elevated" admin actor lacked the capability-specific `purchase_manager`/`purchase_user` groups, so once cap-permission is enabled admin would be LESS capable than manager (grants key on exact group names). Fixed: dev-admin is now cumulative.

## Tests

13 server (role mapping units + in-process `app.handle` probes through the ACTUAL dev default, REST + GraphQL) + 14 UI (localStorage shim pattern). `bun run check` / `typecheck` clean; full `bun run test` PASS (re-run after the codex fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)