### PR TITLE
feat(adapter-ui): AI trace detail drill-down — per-call content panel (Spec 69 P3 / #350)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
@@ -28,10 +28,10 @@ import { useTranslation } from "react-i18next";
 import {
   type AIGeneration,
   type AITrace,
-  type AITraceGenerationsResult,
   type AITraceStatus,
   fetchTraceGenerations,
 } from "../lib/ai-traces-client";
+import { resolveStoredResult, type StoredGenerationsResult } from "../lib/trace-detail-state";
 
 // ── Constants ────────────────────────────────────────────
 
@@ -199,8 +199,11 @@ export function TraceDetailPanel({
   onOpenChange: (open: boolean) => void;
 }) {
   const { t } = useTranslation();
-  const [result, setResult] = useState<AITraceGenerationsResult | null>(null);
-  const [loading, setLoading] = useState(false);
+  // The fetched result, tagged with the traceId it belongs to. Rendering goes
+  // through `resolveStoredResult` so a result for trace A is NEVER shown under
+  // trace B's header (not even for the one frame before the fetch effect for B
+  // commits) — the skeleton shows instead.
+  const [stored, setStored] = useState<StoredGenerationsResult | null>(null);
 
   // Monotonic request token: a slow in-flight fetch for a previously selected
   // trace must not overwrite the result of a newer selection (same stale-guard
@@ -209,11 +212,14 @@ export function TraceDetailPanel({
 
   const traceId = trace?.traceId;
   useEffect(() => {
-    if (!traceId) return;
+    if (!traceId) {
+      // Panel closed: drop the previous trace's generations instead of
+      // retaining them in memory for the lifetime of the page.
+      setStored(null);
+      return;
+    }
     const seq = ++reqSeq.current;
     const controller = new AbortController();
-    setResult(null);
-    setLoading(true);
     fetchTraceGenerations({
       traceId,
       limit: GENERATION_LIMIT,
@@ -223,20 +229,23 @@ export function TraceDetailPanel({
         // Drop a stale response superseded by a newer selection, or one whose
         // request was aborted (panel closed / unmounted).
         if (seq !== reqSeq.current || controller.signal.aborted) return;
-        setResult(next);
-        setLoading(false);
+        setStored({ traceId, result: next });
       })
       .catch(() => {
         // fetchTraceGenerations never rejects by construction; this guard only
         // keeps the skeleton from sticking forever if that invariant changes.
         if (seq !== reqSeq.current || controller.signal.aborted) return;
-        setResult({ kind: "error", message: "Failed to load trace generations" });
-        setLoading(false);
+        setStored({
+          traceId,
+          result: { kind: "error", message: "Failed to load trace generations" },
+        });
       });
     // Abort the in-flight fetch when the selection changes or the panel closes.
     return () => controller.abort();
   }, [traceId]);
 
+  // Null while closed, loading, or when `stored` belongs to a previous trace.
+  const result = resolveStoredResult(stored, traceId);
   const generations = result?.kind === "ok" ? result.generations : [];
 
   return (
@@ -255,8 +264,10 @@ export function TraceDetailPanel({
         </SheetHeader>
 
         <div className="flex-1 space-y-3 overflow-y-auto p-4">
-          {/* Loading skeleton */}
-          {loading && !result && <PanelSkeleton />}
+          {/* Loading skeleton — panel open but no result for THIS trace yet
+              (covers both the in-flight fetch and the pre-effect frame after
+              switching traces). */}
+          {traceId !== undefined && result === null && <PanelSkeleton />}
 
           {/* Permission-denied state */}
           {result?.kind === "denied" && (

--- a/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
@@ -218,13 +218,21 @@ export function TraceDetailPanel({
       traceId,
       limit: GENERATION_LIMIT,
       signal: controller.signal,
-    }).then((next) => {
-      // Drop a stale response superseded by a newer selection, or one whose
-      // request was aborted (panel closed / unmounted).
-      if (seq !== reqSeq.current || controller.signal.aborted) return;
-      setResult(next);
-      setLoading(false);
-    });
+    })
+      .then((next) => {
+        // Drop a stale response superseded by a newer selection, or one whose
+        // request was aborted (panel closed / unmounted).
+        if (seq !== reqSeq.current || controller.signal.aborted) return;
+        setResult(next);
+        setLoading(false);
+      })
+      .catch(() => {
+        // fetchTraceGenerations never rejects by construction; this guard only
+        // keeps the skeleton from sticking forever if that invariant changes.
+        if (seq !== reqSeq.current || controller.signal.aborted) return;
+        setResult({ kind: "error", message: "Failed to load trace generations" });
+        setLoading(false);
+      });
     // Abort the in-flight fetch when the selection changes or the panel closes.
     return () => controller.abort();
   }, [traceId]);

--- a/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
@@ -161,14 +161,23 @@ function GenerationCard({ generation }: { generation: AIGeneration }) {
       {/* Prompt messages (redacted server-side, displayed as-is) */}
       <div className="space-y-2">
         <div className="text-xs font-medium">{t("aiTraces.detail.prompt", "Prompt")}</div>
-        {generation.messages.map((message, i) => (
-          <ContentBlock
-            // biome-ignore lint/suspicious/noArrayIndexKey: messages are static per generation
-            key={i}
-            label={t(`aiTraces.detail.role.${message.role}`, message.role)}
-            content={message.content}
-          />
-        ))}
+        {generation.messages.length === 0 ? (
+          // Mirror the completion section's empty fallback: an empty messages
+          // array (fully redacted / never recorded) must not leave the heading
+          // orphaned with nothing beneath it.
+          <p className="text-xs italic text-muted-foreground">
+            {t("aiTraces.detail.noMessages", "No prompt messages recorded")}
+          </p>
+        ) : (
+          generation.messages.map((message, i) => (
+            <ContentBlock
+              // biome-ignore lint/suspicious/noArrayIndexKey: messages are static per generation
+              key={i}
+              label={t(`aiTraces.detail.role.${message.role}`, message.role)}
+              content={message.content}
+            />
+          ))
+        )}
       </div>
 
       {/* Completion (redacted server-side; empty for streaming calls) */}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/trace-detail-panel.tsx
@@ -1,0 +1,290 @@
+/**
+ * TraceDetailPanel — per-trace content drill-down for /admin/ai-traces
+ * (Spec 69 — "Langfuse-class observability", issue #350).
+ *
+ * Side Sheet that opens when a trace row is selected on the AI-traces page and
+ * shows the trace's per-call generations: model, token split, cost, latency,
+ * status, and the prompt messages + completion. All content is rendered
+ * exactly as the server returns it — the server already redacts; the UI never
+ * adds a "reveal raw" affordance.
+ *
+ * Data source audit:
+ * - All data: DYNAMIC — fetched from GET /api/ai/traces/:id/generations on
+ *   open; refetched when a different trace is selected.
+ */
+
+import {
+  Badge,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  Skeleton,
+} from "@linchkit/ui-kit/components";
+import { ActivityIcon, ShieldOffIcon, XCircleIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  type AIGeneration,
+  type AITrace,
+  type AITraceGenerationsResult,
+  type AITraceStatus,
+  fetchTraceGenerations,
+} from "../lib/ai-traces-client";
+
+// ── Constants ────────────────────────────────────────────
+
+/** Max generations requested per trace (server hard-caps anyway). */
+const GENERATION_LIMIT = 100;
+
+// ── Shared format helpers (also used by the list page) ───
+
+/** Map a trace/generation status to a Badge class (ok=green, error=red, partial=amber). */
+export function statusBadgeClass(status: AITraceStatus): string {
+  switch (status) {
+    case "ok":
+      return "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400";
+    case "error":
+      return "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400";
+    default:
+      // partial
+      return "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400";
+  }
+}
+
+/** Format a USD cost, or "—" when zero/absent (per spec — `$0.000026`, `—` when 0). */
+export function formatCost(cost: number | undefined): string {
+  if (!cost) return "—";
+  return `$${cost.toFixed(6)}`;
+}
+
+/** Format a latency in ms (`420ms`, `1.25s`), or "—" when invalid. */
+function formatLatency(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+// ── Sub-components ───────────────────────────────────────
+
+function PanelSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+        <Skeleton key={i} className="h-32 w-full" />
+      ))}
+    </div>
+  );
+}
+
+/** Redacted text block (prompt message / completion) — monospace, pre-wrap. */
+function ContentBlock({ label, content }: { label: string; content: string }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <pre className="whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 font-mono text-xs">
+        {content}
+      </pre>
+    </div>
+  );
+}
+
+function GenerationCard({ generation }: { generation: AIGeneration }) {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-lg border p-3 space-y-3">
+      {/* Model / provider / status */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="truncate font-medium text-sm" title={generation.model}>
+            {generation.model}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {t("aiTraces.detail.provider", "Provider")}: {generation.provider}
+          </div>
+        </div>
+        <Badge
+          variant="secondary"
+          className={`shrink-0 text-[10px] ${statusBadgeClass(generation.status)}`}
+        >
+          {t(`aiTraces.status.${generation.status}`, generation.status)}
+        </Badge>
+      </div>
+
+      {/* Metrics */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono text-xs text-muted-foreground">
+        <span>
+          {t("aiTraces.detail.tokens", "Tokens")}: {(generation.inputTokens ?? 0).toLocaleString()}{" "}
+          / {(generation.outputTokens ?? 0).toLocaleString()}
+        </span>
+        <span>
+          {t("aiTraces.detail.cost", "Cost")}: {formatCost(generation.cost)}
+        </span>
+        <span>
+          {t("aiTraces.detail.latency", "Latency")}: {formatLatency(generation.latencyMs)}
+        </span>
+      </div>
+
+      {/* Optional flags */}
+      {(generation.cached || generation.partial || generation.fallbackUsed) && (
+        <div className="flex flex-wrap gap-1.5">
+          {generation.cached && (
+            <Badge variant="outline" className="text-[10px]">
+              {t("aiTraces.detail.cached", "Cached")}
+            </Badge>
+          )}
+          {generation.partial && (
+            <Badge variant="outline" className="text-[10px]">
+              {t("aiTraces.detail.partial", "Partial")}
+            </Badge>
+          )}
+          {generation.fallbackUsed && (
+            <Badge variant="outline" className="text-[10px]">
+              {t("aiTraces.detail.fallback", "Fallback")}: {generation.fallbackUsed}
+            </Badge>
+          )}
+        </div>
+      )}
+
+      {/* Error detail */}
+      {generation.error && (
+        <div className="flex items-start gap-1.5 rounded-md bg-red-50 p-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-400">
+          <XCircleIcon className="mt-0.5 size-3.5 shrink-0" />
+          <span className="break-words">{generation.error}</span>
+        </div>
+      )}
+
+      {/* Prompt messages (redacted server-side, displayed as-is) */}
+      <div className="space-y-2">
+        <div className="text-xs font-medium">{t("aiTraces.detail.prompt", "Prompt")}</div>
+        {generation.messages.map((message, i) => (
+          <ContentBlock
+            // biome-ignore lint/suspicious/noArrayIndexKey: messages are static per generation
+            key={i}
+            label={t(`aiTraces.detail.role.${message.role}`, message.role)}
+            content={message.content}
+          />
+        ))}
+      </div>
+
+      {/* Completion (redacted server-side; empty for streaming calls) */}
+      <div className="space-y-2">
+        <div className="text-xs font-medium">{t("aiTraces.detail.completion", "Completion")}</div>
+        {generation.completion ? (
+          <pre className="whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 font-mono text-xs">
+            {generation.completion}
+          </pre>
+        ) : (
+          <p className="text-xs italic text-muted-foreground">
+            {t("aiTraces.detail.noCompletion", "No completion recorded (streaming or empty)")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────
+
+export function TraceDetailPanel({
+  trace,
+  onOpenChange,
+}: {
+  /** The selected trace, or null when the panel is closed. */
+  trace: AITrace | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const [result, setResult] = useState<AITraceGenerationsResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Monotonic request token: a slow in-flight fetch for a previously selected
+  // trace must not overwrite the result of a newer selection (same stale-guard
+  // pattern as the list page).
+  const reqSeq = useRef(0);
+
+  const traceId = trace?.traceId;
+  useEffect(() => {
+    if (!traceId) return;
+    const seq = ++reqSeq.current;
+    const controller = new AbortController();
+    setResult(null);
+    setLoading(true);
+    fetchTraceGenerations({
+      traceId,
+      limit: GENERATION_LIMIT,
+      signal: controller.signal,
+    }).then((next) => {
+      // Drop a stale response superseded by a newer selection, or one whose
+      // request was aborted (panel closed / unmounted).
+      if (seq !== reqSeq.current || controller.signal.aborted) return;
+      setResult(next);
+      setLoading(false);
+    });
+    // Abort the in-flight fetch when the selection changes or the panel closes.
+    return () => controller.abort();
+  }, [traceId]);
+
+  const generations = result?.kind === "ok" ? result.generations : [];
+
+  return (
+    <Sheet open={trace !== null} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-xl">
+        <SheetHeader className="border-b px-4 py-3">
+          <SheetTitle className="text-sm">
+            {t("aiTraces.detail.title", "Trace Detail")}
+            {trace && <span className="ml-2 font-normal text-muted-foreground">{trace.name}</span>}
+          </SheetTitle>
+          {trace && (
+            <SheetDescription className="break-all font-mono text-xs">
+              {trace.traceId}
+            </SheetDescription>
+          )}
+        </SheetHeader>
+
+        <div className="flex-1 space-y-3 overflow-y-auto p-4">
+          {/* Loading skeleton */}
+          {loading && !result && <PanelSkeleton />}
+
+          {/* Permission-denied state */}
+          {result?.kind === "denied" && (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+              <ShieldOffIcon className="size-10 opacity-30" />
+              <p className="text-sm">
+                {t("aiTraces.denied", "You don't have permission to view AI traces.")}
+              </p>
+            </div>
+          )}
+
+          {/* Error banner */}
+          {result?.kind === "error" && (
+            <div className="flex items-center gap-2 rounded-lg bg-red-50 p-4 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-400">
+              <XCircleIcon className="size-4 shrink-0" />
+              {t("aiTraces.detail.fetchError", "Failed to load trace detail")}: {result.message}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {result?.kind === "ok" && generations.length === 0 && (
+            <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+              <ActivityIcon className="size-10 opacity-30" />
+              <p className="text-sm">
+                {t("aiTraces.detail.empty", "No generations recorded for this trace")}
+              </p>
+            </div>
+          )}
+
+          {/* Generation cards */}
+          {result?.kind === "ok" &&
+            generations.map((generation) => (
+              <GenerationCard key={generation.id} generation={generation} />
+            ))}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -208,6 +208,7 @@
       "prompt": "Prompt",
       "completion": "Completion",
       "noCompletion": "No completion recorded (streaming or empty)",
+      "noMessages": "No prompt messages recorded",
       "role": {
         "system": "System",
         "user": "User",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -194,7 +194,28 @@
     "traceId": "Trace ID",
     "empty": "No AI traces recorded yet",
     "denied": "You don't have permission to view AI traces.",
-    "fetchError": "Failed to load AI traces"
+    "fetchError": "Failed to load AI traces",
+    "detail": {
+      "title": "Trace Detail",
+      "open": "View trace detail",
+      "provider": "Provider",
+      "tokens": "Tokens",
+      "cost": "Cost",
+      "latency": "Latency",
+      "cached": "Cached",
+      "partial": "Partial",
+      "fallback": "Fallback",
+      "prompt": "Prompt",
+      "completion": "Completion",
+      "noCompletion": "No completion recorded (streaming or empty)",
+      "role": {
+        "system": "System",
+        "user": "User",
+        "assistant": "Assistant"
+      },
+      "empty": "No generations recorded for this trace",
+      "fetchError": "Failed to load trace detail"
+    }
   },
   "viewTabs": {
     "newView": "New View",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -194,7 +194,28 @@
     "traceId": "追踪 ID",
     "empty": "暂无 AI 调用追踪记录",
     "denied": "您没有查看 AI 调用追踪的权限。",
-    "fetchError": "加载 AI 调用追踪失败"
+    "fetchError": "加载 AI 调用追踪失败",
+    "detail": {
+      "title": "追踪详情",
+      "open": "查看追踪详情",
+      "provider": "提供商",
+      "tokens": "Token",
+      "cost": "成本",
+      "latency": "延迟",
+      "cached": "缓存",
+      "partial": "部分",
+      "fallback": "降级",
+      "prompt": "提示词",
+      "completion": "补全结果",
+      "noCompletion": "未记录补全结果（流式或为空）",
+      "role": {
+        "system": "系统",
+        "user": "用户",
+        "assistant": "助手"
+      },
+      "empty": "该追踪暂无生成记录",
+      "fetchError": "加载追踪详情失败"
+    }
   },
   "viewTabs": {
     "newView": "新视图",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -208,6 +208,7 @@
       "prompt": "提示词",
       "completion": "补全结果",
       "noCompletion": "未记录补全结果（流式或为空）",
+      "noMessages": "未记录提示词消息",
       "role": {
         "system": "系统",
         "user": "用户",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/fetch-trace-generations.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/fetch-trace-generations.test.ts
@@ -1,0 +1,192 @@
+/**
+ * fetchTraceGenerations wire-mapping tests.
+ *
+ * Pure logic-only (no jsdom): the `fetch` seam is replaced by an injected stub
+ * (dependency injection — never a global fetch mock), and the discriminated
+ * `AITraceGenerationsResult` arms are asserted against the
+ * `GET /api/ai/traces/:id/generations` envelope. These cover the same states
+ * the detail panel renders: populated cards (`ok` + generations), the empty
+ * state (`ok` + none), and the permission-denied state (`denied`).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+// `api.ts` reads the auth token from `localStorage` via `getAuthHeaders()`.
+// Under the pure-logic (no-jsdom) test runner that global is absent, so install
+// a minimal in-memory stub BEFORE importing the module under test. This is a
+// browser-API shim, not a network/fetch mock — the fetch seam is still injected.
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, String(value)),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+}
+
+const { fetchTraceGenerations } = await import("../ai-traces-client");
+type AIGeneration = import("../ai-traces-client").AIGeneration;
+
+// ── Helpers ─────────────────────────────────────────────────
+
+/** Build a stub `fetch` returning the given JSON body + HTTP status. */
+function stubFetch(body: unknown, init: { status?: number } = {}): typeof fetch {
+  const status = init.status ?? 200;
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+const SAMPLE_GENERATION: AIGeneration = {
+  id: "gen-1",
+  traceId: "trace-abcdef123456",
+  model: "glm-4.6",
+  provider: "zhipu",
+  messages: [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "Fill the form for [REDACTED]." },
+  ],
+  completion: '{"name":"[REDACTED]"}',
+  inputTokens: 120,
+  outputTokens: 45,
+  cost: 0.000026,
+  latencyMs: 420,
+  status: "ok",
+  startedAt: 1_700_000_000_000,
+  endedAt: 1_700_000_000_420,
+};
+
+// ── ok: populated ───────────────────────────────────────────
+
+describe("fetchTraceGenerations", () => {
+  test("maps a successful envelope to { kind: 'ok' } with generations", async () => {
+    const result = await fetchTraceGenerations({
+      traceId: "trace-abcdef123456",
+      fetchImpl: stubFetch({
+        success: true,
+        data: { generations: [SAMPLE_GENERATION], count: 1 },
+      }),
+    });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.count).toBe(1);
+    expect(result.generations).toHaveLength(1);
+    expect(result.generations[0]?.id).toBe("gen-1");
+    expect(result.generations[0]?.messages).toHaveLength(2);
+  });
+
+  // ── ok: empty ─────────────────────────────────────────────
+
+  test("maps an empty data envelope to { kind: 'ok' } with no generations", async () => {
+    const result = await fetchTraceGenerations({
+      traceId: "trace-empty",
+      fetchImpl: stubFetch({ success: true, data: { generations: [], count: 0 } }),
+    });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.generations).toHaveLength(0);
+    expect(result.count).toBe(0);
+  });
+
+  // ── denied ────────────────────────────────────────────────
+
+  test("maps a 403 AUTHZ_DENIED envelope to { kind: 'denied' }", async () => {
+    const result = await fetchTraceGenerations({
+      traceId: "trace-denied",
+      fetchImpl: stubFetch(
+        { success: false, error: { code: "AUTHZ_DENIED", message: "Access denied" } },
+        { status: 403 },
+      ),
+    });
+    expect(result.kind).toBe("denied");
+    if (result.kind !== "denied") throw new Error("expected denied");
+    expect(result.message).toBe("Access denied");
+  });
+
+  test("maps an AI.READ_TRACES.BLOCKED code to { kind: 'denied' } regardless of status", async () => {
+    const result = await fetchTraceGenerations({
+      traceId: "trace-blocked",
+      fetchImpl: stubFetch({
+        success: false,
+        error: { code: "AI.READ_TRACES.BLOCKED", message: "blocked" },
+      }),
+    });
+    expect(result.kind).toBe("denied");
+  });
+
+  // ── error ─────────────────────────────────────────────────
+
+  test("maps a non-authz failure to { kind: 'error' }", async () => {
+    const result = await fetchTraceGenerations({
+      traceId: "trace-error",
+      fetchImpl: stubFetch(
+        { success: false, error: { code: "INTERNAL", message: "boom" } },
+        { status: 500 },
+      ),
+    });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("expected error");
+    expect(result.message).toBe("boom");
+  });
+
+  test("maps a transport throw to { kind: 'error' }", async () => {
+    const throwingFetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const result = await fetchTraceGenerations({
+      traceId: "trace-offline",
+      fetchImpl: throwingFetch,
+    });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") throw new Error("expected error");
+    expect(result.message).toBe("network down");
+  });
+
+  // ── URL construction (contract) ───────────────────────────
+
+  test("builds the request URL with the encoded trace id and limit param", async () => {
+    let captured = "";
+    const capturingFetch = (async (url: string) => {
+      captured = url;
+      return new Response(JSON.stringify({ success: true, data: { generations: [], count: 0 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await fetchTraceGenerations({ traceId: "trace-123", limit: 100, fetchImpl: capturingFetch });
+    expect(captured).toBe("/api/ai/traces/trace-123/generations?limit=100");
+
+    await fetchTraceGenerations({ traceId: "trace-123", fetchImpl: capturingFetch });
+    expect(captured).toBe("/api/ai/traces/trace-123/generations");
+
+    // Path-unsafe ids must be percent-encoded, never spliced raw into the path.
+    await fetchTraceGenerations({ traceId: "trace/../x?y", fetchImpl: capturingFetch });
+    expect(captured).toBe("/api/ai/traces/trace%2F..%2Fx%3Fy/generations");
+  });
+
+  // ── denied: non-JSON 403 body (proxy / gateway) ───────────
+
+  test("maps a 403 with a non-JSON body to { kind: 'denied' }", async () => {
+    const nonJsonFetch = (async () =>
+      new Response("Forbidden", {
+        status: 403,
+        headers: { "Content-Type": "text/plain" },
+      })) as unknown as typeof fetch;
+    const result = await fetchTraceGenerations({
+      traceId: "trace-proxy",
+      fetchImpl: nonJsonFetch,
+    });
+    expect(result.kind).toBe("denied");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/trace-detail-state.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/__tests__/trace-detail-state.test.ts
@@ -1,0 +1,47 @@
+/**
+ * resolveStoredResult tests — the trace-detail panel's "result belongs to the
+ * selected trace" guard (pure logic, no jsdom).
+ *
+ * These cover the two review findings fixed at this seam:
+ * - close (traceId undefined) must never surface a previous trace's result;
+ * - switching trace A → B must hide A's result (skeleton) until B's arrives,
+ *   even though A's result is still the stored state at that point.
+ *
+ * The render wiring itself (Sheet/skeleton JSX) has no jsdom harness in this
+ * package and is intentionally not rendered here.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AITraceGenerationsResult } from "../ai-traces-client";
+import { resolveStoredResult, type StoredGenerationsResult } from "../trace-detail-state";
+
+const OK_RESULT: AITraceGenerationsResult = { kind: "ok", generations: [], count: 0 };
+
+const STORED_A: StoredGenerationsResult = { traceId: "trace-a", result: OK_RESULT };
+
+describe("resolveStoredResult", () => {
+  test("returns the stored result when it belongs to the selected trace", () => {
+    expect(resolveStoredResult(STORED_A, "trace-a")).toBe(OK_RESULT);
+  });
+
+  test("returns null when nothing has been stored yet (initial open)", () => {
+    expect(resolveStoredResult(null, "trace-a")).toBeNull();
+  });
+
+  test("returns null when the panel is closed (undefined traceId)", () => {
+    // Close while A's result is still stored — must not surface it.
+    expect(resolveStoredResult(STORED_A, undefined)).toBeNull();
+  });
+
+  test("returns null when the stored result belongs to a previous trace (A → B switch)", () => {
+    // The pre-effect frame after selecting B: stored is still A's result.
+    expect(resolveStoredResult(STORED_A, "trace-b")).toBeNull();
+  });
+
+  test("non-ok results are also keyed to their trace", () => {
+    const denied: AITraceGenerationsResult = { kind: "denied", message: "Access denied" };
+    const stored: StoredGenerationsResult = { traceId: "trace-a", result: denied };
+    expect(resolveStoredResult(stored, "trace-a")).toBe(denied);
+    expect(resolveStoredResult(stored, "trace-b")).toBeNull();
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/ai-traces-client.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/ai-traces-client.ts
@@ -1,9 +1,11 @@
 /**
  * AI Traces client (Spec 69 — "Langfuse-class observability", issue #350).
  *
- * Thin typed wrapper over `GET /api/ai/traces` for the admin AI-traces page.
- * Split out of `api.ts` to keep that file within the file-size cap; reuses the
- * shared `getAuthHeaders` / `handleUnauthorized` helpers.
+ * Thin typed wrapper over `GET /api/ai/traces` (roll-up list) and
+ * `GET /api/ai/traces/:id/generations` (per-trace drill-down) for the admin
+ * AI-traces page. Split out of `api.ts` to keep that file within the
+ * file-size cap; reuses the shared `getAuthHeaders` / `handleUnauthorized`
+ * helpers.
  */
 
 import { getAuthHeaders, handleUnauthorized } from "./api";
@@ -37,6 +39,46 @@ export interface AITrace {
   tags?: string[];
 }
 
+/** One redacted prompt message inside an {@link AIGeneration}. */
+export interface AITraceMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/**
+ * A single AI generation (one model call) as returned by
+ * `GET /api/ai/traces/:id/generations`.
+ *
+ * Local mirror of the `@linchkit/core` `AIGeneration` wire shape (same module
+ * boundary as {@link AITrace}). `messages` / `completion` arrive already
+ * redacted by the server — the UI displays them as-is, never un-masks.
+ * `startedAt` / `endedAt` are epoch milliseconds; `completion` is empty for
+ * streaming calls.
+ */
+export interface AIGeneration {
+  id: string;
+  traceId: string;
+  model: string;
+  provider: string;
+  /** Redacted prompt messages. */
+  messages: AITraceMessage[];
+  /** Redacted completion (empty for streaming). */
+  completion: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost?: number;
+  latencyMs: number;
+  temperature?: number;
+  responseFormat?: "text" | "json";
+  fallbackUsed?: string;
+  cached?: boolean;
+  partial?: boolean;
+  status: AITraceStatus;
+  error?: string;
+  startedAt: number;
+  endedAt: number;
+}
+
 /**
  * Discriminated result of `fetchAITraces` so the caller can distinguish a
  * successful read from an authorization denial (which needs a friendlier
@@ -55,58 +97,66 @@ export type AITracesResult =
   | { kind: "denied"; message: string }
   | { kind: "error"; message: string };
 
-/** Error codes the trace endpoint returns for an authorization denial. */
-const AI_TRACE_DENIED_CODES: ReadonlySet<string> = new Set([
+/** Discriminated result of `fetchTraceGenerations` (same arms as {@link AITracesResult}). */
+export type AITraceGenerationsResult =
+  | { kind: "ok"; generations: AIGeneration[]; count: number }
+  | { kind: "denied"; message: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Error codes the trace endpoints return for an authorization denial — shared
+ * by the list and the per-trace generations fetchers (single source of truth).
+ */
+export const AI_TRACE_DENIED_CODES: ReadonlySet<string> = new Set([
   "AUTHZ_DENIED",
   "AI.READ_TRACES.BLOCKED",
 ]);
 
 const DENIED_MESSAGE = "You don't have permission to view AI traces.";
 
+/** Standard `{ success, data, error }` envelope both trace endpoints return. */
+interface TraceApiEnvelope<TData> {
+  success?: boolean;
+  data?: TData;
+  error?: { code?: string; message?: string };
+}
+
 /**
- * Fetch recent AI traces from `GET /api/ai/traces`.
- *
- * The endpoint returns `{ success: true, data: { traces, count } }` on success
- * and `{ success: false, error: { code, message } }` on an authorization
- * failure (HTTP 403). This helper maps an authz denial to a distinct
- * `{ kind: "denied" }` arm so the page can render a permission-specific message
- * — even when the 403 body is empty / non-JSON (e.g. from a proxy or gateway).
+ * Shared request core for both trace endpoints: performs the authenticated
+ * fetch, routes a 401 through `handleUnauthorized`, and maps the response
+ * envelope to a discriminated outcome. An authz denial (HTTP 403, a canonical
+ * denied code, or a non-JSON 403 body from a proxy/gateway) becomes
+ * `{ kind: "denied" }`; everything else failing becomes `{ kind: "error" }`.
  *
  * The optional `fetchImpl` lets tests inject a stub `fetch` without leaking a
  * global mock across the batched suite (same DI pattern as `resolveSchemaIntent`).
  */
-export async function fetchAITraces(
-  options: {
-    limit?: number;
-    status?: AITraceStatus;
-    signal?: AbortSignal;
-    fetchImpl?: typeof fetch;
-  } = {},
-): Promise<AITracesResult> {
+async function requestTraceApi<TData>(options: {
+  url: string;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+  /** Fallback failure message when the response carries no error message. */
+  fallbackMessage: string;
+}): Promise<
+  | { kind: "ok"; data: TData }
+  | { kind: "denied"; message: string }
+  | { kind: "error"; message: string }
+> {
   const doFetch = options.fetchImpl ?? fetch;
-  const params = new URLSearchParams();
-  if (options.limit !== undefined) params.set("limit", String(options.limit));
-  if (options.status !== undefined) params.set("status", options.status);
-  const qs = params.toString();
-  const url = `/api/ai/traces${qs ? `?${qs}` : ""}`;
 
   let res: Response;
   try {
-    res = await doFetch(url, { headers: getAuthHeaders(), signal: options.signal });
+    res = await doFetch(options.url, { headers: getAuthHeaders(), signal: options.signal });
   } catch (err) {
     return {
       kind: "error",
-      message: err instanceof Error ? err.message : "Failed to load AI traces",
+      message: err instanceof Error ? err.message : options.fallbackMessage,
     };
   }
   // 401 → clears the token and redirects to /login (when auth is enabled).
   handleUnauthorized(res);
 
-  let json: {
-    success?: boolean;
-    data?: { traces?: AITrace[]; count?: number };
-    error?: { code?: string; message?: string };
-  };
+  let json: TraceApiEnvelope<TData>;
   try {
     json = await res.json();
   } catch {
@@ -117,18 +167,83 @@ export async function fetchAITraces(
   }
 
   if (json.success && json.data) {
-    return {
-      kind: "ok",
-      traces: json.data.traces ?? [],
-      count: json.data.count ?? json.data.traces?.length ?? 0,
-    };
+    return { kind: "ok", data: json.data };
   }
 
   const code = json.error?.code ?? "";
-  const message = json.error?.message ?? "Failed to load AI traces";
+  const message = json.error?.message ?? options.fallbackMessage;
   // Permission denied (authenticated): 403 status, or the canonical authz code.
   if (res.status === 403 || AI_TRACE_DENIED_CODES.has(code)) {
     return { kind: "denied", message: message || DENIED_MESSAGE };
   }
   return { kind: "error", message };
+}
+
+/**
+ * Fetch recent AI traces from `GET /api/ai/traces`.
+ *
+ * The endpoint returns `{ success: true, data: { traces, count } }` on success
+ * and `{ success: false, error: { code, message } }` on an authorization
+ * failure (HTTP 403) — see {@link requestTraceApi} for the envelope mapping.
+ */
+export async function fetchAITraces(
+  options: {
+    limit?: number;
+    status?: AITraceStatus;
+    signal?: AbortSignal;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<AITracesResult> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.status !== undefined) params.set("status", options.status);
+  const qs = params.toString();
+  const url = `/api/ai/traces${qs ? `?${qs}` : ""}`;
+
+  const outcome = await requestTraceApi<{ traces?: AITrace[]; count?: number }>({
+    url,
+    signal: options.signal,
+    fetchImpl: options.fetchImpl,
+    fallbackMessage: "Failed to load AI traces",
+  });
+  if (outcome.kind !== "ok") return outcome;
+  return {
+    kind: "ok",
+    traces: outcome.data.traces ?? [],
+    count: outcome.data.count ?? outcome.data.traces?.length ?? 0,
+  };
+}
+
+/**
+ * Fetch the per-call generations of one trace from
+ * `GET /api/ai/traces/:id/generations`.
+ *
+ * The endpoint returns `{ success: true, data: { generations, count } }` on
+ * success and the same denial/error envelope as the list endpoint — see
+ * {@link requestTraceApi}. Content (`messages` / `completion`) is already
+ * redacted server-side and is displayed as-is.
+ */
+export async function fetchTraceGenerations(options: {
+  traceId: string;
+  limit?: number;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+}): Promise<AITraceGenerationsResult> {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  const qs = params.toString();
+  const url = `/api/ai/traces/${encodeURIComponent(options.traceId)}/generations${qs ? `?${qs}` : ""}`;
+
+  const outcome = await requestTraceApi<{ generations?: AIGeneration[]; count?: number }>({
+    url,
+    signal: options.signal,
+    fetchImpl: options.fetchImpl,
+    fallbackMessage: "Failed to load trace generations",
+  });
+  if (outcome.kind !== "ok") return outcome;
+  return {
+    kind: "ok",
+    generations: outcome.data.generations ?? [],
+    count: outcome.data.count ?? outcome.data.generations?.length ?? 0,
+  };
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/ai-traces-client.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/ai-traces-client.ts
@@ -163,7 +163,7 @@ async function requestTraceApi<TData>(options: {
     // Empty / non-JSON body (proxy, gateway, 204). A 403 is still a denial —
     // map it before falling back to a generic error so the friendly state shows.
     if (res.status === 403) return { kind: "denied", message: DENIED_MESSAGE };
-    return { kind: "error", message: "AI traces endpoint returned an invalid response" };
+    return { kind: "error", message: options.fallbackMessage };
   }
 
   if (json.success && json.data) {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/trace-detail-state.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/trace-detail-state.ts
@@ -1,0 +1,33 @@
+/**
+ * Trace-detail panel state helpers (pure, render-free).
+ *
+ * The detail panel stores its fetched generations TOGETHER with the traceId
+ * they belong to, and only surfaces them when that id matches the currently
+ * selected trace. This closes the one-frame stale window when switching
+ * trace A → B: before the fetch effect for B commits, the stored result still
+ * belongs to A, so the resolver returns null and the panel renders the
+ * loading skeleton instead of A's cards under B's header.
+ */
+
+import type { AITraceGenerationsResult } from "./ai-traces-client";
+
+/** A generations result tagged with the traceId it was fetched for. */
+export interface StoredGenerationsResult {
+  traceId: string;
+  result: AITraceGenerationsResult;
+}
+
+/**
+ * Resolve the result to render for the currently selected trace.
+ *
+ * Returns the stored result only when it belongs to `traceId`; returns null
+ * when the panel is closed (`traceId` undefined), nothing is stored yet, or
+ * the stored result belongs to a previously selected trace.
+ */
+export function resolveStoredResult(
+  stored: StoredGenerationsResult | null,
+  traceId: string | undefined,
+): AITraceGenerationsResult | null {
+  if (!stored || !traceId || stored.traceId !== traceId) return null;
+  return stored.result;
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -97,7 +97,10 @@ function TraceRow({ trace, onSelect }: { trace: AITrace; onSelect: (trace: AITra
     <TableRow
       role="button"
       tabIndex={0}
-      aria-label={t("aiTraces.detail.open", "View trace detail")}
+      // Include the trace name: `role="button"` makes aria-label the row's
+      // ENTIRE accessible name (cell content is no longer announced), so a
+      // fixed label would make every row indistinguishable to screen readers.
+      aria-label={`${t("aiTraces.detail.open", "View trace detail")}: ${trace.name}`}
       className="cursor-pointer"
       onClick={() => onSelect(trace)}
       onKeyDown={(e) => {

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -94,29 +94,31 @@ function TraceRow({ trace, onSelect }: { trace: AITrace; onSelect: (trace: AITra
     ? "—"
     : formatRelativeTime(started.toISOString(), t);
   return (
-    <TableRow
-      role="button"
-      tabIndex={0}
-      // Include the trace name: `role="button"` makes aria-label the row's
-      // ENTIRE accessible name (cell content is no longer announced), so a
-      // fixed label would make every row indistinguishable to screen readers.
-      aria-label={`${t("aiTraces.detail.open", "View trace detail")}: ${trace.name}`}
-      className="cursor-pointer"
-      onClick={() => onSelect(trace)}
-      onKeyDown={(e) => {
-        // Keyboard activation parity with a native button (Enter / Space).
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onSelect(trace);
-        }
-      }}
-    >
+    // No role/tabIndex on the row: `role="button"` on a <tr> destroys table
+    // semantics for screen readers (the row collapses into one button and the
+    // cells are no longer announced). The row's onClick is a mouse-only
+    // convenience; the accessible + keyboard entry point is the real <button>
+    // in the name cell below.
+    <TableRow className="cursor-pointer" onClick={() => onSelect(trace)}>
       <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
         <div>{startedLabel}</div>
         {duration && <div className="text-[10px] opacity-70">{duration}</div>}
       </TableCell>
       <TableCell>
-        <div className="font-medium text-sm">{trace.name}</div>
+        <button
+          type="button"
+          // Plain text-button styled to match the cell typography; Enter/Space
+          // activation is native. stopPropagation keeps the row's onClick from
+          // firing a second (idempotent, but redundant) select.
+          className="block text-left font-medium text-sm hover:underline underline-offset-2"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect(trace);
+          }}
+        >
+          {trace.name}
+          <span className="sr-only"> — {t("aiTraces.detail.open", "View trace detail")}</span>
+        </button>
         {trace.scenario && <div className="text-xs text-muted-foreground">{trace.scenario}</div>}
       </TableCell>
       <TableCell className="text-xs text-muted-foreground">{trace.origin}</TableCell>

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -234,6 +234,9 @@ export function AITracesPage() {
             onClick={() => {
               effectCtrlRef.current?.abort();
               manualCtrlRef.current?.abort();
+              // Same list/panel desync risk as the filter change: the refreshed
+              // window (100 most-recent) may no longer contain the selected trace.
+              setSelectedTrace(null);
               const ctrl = new AbortController();
               manualCtrlRef.current = ctrl;
               load(ctrl.signal);

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -31,6 +31,7 @@ import { formatRelativeTime } from "@linchkit/ui-kit/lib/utils";
 import { ActivityIcon, RefreshCwIcon, ShieldOffIcon, XCircleIcon } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { formatCost, statusBadgeClass, TraceDetailPanel } from "../components/trace-detail-panel";
 import {
   type AITrace,
   type AITraceStatus,
@@ -52,19 +53,8 @@ const STATUS_OPTIONS: ReadonlyArray<AITraceStatus | "__all__"> = [
 ];
 
 // ── Helpers ──────────────────────────────────────────────
-
-/** Map a trace status to a Badge variant (ok=green, error=red, partial=amber). */
-function statusBadgeClass(status: AITraceStatus): string {
-  switch (status) {
-    case "ok":
-      return "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400";
-    case "error":
-      return "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400";
-    default:
-      // partial
-      return "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400";
-  }
-}
+// `statusBadgeClass` / `formatCost` are shared with the detail panel and live
+// in `../components/trace-detail-panel`.
 
 /** Format trace duration (endedAt - startedAt) in ms, or "" when unfinished. */
 function formatTraceDuration(trace: AITrace): string {
@@ -74,12 +64,6 @@ function formatTraceDuration(trace: AITrace): string {
   if (!Number.isFinite(ms) || ms < 0) return "";
   if (ms < 1000) return `${Math.round(ms)}ms`;
   return `${(ms / 1000).toFixed(2)}s`;
-}
-
-/** Format a USD cost, or "—" when zero (per spec — `$0.000026`, `—` when 0). */
-function formatCost(cost: number): string {
-  if (!cost) return "—";
-  return `$${cost.toFixed(6)}`;
 }
 
 /** Truncate a trace id for compact monospace display. */
@@ -100,7 +84,7 @@ function LoadingSkeleton() {
   );
 }
 
-function TraceRow({ trace }: { trace: AITrace }) {
+function TraceRow({ trace, onSelect }: { trace: AITrace; onSelect: (trace: AITrace) => void }) {
   const { t } = useTranslation();
   const duration = formatTraceDuration(trace);
   // Guard against a missing / invalid `startedAt` — `new Date(NaN).toISOString()`
@@ -110,7 +94,20 @@ function TraceRow({ trace }: { trace: AITrace }) {
     ? "—"
     : formatRelativeTime(started.toISOString(), t);
   return (
-    <TableRow>
+    <TableRow
+      role="button"
+      tabIndex={0}
+      aria-label={t("aiTraces.detail.open", "View trace detail")}
+      className="cursor-pointer"
+      onClick={() => onSelect(trace)}
+      onKeyDown={(e) => {
+        // Keyboard activation parity with a native button (Enter / Space).
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(trace);
+        }
+      }}
+    >
       <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
         <div>{startedLabel}</div>
         {duration && <div className="text-[10px] opacity-70">{duration}</div>}
@@ -145,6 +142,8 @@ export function AITracesPage() {
   const [result, setResult] = useState<AITracesResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [statusFilter, setStatusFilter] = useState<AITraceStatus | "__all__">("__all__");
+  // The trace whose content drill-down is open in the side panel (null = closed).
+  const [selectedTrace, setSelectedTrace] = useState<AITrace | null>(null);
 
   // Monotonic request token: a slow in-flight fetch (e.g. an older status
   // filter) must not overwrite the result of a newer one that already resolved.
@@ -281,11 +280,19 @@ export function AITracesPage() {
           </TableHeader>
           <TableBody>
             {traces.map((trace) => (
-              <TraceRow key={trace.traceId} trace={trace} />
+              <TraceRow key={trace.traceId} trace={trace} onSelect={setSelectedTrace} />
             ))}
           </TableBody>
         </Table>
       )}
+
+      {/* Per-trace content drill-down (Sheet side panel) */}
+      <TraceDetailPanel
+        trace={selectedTrace}
+        onOpenChange={(open) => {
+          if (!open) setSelectedTrace(null);
+        }}
+      />
     </div>
   );
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/ai-traces.tsx
@@ -207,7 +207,13 @@ export function AITracesPage() {
         <div className="flex items-center gap-2 shrink-0">
           <Select
             value={statusFilter}
-            onValueChange={(v) => setStatusFilter(v as AITraceStatus | "__all__")}
+            onValueChange={(v) => {
+              setStatusFilter(v as AITraceStatus | "__all__");
+              // Close the drill-down panel: the selected trace may not exist in
+              // the newly-filtered list, which would leave the panel showing a
+              // trace with no corresponding row (list/panel out of sync).
+              setSelectedTrace(null);
+            }}
           >
             <SelectTrigger className="w-36">
               <SelectValue />


### PR DESCRIPTION
## What

The traces list (#563) shows rollup metadata only; the per-call CONTENT endpoint (#564) had no UI. This closes the loop on "调用追踪内容呢?": clicking a trace row opens a Sheet side panel showing each generation — model/provider, status badge, token split, cost, latency, cached/partial/fallback flags, and the **redacted** prompt messages + completion exactly as the server stores them (no reveal toggle, by design — privacy decision locked).

## How

- `fetchTraceGenerations` + local `AIGeneration`/`AITraceMessage` mirrors in `ai-traces-client.ts`. A shared `requestTraceApi` generic now unifies the denied/error/non-JSON-403 mapping for BOTH fetchers — `fetchAITraces` was refactored onto it (reviewer verified verbatim-equivalent behavior; its 8 existing tests pass unmodified).
- `trace-detail-panel.tsx` (Sheet, same pattern as ai-assistant): fetch-on-open with the page's stale-guard pattern (monotonic seq + AbortController, abort on close/selection-change/unmount, defensive catch); skeleton/denied/error/empty states; per-generation cards.
- Rows are keyboard-accessible (`role=button`, Enter/Space) with the trace name in the accessible label (a fixed label would make every row announce identically to screen readers). en+zh-CN `aiTraces.detail.*` keys.

## Tests

8 new DI-fetchImpl tests (envelopes, denied codes, URL contract incl. percent-encoding of path-unsafe ids). `bun test ./addons/adapter-ui/`: 603 pass. Full `bun run test` PASS.

## Review

Cross-model pass (claude CLI): race-guards verified path-by-path, refactor equivalence diffed against HEAD~1, XSS-safe (text nodes only, no dangerouslySetInnerHTML anywhere). 1 a11y issue + 2 nits fixed in the follow-up commit; 2 cosmetic nits (Sheet exit-animation flicker, >100-generations truncation notice) deliberately left — noted here for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)