### PR TITLE
fix(adapter-ui,adapter-server): surface action-failure reasons — toasts + production exemption for rule-block policy text (Spec 72 P2)

### DIFF
--- a/.changeset/batch-rule-block-sanitize-exemption.md
+++ b/.changeset/batch-rule-block-sanitize-exemption.md
@@ -1,0 +1,8 @@
+---
+"@linchkit/core": patch
+"@linchkit/cap-adapter-server": patch
+---
+
+fix(core,adapter-server): rule_block policy text survives batch production sanitization
+
+`extractErrorFromResult` in the batch action engine now threads the engine-stamped `data.context.constraint` marker (e.g. `"rule_block"`) onto `BatchFailedItem.error.constraint` (additive, optional) — including through the `all_or_nothing` abort path. `sanitizeBatchResult` (shared by REST `POST /api/actions/batch` and GraphQL `Mutation.batch_actions`) uses that server-controlled marker to keep a rule `block` reason — the rule author's user-facing policy text — verbatim in production, mirroring the single-action route's exemption. All other failures are still flattened to the generic message.

--- a/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
@@ -57,6 +57,28 @@ const adminOnly: ActionDefinition = {
   handler: async () => ({ ok: true }),
 };
 
+// Rule-blocked fixture: the rule `block` reason is user-facing policy text
+// and must survive production sanitization per item (constraint: "rule_block").
+const POLICY_MESSAGE = "金额超过 10000 需要经理审批 / Amounts over 10000 require manager approval";
+
+const gatedAction: ActionDefinition = {
+  name: "do_gated",
+  entity: "item",
+  label: "Gated",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async () => ({ ok: true }),
+};
+
+const blockGatedRule = {
+  name: "always_block_gated",
+  label: "Always Block (test)",
+  description: "Blocks do_gated unconditionally to exercise the batch rule_block envelope",
+  trigger: { action: "do_gated" },
+  condition: () => true,
+  effect: { type: "block" as const, message: POLICY_MESSAGE },
+};
+
 // Snapshot-aware in-memory provider so we can verify rollback behavior under
 // `all_or_nothing`. InMemoryStore alone has no rollback semantics, so we
 // pair a custom DataProvider with a fake TransactionManager.
@@ -126,10 +148,12 @@ const txManager = createFakeTxManager(provider);
 const executor = createActionExecutor({
   dataProvider: provider,
   transactionManager: txManager,
+  rules: [blockGatedRule],
 });
 executor.registry.register(createItem);
 executor.registry.register(failItem);
 executor.registry.register(adminOnly);
+executor.registry.register(gatedAction);
 
 const commandLayer = createCommandLayer({ executor });
 commandLayer.use({
@@ -291,6 +315,95 @@ describe("POST /api/actions/batch", () => {
         process.env.NODE_ENV = prevEnv;
       }
     }
+  });
+
+  test("(h2) production mode keeps rule_block policy text, still sanitizes other failures", async () => {
+    // A rule `block` reason is the rule author's user-facing policy text —
+    // it must reach the caller verbatim even in production, while non-policy
+    // failures in the SAME batch are still flattened to the generic message.
+    // Detection rides the engine-stamped `constraint: "rule_block"` marker,
+    // never message content.
+    provider.records.clear();
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { status, body } = await postJSON("/api/actions/batch", {
+        strategy: "partial",
+        actions: [
+          { name: "do_gated", input: {} },
+          { name: "fail_item", input: {} },
+        ],
+      });
+      expect(status).toBe(200);
+      expect(body?.success).toBe(false);
+      const failed = body?.failed as Array<{
+        index: number;
+        error: { code: string; message: string; constraint?: string };
+      }>;
+      expect(failed.length).toBe(2);
+      const blocked = failed.find((f) => f.index === 0);
+      const thrown = failed.find((f) => f.index === 1);
+      expect(blocked?.error.message).toBe(POLICY_MESSAGE);
+      expect(blocked?.error.constraint).toBe("rule_block");
+      expect(thrown?.error.message).toBe("Action execution failed");
+      expect(thrown?.error.message).not.toContain("intentional failure");
+    } finally {
+      if (prevEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = prevEnv;
+      }
+    }
+  });
+
+  test("(h3) production mode keeps rule_block policy text under all_or_nothing abort", async () => {
+    // The all_or_nothing path threads the constraint through BatchAbortError;
+    // the aborting item's policy text must survive sanitization too.
+    provider.records.clear();
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { status, body } = await postJSON("/api/actions/batch", {
+        strategy: "all_or_nothing",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "do_gated", input: {} },
+        ],
+      });
+      expect(status).toBe(200);
+      expect(body?.success).toBe(false);
+      const failed = body?.failed as Array<{
+        index: number;
+        error: { message: string; constraint?: string };
+      }>;
+      expect(failed.length).toBe(1);
+      expect(failed[0]?.index).toBe(1);
+      expect(failed[0]?.error.message).toBe(POLICY_MESSAGE);
+      expect(failed[0]?.error.constraint).toBe("rule_block");
+      expect(provider.records.size).toBe(0);
+    } finally {
+      if (prevEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = prevEnv;
+      }
+    }
+  });
+
+  test("(h4) dev mode passes rule_block message through unchanged", async () => {
+    // Dev-mode parity: the sanitizer is a no-op, so the policy text (and the
+    // raw failure text) arrive untouched.
+    provider.records.clear();
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "partial",
+      actions: [{ name: "do_gated", input: {} }],
+    });
+    expect(status).toBe(200);
+    const failed = body?.failed as Array<{
+      error: { message: string; constraint?: string };
+    }>;
+    expect(failed[0]?.error.message).toBe(POLICY_MESSAGE);
+    expect(failed[0]?.error.constraint).toBe("rule_block");
   });
 
   test("(g) /api/actions/batch is NOT captured by /api/actions/:name", async () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
@@ -61,6 +61,28 @@ const adminOnly: ActionDefinition = {
   handler: async () => ({ ok: true }),
 };
 
+// Rule-blocked fixture: the rule `block` reason is user-facing policy text
+// and must survive production sanitization per item (constraint: "rule_block").
+const POLICY_MESSAGE = "金额超过 10000 需要经理审批 / Amounts over 10000 require manager approval";
+
+const gatedAction: ActionDefinition = {
+  name: "do_gated",
+  entity: "item",
+  label: "Gated",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async () => ({ ok: true }),
+};
+
+const blockGatedRule = {
+  name: "always_block_gated",
+  label: "Always Block (test)",
+  description: "Blocks do_gated unconditionally to exercise the batch rule_block envelope",
+  trigger: { action: "do_gated" },
+  condition: () => true,
+  effect: { type: "block" as const, message: POLICY_MESSAGE },
+};
+
 // Snapshot-aware in-memory provider so we can verify rollback under
 // `all_or_nothing`. Mirrors the REST batch test fixture.
 function createSnapshotProvider() {
@@ -129,10 +151,12 @@ const txManager = createFakeTxManager(provider);
 const executor = createActionExecutor({
   dataProvider: provider,
   transactionManager: txManager,
+  rules: [blockGatedRule],
 });
 executor.registry.register(createItem);
 executor.registry.register(failItem);
 executor.registry.register(adminOnly);
+executor.registry.register(gatedAction);
 
 const commandLayer = createCommandLayer({ executor, transactionManager: txManager });
 commandLayer.use({
@@ -153,7 +177,7 @@ const graphqlSchema = buildGraphQLSchema([itemSchema], {
   executor,
   commandLayer,
   dataProvider: provider,
-  actions: [createItem, failItem, adminOnly],
+  actions: [createItem, failItem, adminOnly, gatedAction],
   transactionManager: txManager,
 });
 
@@ -461,6 +485,45 @@ describe("GraphQL batch_actions mutation", () => {
       expect(batch.failed[0]?.error.message).toBe("Action execution failed");
       expect(typeof batch.failed[0]?.error.code).toBe("string");
       expect((batch.failed[0]?.error.code as string).length).toBeGreaterThan(0);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  test("(i) production mode keeps rule_block policy text, still sanitizes other failures", async () => {
+    // A rule `block` reason is the rule author's user-facing policy text —
+    // it must reach the caller verbatim even in production, while non-policy
+    // failures in the SAME batch are still flattened to the generic message.
+    // Detection rides the engine-stamped `constraint: "rule_block"` marker
+    // (server-controlled), never message content.
+    provider.records.clear();
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const result = await gql(
+        `mutation Run($actions: [BatchActionInputItem!]!) {
+          batch_actions(actions: $actions, strategy: "partial") {
+            ${BATCH_SELECTION}
+          }
+        }`,
+        {
+          actions: [
+            { name: "do_gated", input: JSON.stringify({}) },
+            { name: "fail_item", input: JSON.stringify({}) },
+          ],
+        },
+      );
+      expect(result.errors).toBeUndefined();
+      const batch = result.data?.batch_actions;
+      expect(batch).toBeDefined();
+      if (!batch) return;
+      expect(batch.success).toBe(false);
+      expect(batch.failed.length).toBe(2);
+      const blocked = batch.failed.find((f) => f.index === 0);
+      const thrown = batch.failed.find((f) => f.index === 1);
+      expect(blocked?.error.message).toBe(POLICY_MESSAGE);
+      expect(thrown?.error.message).toBe("Action execution failed");
+      expect(thrown?.error.message).not.toContain("intentional failure");
     } finally {
       process.env.NODE_ENV = originalNodeEnv;
     }

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
@@ -209,7 +209,7 @@ interface BatchSucceededItem {
 interface BatchFailedItem {
   index: number;
   executionId: string | null;
-  error: { code: string; message: string; field: string | null };
+  error: { code: string; message: string; field: string | null; constraint: string | null };
 }
 
 interface BatchActionsResultGQL {
@@ -227,7 +227,7 @@ const BATCH_SELECTION = `
   parentExecutionId
   strategy
   succeeded { index executionId data record warnings }
-  failed { index executionId error { code message field } }
+  failed { index executionId error { code message field constraint } }
   rolledBack { index executionId data record warnings }
   summary { total succeeded failed }
 `;
@@ -524,6 +524,10 @@ describe("GraphQL batch_actions mutation", () => {
       expect(blocked?.error.message).toBe(POLICY_MESSAGE);
       expect(thrown?.error.message).toBe("Action execution failed");
       expect(thrown?.error.message).not.toContain("intentional failure");
+      // The constraint marker must reach GraphQL clients too (REST parity) so
+      // they can branch on rule blocks structurally instead of by message.
+      expect(blocked?.error.constraint).toBe("rule_block");
+      expect(thrown?.error.constraint).toBeNull();
     } finally {
       process.env.NODE_ENV = originalNodeEnv;
     }

--- a/addons/adapter-server/cap-adapter-server/__tests__/rest-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/rest-actions.test.ts
@@ -316,3 +316,90 @@ describe("REST action endpoint — input passthrough", () => {
     expect(data.title).toBe("Provided");
   });
 });
+
+// ── Production sanitization: policy messages are exempt ───
+//
+// In production the failure envelope is sanitized to a generic message —
+// EXCEPT a rule `block` reason (constraint: "rule_block"), which is the rule
+// author's user-facing policy text and must reach the caller verbatim, or
+// every policy block would read "Action execution failed" exactly where the
+// message matters.
+
+const POLICY_MESSAGE = "金额超过 10000 需要经理审批 / Amounts over 10000 require manager approval";
+
+const gatedAction: ActionDefinition = {
+  name: "do_gated",
+  entity: "item",
+  label: "Gated",
+  policy: { mode: "sync", transaction: false },
+  handler: async () => ({ ok: true }),
+};
+
+const alwaysBlockRule = {
+  name: "always_block_gated",
+  label: "Always Block (test)",
+  description: "Blocks do_gated unconditionally to exercise the rule_block envelope",
+  trigger: { action: "do_gated" },
+  condition: () => true,
+  effect: { type: "block" as const, message: POLICY_MESSAGE },
+};
+
+const blockingExecutor = createActionExecutor({
+  dataProvider: store,
+  executionLogger,
+  rules: [alwaysBlockRule],
+});
+blockingExecutor.registry.register(gatedAction);
+blockingExecutor.registry.register(throwAction);
+const blockingApp = createServer(buildGraphQLSchema([itemSchema]), { executor: blockingExecutor });
+
+async function postBlocking(
+  name: string,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await blockingApp.handle(
+    new Request(actionUrl(name), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("production sanitization — rule_block policy text is exempt", () => {
+  test("NODE_ENV=production: a rule-block reason reaches the caller verbatim", async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { body } = await postBlocking("do_gated");
+      expect(body.success).toBe(false);
+      const error = body.error as Record<string, unknown>;
+      expect(error.message).toBe(POLICY_MESSAGE);
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  test("NODE_ENV=production: a non-policy failure is still sanitized", async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { body } = await postBlocking("do_throw");
+      expect(body.success).toBe(false);
+      const error = body.error as Record<string, unknown>;
+      expect(error.message).toBe("Action execution failed");
+      expect(JSON.stringify(body)).not.toContain("Something went wrong");
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
+
+  test("dev mode: both messages pass through unchanged (regression)", async () => {
+    const { body: blocked } = await postBlocking("do_gated");
+    expect((blocked.error as Record<string, unknown>).message).toBe(POLICY_MESSAGE);
+    const { body: thrown } = await postBlocking("do_throw");
+    expect(String((thrown.error as Record<string, unknown>).message)).toContain(
+      "Something went wrong",
+    );
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/rest-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/rest-actions.test.ts
@@ -403,3 +403,44 @@ describe("production sanitization — rule_block policy text is exempt", () => {
     );
   });
 });
+
+// ── Failure envelope hardening: non-string data.error ─────
+//
+// The envelope's `message` must be strictly a string at runtime: a
+// (mis)behaving executor putting a non-string value on `data.error` must fall
+// back to the generic message — a type cast alone only satisfies the compiler
+// and would serialize the raw value to the client. The stub executor below is
+// injected through createServer options (same DI seam as the real one); the
+// route only calls `execute` on it.
+
+const nonStringFailureExecutor = {
+  execute: async () => ({
+    success: false,
+    data: { error: { internal: "raw-failure-object" } },
+    executionId: "exec-nonstring",
+  }),
+} as unknown as ReturnType<typeof createActionExecutor>;
+
+const nonStringApp = createServer(buildGraphQLSchema([itemSchema]), {
+  executor: nonStringFailureExecutor,
+});
+
+describe("failure envelope hardening — non-string data.error never leaks", () => {
+  test("falls back to the generic message and omits the raw value (dev mode included)", async () => {
+    const res = await nonStringApp.handle(
+      new Request(actionUrl("do_anything"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // No structured code and no string message → default business-failure 422
+    // (resolveStatusCode must not crash on the non-string error either).
+    expect(res.status).toBe(422);
+    expect(body.success).toBe(false);
+    expect((body.error as Record<string, unknown>).message).toBe("Action execution failed");
+    expect(JSON.stringify(body)).not.toContain("raw-failure-object");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-batch-mutation.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-batch-mutation.ts
@@ -74,6 +74,11 @@ const BatchFailedItemErrorType = new GraphQLObjectType({
     code: { type: new GraphQLNonNull(GraphQLString) },
     message: { type: new GraphQLNonNull(GraphQLString) },
     field: { type: GraphQLString },
+    constraint: {
+      type: GraphQLString,
+      description:
+        "Engine-stamped constraint marker (e.g. 'rule_block') — same field the REST batch endpoint exposes.",
+    },
   },
 });
 
@@ -138,7 +143,7 @@ function serializeBatchResult(result: BatchActionsResult): {
   failed: Array<{
     index: number;
     executionId: string | null;
-    error: { code: string; message: string; field: string | null };
+    error: { code: string; message: string; field: string | null; constraint: string | null };
   }>;
   rolledBack: Array<{
     index: number;
@@ -168,6 +173,9 @@ function serializeBatchResult(result: BatchActionsResult): {
         code: item.error.code,
         message: item.error.message,
         field: item.error.field ?? null,
+        // Keep the REST and GraphQL surfaces consistent: the constraint marker
+        // (e.g. "rule_block") rides along so clients can branch on it.
+        constraint: item.error.constraint ?? null,
       },
     })),
     rolledBack: result.rolledBack ? result.rolledBack.map(encodeSucceeded) : null,

--- a/addons/adapter-server/cap-adapter-server/src/lib/sanitize-batch-result.ts
+++ b/addons/adapter-server/cap-adapter-server/src/lib/sanitize-batch-result.ts
@@ -32,9 +32,12 @@ export function sanitizeBatchResult(result: BatchActionsResult): BatchActionsRes
     failed: result.failed.map((f) => {
       // Engine-stamped policy marker — keep the rule author's policy text.
       // Re-check the message type at runtime: upstream casts could smuggle a
-      // non-string value past the compiler.
+      // non-string value past the compiler. A zero-length message offers the
+      // client nothing — fall through to the generic fallback instead.
       const isPolicyMessage =
-        f.error.constraint === "rule_block" && typeof f.error.message === "string";
+        f.error.constraint === "rule_block" &&
+        typeof f.error.message === "string" &&
+        f.error.message.length > 0;
       if (isPolicyMessage) return f;
       return {
         ...f,

--- a/addons/adapter-server/cap-adapter-server/src/lib/sanitize-batch-result.ts
+++ b/addons/adapter-server/cap-adapter-server/src/lib/sanitize-batch-result.ts
@@ -8,6 +8,13 @@
  * failures. `rolledBack` items are successes (no error message), so they
  * are passed through untouched.
  *
+ * EXCEPTION: a rule `block` reason is the rule author's user-facing policy
+ * text (e.g. "Amounts over 10000 require manager approval") — written
+ * precisely to be shown to the caller. The batch engine threads the
+ * server-stamped `constraint: "rule_block"` marker onto the failed item, so
+ * detection never depends on message content. This mirrors the single-action
+ * exemption in `routes/action-api.ts`.
+ *
  * Shared by REST (`/api/actions/batch`) and GraphQL (`Mutation.batch_actions`)
  * so both transports apply identical dev-mode parity (full message visible)
  * and prod-mode safety.
@@ -22,9 +29,17 @@ export function sanitizeBatchResult(result: BatchActionsResult): BatchActionsRes
   if (isDevMode) return result;
   return {
     ...result,
-    failed: result.failed.map((f) => ({
-      ...f,
-      error: { ...f.error, message: GENERIC_FAILURE_MESSAGE },
-    })),
+    failed: result.failed.map((f) => {
+      // Engine-stamped policy marker — keep the rule author's policy text.
+      // Re-check the message type at runtime: upstream casts could smuggle a
+      // non-string value past the compiler.
+      const isPolicyMessage =
+        f.error.constraint === "rule_block" && typeof f.error.message === "string";
+      if (isPolicyMessage) return f;
+      return {
+        ...f,
+        error: { ...f.error, message: GENERIC_FAILURE_MESSAGE },
+      };
+    }),
   };
 }

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -233,9 +233,17 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
       const errData = result.data as Record<string, unknown> | undefined;
       const rawMessage = (errData?.error as string) ?? "Action execution failed";
 
-      // In production, sanitize internal error details to prevent information leakage
+      // In production, sanitize internal error details to prevent information
+      // leakage. EXCEPTION: a rule `block` reason is the rule author's
+      // user-facing policy text (e.g. "金额超过 10000 需要经理审批 / Amounts
+      // over 10000 require manager approval") — written precisely to be shown
+      // to the caller. Sanitizing it would flatten every policy block to
+      // "Action execution failed" in production, hiding the rule's message
+      // exactly where it matters.
       const isDevMode = process.env.NODE_ENV !== "production";
-      const safeMessage = isDevMode ? rawMessage : "Action execution failed";
+      const constraint = (errData?.context as Record<string, unknown> | undefined)?.constraint;
+      const isPolicyMessage = constraint === "rule_block" && typeof errData?.error === "string";
+      const safeMessage = isDevMode || isPolicyMessage ? rawMessage : "Action execution failed";
 
       return {
         success: false,

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -246,7 +246,10 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
       // production, hiding the rule's message exactly where it matters.
       const isDevMode = process.env.NODE_ENV !== "production";
       const constraint = (errData?.context as Record<string, unknown> | undefined)?.constraint;
-      const isPolicyMessage = constraint === "rule_block" && typeof errData?.error === "string";
+      // rawMessage's assignment above already guarantees a string (the
+      // non-string fallback is non-empty); the length guard keeps an
+      // empty-string policy message from reaching the client verbatim.
+      const isPolicyMessage = constraint === "rule_block" && rawMessage.length > 0;
       const safeMessage = isDevMode || isPolicyMessage ? rawMessage : "Action execution failed";
 
       return {

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -239,11 +239,10 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
 
       // In production, sanitize internal error details to prevent information
       // leakage. EXCEPTION: a rule `block` reason is the rule author's
-      // user-facing policy text (e.g. "金额超过 10000 需要经理审批 / Amounts
-      // over 10000 require manager approval") — written precisely to be shown
-      // to the caller. Sanitizing it would flatten every policy block to
-      // "Action execution failed" in production, hiding the rule's message
-      // exactly where it matters.
+      // user-facing policy text (e.g. "Amounts over 10000 require manager
+      // approval") — written precisely to be shown to the caller. Sanitizing
+      // it would flatten every policy block to "Action execution failed" in
+      // production, hiding the rule's message exactly where it matters.
       const isDevMode = process.env.NODE_ENV !== "production";
       const constraint = (errData?.context as Record<string, unknown> | undefined)?.constraint;
       const isPolicyMessage = constraint === "rule_block" && typeof errData?.error === "string";

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -231,7 +231,11 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
 
       set.status = resolveStatusCode(result);
       const errData = result.data as Record<string, unknown> | undefined;
-      const rawMessage = (errData?.error as string) ?? "Action execution failed";
+      // Strictly require a string: a cast alone only satisfies the compiler —
+      // a non-string `data.error` value must fall back to the generic message
+      // instead of being serialized to the client.
+      const rawMessage =
+        typeof errData?.error === "string" ? errData.error : "Action execution failed";
 
       // In production, sanitize internal error details to prevent information
       // leakage. EXCEPTION: a rule `block` reason is the rule author's

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -141,7 +141,8 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
       // `success` and the per-item arrays. (Consider HTTP 207 Multi-Status
       // for `partial` mode with mixed outcomes in a follow-up.) In production
       // we strip per-item error messages to prevent internal-detail leakage,
-      // matching the single-action route below.
+      // matching the single-action route below — including its rule_block
+      // exemption (policy text survives; see sanitizeBatchResult).
       return sanitizeBatchResult(result);
     })
     // REST action endpoint — executes via ActionExecutor

--- a/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
@@ -119,8 +119,9 @@ export function resolveStatusCode(result: { success: boolean; data?: unknown }):
     if (codeStatus !== undefined) return codeStatus;
   }
 
-  // Fallback: match on error message text
-  const errorMsg = (errData?.error as string) ?? "";
+  // Fallback: match on error message text. Strictly require a string — a
+  // truthy non-string `data.error` would otherwise crash `.includes` below.
+  const errorMsg = typeof errData?.error === "string" ? errData.error : "";
 
   // Not found patterns
   if (errorMsg.includes("not found")) return 404;

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
@@ -207,7 +207,12 @@ describe("executeHeaderAction — failure message surfacing", () => {
     expect(outcome).toEqual({ kind: "failed", message: "金额超过 10000 需要经理审批" });
   });
 
-  test("surfaces a raw data.error string (core ActionResult rule-block shape)", async () => {
+  // Core-seam shape, NOT the REST envelope: REST failures carry no `data`
+  // key, so this arm is unreachable via today's REST transport. It covers
+  // direct core-seam consumers / non-REST transports, gated on the same
+  // `constraint === "rule_block"` exemption the server applies before
+  // un-sanitizing a message.
+  test("surfaces a rule-block data.error string (core ActionResult seam, unreachable via REST)", async () => {
     const { api } = makeApi({
       actionSuccess: false,
       actionData: {
@@ -228,8 +233,41 @@ describe("executeHeaderAction — failure message surfacing", () => {
     });
   });
 
+  test("does NOT surface a data.error string without the rule_block constraint (mirrors server sanitization)", async () => {
+    const { api } = makeApi({
+      actionSuccess: false,
+      actionData: { error: "internal failure detail" },
+    });
+
+    const outcome = await executeHeaderAction({
+      ...BASE,
+      actionName: "approve_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "failed" });
+    expect("message" in outcome).toBe(false);
+  });
+
   test("omits the message when the failure carries none (caller falls back to generic i18n)", async () => {
     const { api } = makeApi({ actionSuccess: false, actionData: { error: 42 } });
+
+    const outcome = await executeHeaderAction({
+      ...BASE,
+      actionName: "approve_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "failed" });
+    expect("message" in outcome).toBe(false);
+  });
+
+  test("null action result (misimplemented api) reports a generic failed outcome instead of throwing", async () => {
+    const api: HeaderActionApi = {
+      executeAction: async () =>
+        null as unknown as Awaited<ReturnType<HeaderActionApi["executeAction"]>>,
+      queryRecord: async () => null,
+    };
 
     const outcome = await executeHeaderAction({
       ...BASE,
@@ -254,7 +292,7 @@ describe("resolveActionErrorMessage", () => {
     expect(message).toBe("rule says no");
   });
 
-  test("falls back to a string data.error", () => {
+  test("falls back to a rule-block data.error (core seam shape, gated on the constraint)", () => {
     const message = resolveActionErrorMessage({
       success: false,
       data: { error: "blocked by rule", context: { constraint: "rule_block" } },
@@ -262,17 +300,56 @@ describe("resolveActionErrorMessage", () => {
     expect(message).toBe("blocked by rule");
   });
 
+  test("ignores a data.error WITHOUT the rule_block constraint (server-sanitization parity)", () => {
+    expect(
+      resolveActionErrorMessage({ success: false, data: { error: "internal detail" } }),
+    ).toBeUndefined();
+    expect(
+      resolveActionErrorMessage({
+        success: false,
+        data: { error: "internal detail", context: { constraint: "tenant_scope" } },
+      }),
+    ).toBeUndefined();
+    // A non-object context never satisfies the gate.
+    expect(
+      resolveActionErrorMessage({ success: false, data: { error: "x", context: "rule_block" } }),
+    ).toBeUndefined();
+  });
+
   test("ignores empty strings and non-string data.error", () => {
     expect(
       resolveActionErrorMessage({ success: false, error: { message: "" }, data: { error: "" } }),
     ).toBeUndefined();
     expect(
-      resolveActionErrorMessage({ success: false, data: { error: { nested: true } } }),
+      resolveActionErrorMessage({
+        success: false,
+        data: { error: "", context: { constraint: "rule_block" } },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveActionErrorMessage({
+        success: false,
+        data: { error: { nested: true }, context: { constraint: "rule_block" } },
+      }),
+    ).toBeUndefined();
+  });
+
+  test("ignores a non-string error.message (runtime shape mismatch)", () => {
+    expect(
+      resolveActionErrorMessage({
+        success: false,
+        error: { message: 42 as unknown as string },
+      }),
     ).toBeUndefined();
   });
 
   test("returns undefined when no message exists anywhere", () => {
     expect(resolveActionErrorMessage({ success: false })).toBeUndefined();
     expect(resolveActionErrorMessage({ success: false, data: null })).toBeUndefined();
+  });
+
+  test("returns undefined for a nullish result instead of throwing", () => {
+    expect(resolveActionErrorMessage(null)).toBeUndefined();
+    expect(resolveActionErrorMessage(undefined)).toBeUndefined();
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
@@ -41,6 +41,7 @@ if (typeof globalThis.localStorage === "undefined") {
   });
 }
 
+import { resolveActionErrorMessage } from "../src/lib/api";
 import {
   executeHeaderAction,
   type HeaderActionApi,
@@ -58,12 +59,20 @@ function makeApi(opts: {
   actionSuccess?: boolean;
   record?: Record<string, unknown> | null;
   queryThrows?: boolean;
+  /** Failure envelope from the REST endpoint (`error.message`). */
+  actionError?: { message?: string };
+  /** Core ActionResult shape — rule blocks may carry a raw `data.error` string. */
+  actionData?: unknown;
 }): { api: HeaderActionApi; calls: ApiCalls } {
   const calls: ApiCalls = { executeAction: [], queryRecord: [] };
   const api: HeaderActionApi = {
     executeAction: async (actionName, input) => {
       calls.executeAction.push({ actionName, input });
-      return { success: opts.actionSuccess ?? true };
+      return {
+        success: opts.actionSuccess ?? true,
+        ...(opts.actionError ? { error: opts.actionError } : {}),
+        ...(opts.actionData !== undefined ? { data: opts.actionData } : {}),
+      };
     },
     queryRecord: async (schema, id, fields) => {
       calls.queryRecord.push({ schema, id, fields });
@@ -175,5 +184,95 @@ describe("executeHeaderAction — plain (non-transition) actions", () => {
     const outcome = await executeHeaderAction({ ...BASE, actionName: "send_reminder", api });
 
     expect(outcome).toEqual({ kind: "failed" });
+  });
+});
+
+describe("executeHeaderAction — failure message surfacing", () => {
+  // Regression: a rule block (e.g. "Amounts over 10000 require manager
+  // approval") used to be dropped — the user only saw a generic "Action
+  // failed" toast. The outcome must carry the server's message so the hook
+  // can show it.
+  test("surfaces error.message from the REST failure envelope", async () => {
+    const { api } = makeApi({
+      actionSuccess: false,
+      actionError: { message: "金额超过 10000 需要经理审批" },
+    });
+
+    const outcome = await executeHeaderAction({
+      ...BASE,
+      actionName: "approve_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "failed", message: "金额超过 10000 需要经理审批" });
+  });
+
+  test("surfaces a raw data.error string (core ActionResult rule-block shape)", async () => {
+    const { api } = makeApi({
+      actionSuccess: false,
+      actionData: {
+        error: "Amounts over 10000 require manager approval",
+        context: { constraint: "rule_block" },
+      },
+    });
+
+    const outcome = await executeHeaderAction({
+      ...BASE,
+      actionName: "approve_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({
+      kind: "failed",
+      message: "Amounts over 10000 require manager approval",
+    });
+  });
+
+  test("omits the message when the failure carries none (caller falls back to generic i18n)", async () => {
+    const { api } = makeApi({ actionSuccess: false, actionData: { error: 42 } });
+
+    const outcome = await executeHeaderAction({
+      ...BASE,
+      actionName: "approve_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "failed" });
+    expect("message" in outcome).toBe(false);
+  });
+});
+
+// ── resolveActionErrorMessage (pure helper, chokepoint for both shapes) ─────
+
+describe("resolveActionErrorMessage", () => {
+  test("prefers error.message when present", () => {
+    const message = resolveActionErrorMessage({
+      success: false,
+      error: { message: "rule says no" },
+      data: { error: "shadowed" },
+    });
+    expect(message).toBe("rule says no");
+  });
+
+  test("falls back to a string data.error", () => {
+    const message = resolveActionErrorMessage({
+      success: false,
+      data: { error: "blocked by rule", context: { constraint: "rule_block" } },
+    });
+    expect(message).toBe("blocked by rule");
+  });
+
+  test("ignores empty strings and non-string data.error", () => {
+    expect(
+      resolveActionErrorMessage({ success: false, error: { message: "" }, data: { error: "" } }),
+    ).toBeUndefined();
+    expect(
+      resolveActionErrorMessage({ success: false, data: { error: { nested: true } } }),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when no message exists anywhere", () => {
+    expect(resolveActionErrorMessage({ success: false })).toBeUndefined();
+    expect(resolveActionErrorMessage({ success: false, data: null })).toBeUndefined();
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/entity-form-actions.test.ts
@@ -41,7 +41,7 @@ if (typeof globalThis.localStorage === "undefined") {
   });
 }
 
-import { resolveActionErrorMessage } from "../src/lib/api";
+import { resolveActionErrorMessage } from "../src/lib/action-errors";
 import {
   executeHeaderAction,
   type HeaderActionApi,

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/transition-dispatch.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/transition-dispatch.test.ts
@@ -121,6 +121,23 @@ describe("executeTransition — transition with a bound Action", () => {
     expect(calls.transitionRecord).toHaveLength(0);
   });
 
+  test("null action result (misimplemented api) reports failed with the generic fallback instead of throwing", async () => {
+    const api: TransitionDispatchApi = {
+      executeAction: async () =>
+        null as unknown as Awaited<ReturnType<TransitionDispatchApi["executeAction"]>>,
+      transitionRecord: async () => ({}),
+      queryRecord: async () => null,
+    };
+
+    const outcome = await executeTransition({
+      ...BASE,
+      boundAction: "submit_purchase_request",
+      api,
+    });
+
+    expect(outcome).toEqual({ kind: "failed", message: undefined });
+  });
+
   test("re-query failure still reports success with updated: null (caller falls back to full refetch)", async () => {
     const { api } = makeApi({ queryThrows: true });
 

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/action-errors.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/action-errors.ts
@@ -1,0 +1,47 @@
+/**
+ * Action error surfacing helpers.
+ *
+ * Resolves the human-readable failure message from a failed action result so
+ * UI callers (form action handlers, transition dispatch) can show the rule
+ * author's user-facing policy text instead of a generic failure string.
+ * Extracted from lib/api.ts to keep action-error logic in one focused module.
+ */
+
+/**
+ * Resolve the human-readable failure message from a failed action result.
+ *
+ * First arm: the REST action endpoint lifts the failure reason (e.g. a
+ * rule-block message) into `error.message` (see adapter-server
+ * routes/action-api.ts) — this is the only shape today's REST transport
+ * produces, since REST failure envelopes carry no `data` key.
+ *
+ * Second arm: the raw core ActionResult shape — a `data.error` string with
+ * `data.context.constraint === "rule_block"`. It exists for direct core-seam
+ * consumers / non-REST transports (defense in depth; unreachable via today's
+ * REST transport) and mirrors the server's sanitization policy: ONLY a
+ * rule-block reason (the rule author's user-facing policy text) is surfaced
+ * verbatim; any other raw `data.error` is ignored so internal details never
+ * leak past what the REST envelope would have exposed.
+ *
+ * Accepts a nullish result defensively. Returns undefined when no
+ * surfaceable message exists so callers fall back to their generic i18n text.
+ */
+export function resolveActionErrorMessage(
+  result: { success: boolean; error?: { message?: string }; data?: unknown } | null | undefined,
+): string | undefined {
+  if (!result) return undefined;
+  const fromError = result.error?.message;
+  if (typeof fromError === "string" && fromError.length > 0) return fromError;
+  const data = result.data;
+  if (data && typeof data === "object" && "error" in data) {
+    const { error: fromData, context } = data as { error?: unknown; context?: unknown };
+    const constraint =
+      context && typeof context === "object"
+        ? (context as { constraint?: unknown }).constraint
+        : undefined;
+    if (constraint === "rule_block" && typeof fromData === "string" && fromData.length > 0) {
+      return fromData;
+    }
+  }
+  return undefined;
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -553,25 +553,38 @@ export interface ActionResult {
 /**
  * Resolve the human-readable failure message from a failed action result.
  *
- * The REST action endpoint lifts the failure reason (e.g. a rule-block
- * message) into `error.message` (see adapter-server routes/action-api.ts),
- * but depending on the seam a rule-block can also arrive as a raw string on
- * `data.error` (core ActionResult shape, with
- * `data.context.constraint === "rule_block"`). Handle both defensively and
- * return undefined when no message exists so callers fall back to their
- * generic i18n text.
+ * First arm: the REST action endpoint lifts the failure reason (e.g. a
+ * rule-block message) into `error.message` (see adapter-server
+ * routes/action-api.ts) — this is the only shape today's REST transport
+ * produces, since REST failure envelopes carry no `data` key.
+ *
+ * Second arm: the raw core ActionResult shape — a `data.error` string with
+ * `data.context.constraint === "rule_block"`. It exists for direct core-seam
+ * consumers / non-REST transports (defense in depth; unreachable via today's
+ * REST transport) and mirrors the server's sanitization policy: ONLY a
+ * rule-block reason (the rule author's user-facing policy text) is surfaced
+ * verbatim; any other raw `data.error` is ignored so internal details never
+ * leak past what the REST envelope would have exposed.
+ *
+ * Accepts a nullish result defensively. Returns undefined when no
+ * surfaceable message exists so callers fall back to their generic i18n text.
  */
-export function resolveActionErrorMessage(result: {
-  success: boolean;
-  error?: { message?: string };
-  data?: unknown;
-}): string | undefined {
+export function resolveActionErrorMessage(
+  result: { success: boolean; error?: { message?: string }; data?: unknown } | null | undefined,
+): string | undefined {
+  if (!result) return undefined;
   const fromError = result.error?.message;
   if (typeof fromError === "string" && fromError.length > 0) return fromError;
   const data = result.data;
   if (data && typeof data === "object" && "error" in data) {
-    const fromData = (data as { error?: unknown }).error;
-    if (typeof fromData === "string" && fromData.length > 0) return fromData;
+    const { error: fromData, context } = data as { error?: unknown; context?: unknown };
+    const constraint =
+      context && typeof context === "object"
+        ? (context as { constraint?: unknown }).constraint
+        : undefined;
+    if (constraint === "rule_block" && typeof fromData === "string" && fromData.length > 0) {
+      return fromData;
+    }
   }
   return undefined;
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -551,45 +551,6 @@ export interface ActionResult {
 }
 
 /**
- * Resolve the human-readable failure message from a failed action result.
- *
- * First arm: the REST action endpoint lifts the failure reason (e.g. a
- * rule-block message) into `error.message` (see adapter-server
- * routes/action-api.ts) — this is the only shape today's REST transport
- * produces, since REST failure envelopes carry no `data` key.
- *
- * Second arm: the raw core ActionResult shape — a `data.error` string with
- * `data.context.constraint === "rule_block"`. It exists for direct core-seam
- * consumers / non-REST transports (defense in depth; unreachable via today's
- * REST transport) and mirrors the server's sanitization policy: ONLY a
- * rule-block reason (the rule author's user-facing policy text) is surfaced
- * verbatim; any other raw `data.error` is ignored so internal details never
- * leak past what the REST envelope would have exposed.
- *
- * Accepts a nullish result defensively. Returns undefined when no
- * surfaceable message exists so callers fall back to their generic i18n text.
- */
-export function resolveActionErrorMessage(
-  result: { success: boolean; error?: { message?: string }; data?: unknown } | null | undefined,
-): string | undefined {
-  if (!result) return undefined;
-  const fromError = result.error?.message;
-  if (typeof fromError === "string" && fromError.length > 0) return fromError;
-  const data = result.data;
-  if (data && typeof data === "object" && "error" in data) {
-    const { error: fromData, context } = data as { error?: unknown; context?: unknown };
-    const constraint =
-      context && typeof context === "object"
-        ? (context as { constraint?: unknown }).constraint
-        : undefined;
-    if (constraint === "rule_block" && typeof fromData === "string" && fromData.length > 0) {
-      return fromData;
-    }
-  }
-  return undefined;
-}
-
-/**
  * Execute a named action via REST API.
  */
 export async function executeAction(

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -551,6 +551,32 @@ export interface ActionResult {
 }
 
 /**
+ * Resolve the human-readable failure message from a failed action result.
+ *
+ * The REST action endpoint lifts the failure reason (e.g. a rule-block
+ * message) into `error.message` (see adapter-server routes/action-api.ts),
+ * but depending on the seam a rule-block can also arrive as a raw string on
+ * `data.error` (core ActionResult shape, with
+ * `data.context.constraint === "rule_block"`). Handle both defensively and
+ * return undefined when no message exists so callers fall back to their
+ * generic i18n text.
+ */
+export function resolveActionErrorMessage(result: {
+  success: boolean;
+  error?: { message?: string };
+  data?: unknown;
+}): string | undefined {
+  const fromError = result.error?.message;
+  if (typeof fromError === "string" && fromError.length > 0) return fromError;
+  const data = result.data;
+  if (data && typeof data === "object" && "error" in data) {
+    const fromData = (data as { error?: unknown }).error;
+    if (typeof fromData === "string" && fromData.length > 0) return fromData;
+  }
+  return undefined;
+}
+
+/**
  * Execute a named action via REST API.
  */
 export async function executeAction(

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
@@ -93,9 +93,12 @@ export async function executeTransition(opts: {
   }
 
   const result = await api.executeAction(boundAction, { id: recordId });
-  if (!result.success) {
+  // The optional chain is a defensive null guard: a (mis)implemented api
+  // could resolve to null/undefined despite the type — treat it as a plain
+  // failure (generic fallback message) instead of throwing here.
+  if (!result?.success) {
     // Same defensive extraction as executeHeaderAction: the failure reason
-    // may live on `error.message` or as a raw `data.error` string.
+    // may live on `error.message` or as a raw rule-block `data.error` string.
     return { kind: "failed", message: resolveActionErrorMessage(result) };
   }
 

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Transition } from "@linchkit/core/types";
-import { resolveActionErrorMessage } from "./api";
+import { resolveActionErrorMessage } from "./action-errors";
 
 /** Minimal API surface consumed by executeTransition — injectable in tests. */
 export interface TransitionDispatchApi {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/transition-dispatch.ts
@@ -18,13 +18,14 @@
  */
 
 import type { Transition } from "@linchkit/core/types";
+import { resolveActionErrorMessage } from "./api";
 
 /** Minimal API surface consumed by executeTransition — injectable in tests. */
 export interface TransitionDispatchApi {
   executeAction: (
     actionName: string,
     input: Record<string, unknown>,
-  ) => Promise<{ success: boolean; error?: { message?: string } }>;
+  ) => Promise<{ success: boolean; error?: { message?: string }; data?: unknown }>;
   transitionRecord: (
     schema: string,
     id: string,
@@ -93,7 +94,9 @@ export async function executeTransition(opts: {
 
   const result = await api.executeAction(boundAction, { id: recordId });
   if (!result.success) {
-    return { kind: "failed", message: result.error?.message };
+    // Same defensive extraction as executeHeaderAction: the failure reason
+    // may live on `error.message` or as a raw `data.error` string.
+    return { kind: "failed", message: resolveActionErrorMessage(result) };
   }
 
   // Bound action succeeded — re-query the record so the caller can refresh

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -20,6 +20,7 @@ import {
   executeAction,
   queryRecord,
   queryStateTransitions,
+  resolveActionErrorMessage,
   updateRecord,
 } from "../lib/api";
 import { CLONE_STRIP_FIELDS, getMutationReturnFields } from "../lib/entity-form-utils";
@@ -37,7 +38,7 @@ export interface HeaderActionApi {
   executeAction: (
     actionName: string,
     input: Record<string, unknown>,
-  ) => Promise<{ success: boolean }>;
+  ) => Promise<{ success: boolean; error?: { message?: string }; data?: unknown }>;
   queryRecord: (
     schema: string,
     id: string,
@@ -49,7 +50,7 @@ export interface HeaderActionApi {
 export type HeaderActionOutcome =
   | { kind: "transition_success"; updated: Record<string, unknown> | null }
   | { kind: "action_success" }
-  | { kind: "failed" };
+  | { kind: "failed"; message?: string };
 
 /**
  * Execute a header action click.
@@ -82,7 +83,12 @@ export async function executeHeaderAction(opts: {
   const transition = availableTransitions.find((tr) => tr.action === actionName);
 
   const result = await api.executeAction(actionName, { id: recordId });
-  if (!result.success) return { kind: "failed" };
+  if (!result.success) {
+    // Surface the server's failure reason (e.g. a rule-block message) so the
+    // caller can show it instead of a generic "Action failed" toast.
+    const message = resolveActionErrorMessage(result);
+    return message ? { kind: "failed", message } : { kind: "failed" };
+  }
 
   if (!transition) return { kind: "action_success" };
 
@@ -358,7 +364,9 @@ export function useFormActions(opts: UseFormActionsOptions) {
           });
           await fetchRecord();
         } else {
-          toast.error(t("toast.actionFailed", "Action failed"));
+          // Prefer the server's failure reason (e.g. "Amounts over 10000
+          // require manager approval" from a rule block) over the generic text.
+          toast.error(outcome.message ?? t("toast.actionFailed", "Action failed"));
           pushNotification({
             type: "action_failure",
             message: t("notifications.actionFailed", { action: actionName }),

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -83,7 +83,10 @@ export async function executeHeaderAction(opts: {
   const transition = availableTransitions.find((tr) => tr.action === actionName);
 
   const result = await api.executeAction(actionName, { id: recordId });
-  if (!result.success) {
+  // The optional chain is a defensive null guard: a (mis)implemented api
+  // could resolve to null/undefined despite the type — treat it as a plain
+  // failure so the caller falls back to its generic message, not a throw.
+  if (!result?.success) {
     // Surface the server's failure reason (e.g. a rule-block message) so the
     // caller can show it instead of a generic "Action failed" toast.
     const message = resolveActionErrorMessage(result);

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -14,13 +14,13 @@ import type { EnrichedSubmitData } from "../components/auto-form/types";
 import type { StateTransitionInfo } from "../components/status-bar";
 import type { ResolvedEntityBundle } from "../hooks/use-entity-bundle";
 import { pushNotification } from "../hooks/use-notifications";
+import { resolveActionErrorMessage } from "../lib/action-errors";
 import {
   createRecord,
   deleteRecord,
   executeAction,
   queryRecord,
   queryStateTransitions,
-  resolveActionErrorMessage,
   updateRecord,
 } from "../lib/api";
 import { CLONE_STRIP_FIELDS, getMutationReturnFields } from "../lib/entity-form-utils";

--- a/packages/core/src/engine/batch-action-engine.ts
+++ b/packages/core/src/engine/batch-action-engine.ts
@@ -255,7 +255,7 @@ function extractErrorFromResult(result: { data?: unknown }): {
   constraint?: string;
 } {
   const data = result.data as Record<string, unknown> | undefined;
-  const message = (data?.error as string) ?? "Action execution failed";
+  const message = typeof data?.error === "string" ? data.error : "Action execution failed";
   const code = (data?.code as string) ?? "ACTION.EXECUTION.FAILED";
   const ctx = data?.context as Record<string, unknown> | undefined;
   const field = ctx?.field as string | undefined;

--- a/packages/core/src/engine/batch-action-engine.ts
+++ b/packages/core/src/engine/batch-action-engine.ts
@@ -184,6 +184,8 @@ class BatchAbortError extends Error {
     public readonly failedErrorCode: string,
     public readonly failedErrorMessage: string,
     public readonly accumulatedSucceeded: BatchSucceededItem[],
+    /** Engine-stamped policy marker (e.g. "rule_block"), when present. */
+    public readonly failedErrorConstraint?: string,
   ) {
     super(`Batch aborted at index ${failedIndex}: ${failedErrorMessage}`);
     this.name = "BatchAbortError";
@@ -250,13 +252,23 @@ function extractErrorFromResult(result: { data?: unknown }): {
   code: string;
   message: string;
   field?: string;
+  constraint?: string;
 } {
   const data = result.data as Record<string, unknown> | undefined;
   const message = (data?.error as string) ?? "Action execution failed";
   const code = (data?.code as string) ?? "ACTION.EXECUTION.FAILED";
   const ctx = data?.context as Record<string, unknown> | undefined;
   const field = ctx?.field as string | undefined;
-  return field ? { code, message, field } : { code, message };
+  // Engine-stamped policy marker (e.g. "rule_block"). Threaded onto the
+  // failed item so transports can exempt policy text from production
+  // sanitization without inspecting message content.
+  const constraint = typeof ctx?.constraint === "string" ? ctx.constraint : undefined;
+  return {
+    code,
+    message,
+    ...(field !== undefined ? { field } : {}),
+    ...(constraint !== undefined ? { constraint } : {}),
+  };
 }
 
 /**
@@ -408,7 +420,14 @@ async function runAllOrNothing(
         });
         if (!result.success) {
           const err = extractErrorFromResult(result);
-          throw new BatchAbortError(i, result.executionId, err.code, err.message, succeededInside);
+          throw new BatchAbortError(
+            i,
+            result.executionId,
+            err.code,
+            err.message,
+            succeededInside,
+            err.constraint,
+          );
         }
         succeededInside.push(toSucceededItem(i, result.executionId, result));
       }
@@ -428,7 +447,13 @@ async function runAllOrNothing(
           {
             index: err.failedIndex,
             executionId: err.failedExecutionId,
-            error: { code: err.failedErrorCode, message: err.failedErrorMessage },
+            error: {
+              code: err.failedErrorCode,
+              message: err.failedErrorMessage,
+              ...(err.failedErrorConstraint !== undefined
+                ? { constraint: err.failedErrorConstraint }
+                : {}),
+            },
           },
         ],
         rolledBack: err.accumulatedSucceeded,

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -898,6 +898,8 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
         public readonly executionId: string | undefined,
         public readonly errCode: string,
         public readonly errMessage: string,
+        /** Engine-stamped policy marker (e.g. "rule_block"), when present. */
+        public readonly errConstraint?: string,
       ) {
         super(errMessage);
       }
@@ -916,7 +918,7 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
           );
           if (!result.success) {
             const err = extractErrorFromActionResult(result);
-            throw new BatchAbort(i, result.executionId, err.code, err.message);
+            throw new BatchAbort(i, result.executionId, err.code, err.message, err.constraint);
           }
           succeededInside.push(toSucceededItem(i, result));
         }
@@ -935,7 +937,11 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
             {
               index: err.index,
               executionId: err.executionId,
-              error: { code: err.errCode, message: err.errMessage },
+              error: {
+                code: err.errCode,
+                message: err.errMessage,
+                ...(err.errConstraint !== undefined ? { constraint: err.errConstraint } : {}),
+              },
             },
           ],
           rolledBack: succeededInside,
@@ -984,13 +990,23 @@ function extractErrorFromActionResult(result: ActionResult): {
   code: string;
   message: string;
   field?: string;
+  constraint?: string;
 } {
   const data = result.data as Record<string, unknown> | undefined;
   const message = (data?.error as string) ?? "Action execution failed";
   const code = (data?.code as string) ?? "ACTION.EXECUTION.FAILED";
   const ctx = data?.context as Record<string, unknown> | undefined;
   const field = ctx?.field as string | undefined;
-  return field ? { code, message, field } : { code, message };
+  // Engine-stamped policy marker (e.g. "rule_block"). Threaded onto the
+  // failed item so transports can exempt policy text from production
+  // sanitization without inspecting message content.
+  const constraint = typeof ctx?.constraint === "string" ? ctx.constraint : undefined;
+  return {
+    code,
+    message,
+    ...(field !== undefined ? { field } : {}),
+    ...(constraint !== undefined ? { constraint } : {}),
+  };
 }
 
 /** Build a {@link BatchSucceededItem} from a successful {@link ActionResult}. */

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -993,7 +993,7 @@ function extractErrorFromActionResult(result: ActionResult): {
   constraint?: string;
 } {
   const data = result.data as Record<string, unknown> | undefined;
-  const message = (data?.error as string) ?? "Action execution failed";
+  const message = typeof data?.error === "string" ? data.error : "Action execution failed";
   const code = (data?.code as string) ?? "ACTION.EXECUTION.FAILED";
   const ctx = data?.context as Record<string, unknown> | undefined;
   const field = ctx?.field as string | undefined;

--- a/packages/core/src/types/batch.ts
+++ b/packages/core/src/types/batch.ts
@@ -55,8 +55,16 @@ export interface BatchFailedItem {
   index: number;
   /** Child execution ID, if the executor produced one before failing. */
   executionId?: string;
-  /** Structured error. */
-  error: { code: string; message: string; field?: string };
+  /**
+   * Structured error.
+   *
+   * `constraint` is the engine-stamped policy marker copied from the child
+   * result's `data.context.constraint` (e.g. `"rule_block"` for a rule
+   * `block` effect). It is server-controlled — transports use it to decide
+   * whether `message` is user-facing policy text that survives production
+   * sanitization.
+   */
+  error: { code: string; message: string; field?: string; constraint?: string };
 }
 
 /** Top-level batch result returned by `executeBatch` / `CommandLayer.executeBatch`. */


### PR DESCRIPTION
## What

When a business rule BLOCKS an action (e.g. `approve_purchase_request` over the manager threshold, #567), the UI showed only a generic "Action failed" toast and dropped the server's reason — while the AI assistant's `ActionProposalCard` already displayed it. Worse: in production the server sanitized the reason away entirely, so the rule author's message could never reach any client. Both fixed. Phase-2 enabler for the procurement north-star scenario (Spec 72, issue #565).

## How

- **UI chokepoint** — exported `resolveActionErrorMessage(result)` in `lib/api.ts` handles both failure envelopes (REST-lifted `error.message` and the core seam's raw `data.error` string, verified against `action-engine.ts` and `action-api.ts`). Wired into BOTH dispatchers: the form-header path (`entity-form-actions`) and the transition dispatcher (pills + kanban drags). Generic i18n text stays the fallback; success paths untouched.
- **Server: production sanitization exemption** — `action-api.ts` sanitizes every failure to "Action execution failed" in production, which made this whole feature dev-only (cross-model review caught it). A rule `block` reason (`data.context.constraint === "rule_block"`, string reason) is the rule author's user-facing policy text — written to be shown — and is now exempt. Everything else stays sanitized.

## Tests

- `entity-form-actions`: 6 → 13 (both envelope shapes, fallback, helper units).
- `rest-actions`: +3 — production keeps the rule-block text verbatim; a thrown error is still sanitized (and never leaks its message); dev passthrough regression.
- `transition-dispatch`: 10 unchanged green. Full `bun run test` PASS.

## Review

Cross-model pass (claude CLI; codex hung ×2, gemini auth endpoint unreachable today): verified the helper's shape handling line-by-line against the engine/route envelopes, then flagged 2 issues — stale base vs merged main (fixed: `git merge origin/main`, clean) and the production-sanitization gap (fixed in-PR, above). PR bots provide the additional independent pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved error messages** – Action failures now display more specific, user-friendly messages instead of generic text when available.
* **Better rule violation feedback** – Production environment now properly surfaces rule-authored error messages for blocked actions.
* **Enhanced error handling** – System safely processes unexpected error data formats without degrading functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->