### PR TITLE
feat(core,adapter-server): NL resolver drafts governed UPDATEs to existing rules (Spec 52 / Spec 72 P3)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
@@ -25,6 +25,7 @@ import type {
   EntityDefinition,
   RuleDefinition,
 } from "@linchkit/core";
+import { REQUIRES_CODE_CHANGE_MARKER } from "@linchkit/core/ai";
 import {
   ActionRegistry,
   createOntologyRegistry,
@@ -92,6 +93,7 @@ const warnLargeAmountRule: RuleDefinition = {
   name: "warn_large_amount",
   label: "Warn on large amount",
   description: "Warn when the amount exceeds 5000",
+  priority: 25,
   trigger: { action: "create_purchase_request" },
   condition: { field: "amount", operator: "gt", value: 5000 },
   effect: { type: "warn", message: "Large amount" },
@@ -711,6 +713,11 @@ describe("buildSchemaIntentOntology — existing rules section", () => {
     expect(declarative?.condition).toEqual({ field: "amount", operator: "gt", value: 5000 });
     expect(declarative?.triggerActions).toEqual(["create_purchase_request"]);
     expect(declarative?.effectType).toBe("warn");
+    // Review-integrity: the snapshot carries priority + the full declarative
+    // effect payload so an update never has to fabricate them.
+    expect(declarative?.priority).toBe(25);
+    expect(declarative?.effect).toEqual({ type: "warn", message: "Large amount" });
+    expect(declarative?.roundTrippable).toBe(true);
 
     const code = rules.find((r) => r.name === "manager_approval_threshold");
     expect(code?.conditionKind).toBe("code");
@@ -719,6 +726,65 @@ describe("buildSchemaIntentOntology — existing rules section", () => {
     expect(code?.description).toBe("Requires manager approval when the amount exceeds 10000");
     expect(code?.triggerActions).toEqual(["submit_purchase_request"]);
     expect(code?.effectType).toBe("require_approval");
+    // Code conditions can never be rebuilt declaratively.
+    expect(code?.roundTrippable).toBe(false);
+  });
+
+  test("composite-condition / non-action-trigger / non-declarative-effect rules are marked non-round-trippable", () => {
+    const compositeRule: RuleDefinition = {
+      name: "composite_guard",
+      label: "Composite guard",
+      trigger: { action: "create_purchase_request" },
+      condition: {
+        operator: "and",
+        conditions: [
+          { field: "amount", operator: "gt", value: 1000 },
+          { field: "department", operator: "eq", value: "ops" },
+        ],
+      },
+      effect: { type: "block", message: "blocked" },
+    };
+    const stateChangeRule: RuleDefinition = {
+      name: "state_change_warn",
+      label: "Warn on approval",
+      trigger: { stateChange: { entity: "purchase_request", to: "approved" } },
+      condition: { field: "amount", operator: "gt", value: 100 },
+      effect: { type: "warn", message: "approved large" },
+    };
+    const executeActionRule: RuleDefinition = {
+      name: "auto_followup",
+      label: "Auto follow-up",
+      trigger: { action: "create_purchase_request" },
+      condition: { field: "amount", operator: "gt", value: 100 },
+      effect: { type: "execute_action", action: "submit_purchase_request" },
+    };
+    const entityRegistry = new EntityRegistry();
+    entityRegistry.register(purchaseSchema);
+    const actionRegistry = new ActionRegistry();
+    actionRegistry.register(createPurchaseAction);
+    actionRegistry.register(submitPurchaseAction);
+    const base = createOntologyRegistry({
+      schemas: entityRegistry,
+      actions: actionRegistry,
+      rules: [compositeRule, stateChangeRule, executeActionRule],
+      states: [],
+      views: [],
+    });
+    const ontology = buildSchemaIntentOntology({ base, actor });
+    const entity = ontology.describeEntity("purchase_request");
+    expect(entity).toBeDefined();
+    if (!entity) throw new Error("expected entity");
+    const byName = new Map((entity.rules ?? []).map((r) => [r.name, r]));
+    // The declarative rebuild path cannot express ANY of these faithfully —
+    // each must be marked so the resolver takes the honest diff-only path.
+    expect(byName.get("composite_guard")?.roundTrippable).toBe(false);
+    expect(byName.get("composite_guard")?.conditionKind).toBe("declarative");
+    expect(byName.get("state_change_warn")?.roundTrippable).toBe(false);
+    expect(byName.get("state_change_warn")?.triggerActions).toBeUndefined();
+    expect(byName.get("auto_followup")?.roundTrippable).toBe(false);
+    // Non-declarative effect payloads expose the type only — never the
+    // execute_action params.
+    expect(byName.get("auto_followup")?.effect).toEqual({ type: "execute_action" });
   });
 
   test("action-triggered rules are hidden when the actor cannot run any of their trigger actions", () => {
@@ -828,6 +894,105 @@ describe("POST /api/ai/resolve-schema-intent — update_rule (declarative)", () 
       operator: "gt",
       value: 8000,
     });
+    // Review-integrity e2e: the AI response omitted `priority` — it is
+    // back-filled from the registered rule, never silently reset.
+    expect(changes[0]?.definition?.priority).toBe(25);
+  });
+});
+
+// ── update_rule: composite-condition rule → honest diff-only draft ──
+
+describe("POST /api/ai/resolve-schema-intent — update_rule (composite condition)", () => {
+  let server: ReturnType<typeof createServer>;
+
+  /** Composite-condition rule — the declarative rebuild cannot express it. */
+  const compositeGuardRule: RuleDefinition = {
+    name: "composite_guard",
+    label: "Composite guard",
+    description: "Block large ops purchases",
+    trigger: { action: "create_purchase_request" },
+    condition: {
+      operator: "and",
+      conditions: [
+        { field: "amount", operator: "gt", value: 1000 },
+        { field: "department", operator: "eq", value: "ops" },
+      ],
+    },
+    effect: { type: "block", message: "blocked" },
+  };
+
+  // The AI disobeys and fabricates a SIMPLE condition for the composite rule —
+  // accepting it would silently FLATTEN the AND into one conjunct.
+  const ai = fakeAiService({
+    responseContent: JSON.stringify({
+      kind: "update_rule",
+      targetEntity: "purchase_request",
+      ruleName: "composite_guard",
+      rule: {
+        name: "composite_guard",
+        label: "Composite guard",
+        trigger: { action: "create_purchase_request" },
+        condition: { field: "amount", operator: "gt", value: 2000 },
+        effect: { type: "block", message: "blocked" },
+      },
+      diff: "Raise the amount conjunct from 1000 to 2000.",
+      confidence: 0.9,
+      explanation: "Raise the composite guard amount to 2000.",
+    }),
+  });
+
+  beforeAll(() => {
+    const entityRegistry = new EntityRegistry();
+    entityRegistry.register(purchaseSchema);
+    const actionRegistry = new ActionRegistry();
+    actionRegistry.register(createPurchaseAction);
+    server = createServer(graphqlSchema, {
+      aiService: ai,
+      ontologyRegistry: createOntologyRegistry({
+        schemas: entityRegistry,
+        actions: actionRegistry,
+        rules: [compositeGuardRule],
+        states: [],
+        views: [],
+      }),
+    });
+  });
+
+  test("persists a definition-less diff-only update with the requires-code-change marker", async () => {
+    const { status, json } = await postSchemaIntent(server, {
+      prompt: "raise the composite guard amount to 2000",
+    });
+    expect(status).toBe(200);
+    const body = json as {
+      outcome: string;
+      operation?: string;
+      requiresCodeChange?: boolean;
+      proposalId?: string;
+    };
+    expect(body.outcome).toBe("proposal_draft");
+    expect(body.operation).toBe("update");
+    // Same honest classification as code-backed rules.
+    expect(body.requiresCodeChange).toBe(true);
+    const proposalId = body.proposalId;
+    expect(typeof proposalId).toBe("string");
+    if (!proposalId) throw new Error("expected a governed proposalId");
+
+    const byId = await getProposalById(server, proposalId);
+    expect(byId.status).toBe(200);
+    const changes = byId.json.data?.changes as Array<{
+      operation: string;
+      name: string;
+      definition?: unknown;
+      diff?: string;
+    }>;
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.operation).toBe("update");
+    expect(changes[0]?.name).toBe("composite_guard");
+    // No fabricated definition — the AND was never flattened into one conjunct.
+    expect(changes[0]?.definition).toBeUndefined();
+    expect(changes[0]?.diff).toBe(
+      `${REQUIRES_CODE_CHANGE_MARKER} Raise the amount conjunct from 1000 to 2000.`,
+    );
   });
 });
 
@@ -893,7 +1058,13 @@ describe("POST /api/ai/resolve-schema-intent — update_rule (code-backed)", () 
     // Honest: NO fabricated declarative definition for a code condition — the
     // human-readable diff IS the reviewable spec of the change.
     expect(changes[0]?.definition).toBeUndefined();
-    expect(changes[0]?.diff).toBe("Change the manager-approval threshold from 10000 to 20000.");
+    // The PERSISTED proposal carries the requires-code-change marker (the
+    // HTTP-only `requiresCodeChange` flag is not enough for /admin/proposals
+    // reviewers): on the change diff AND in the proposal description.
+    expect(changes[0]?.diff).toBe(
+      `${REQUIRES_CODE_CHANGE_MARKER} Change the manager-approval threshold from 10000 to 20000.`,
+    );
+    expect(String(byId.json.data?.description ?? "")).toContain(REQUIRES_CODE_CHANGE_MARKER);
   });
 });
 

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
@@ -23,6 +23,7 @@ import type {
   Actor,
   AIService,
   EntityDefinition,
+  OntologyRegistry,
   RuleDefinition,
 } from "@linchkit/core";
 import { REQUIRES_CODE_CHANGE_MARKER } from "@linchkit/core/ai";
@@ -810,6 +811,62 @@ describe("buildSchemaIntentOntology — existing rules section", () => {
     const ruleNames = (entity.rules ?? []).map((r) => r.name);
     expect(ruleNames).toContain("warn_large_amount");
     expect(ruleNames).not.toContain("manager_approval_threshold");
+  });
+
+  test("a malformed rule with no trigger never throws (rides the entity-level gate)", () => {
+    // `createOntologyRegistry` rejects trigger-less rules at construction, but
+    // `buildSchemaIntentOntology` only depends on the OntologyRegistry
+    // INTERFACE — an overlay/custom registry can surface a malformed rule at
+    // runtime, and `"action" in undefined` would throw a TypeError.
+    const malformedRule = {
+      name: "broken_rule",
+      label: "Broken rule",
+      // trigger intentionally ABSENT (undefined at runtime).
+      condition: { field: "amount", operator: "gt", value: 1 },
+      effect: { type: "warn", message: "x" },
+    } as unknown as RuleDefinition;
+    const base = {
+      listEntities: () => ["purchase_request"],
+      actionsFor: () => [createPurchaseAction],
+      describe: (name: string) =>
+        name === "purchase_request"
+          ? {
+              name: "purchase_request",
+              label: "Purchase Request",
+              fields: purchaseSchema.fields,
+              rules: [malformedRule],
+            }
+          : undefined,
+    } as unknown as OntologyRegistry;
+
+    // Site 1+2 (toSchemaIntentRule): no throw; the rule is projected with no
+    // trigger actions and is never offered for declarative rebuild.
+    const ontology = buildSchemaIntentOntology({ base, actor });
+    const entity = ontology.describeEntity("purchase_request");
+    expect(entity).toBeDefined();
+    if (!entity) throw new Error("expected entity");
+    const broken = (entity.rules ?? []).find((r) => r.name === "broken_rule");
+    expect(broken).toBeDefined();
+    expect(broken?.triggerActions).toBeUndefined();
+    expect(broken?.roundTrippable).toBe(false);
+
+    // Site 3 (visibleRules filter, permission-gated path): a trigger-less
+    // rule rides the entity-level gate instead of throwing.
+    const registry = new PermissionRegistry();
+    registry.register({
+      name: "purchase_creator",
+      label: "Purchase creator",
+      permissions: {},
+      grant: { purchase_request: { actions: { create_purchase_request: true } } },
+    });
+    const scopedActor: Actor = { type: "human", id: "user-1", groups: ["purchase_creator"] };
+    const gated = buildSchemaIntentOntology({
+      base,
+      permissionRegistry: registry,
+      actor: scopedActor,
+    });
+    const gatedEntity = gated.describeEntity("purchase_request");
+    expect((gatedEntity?.rules ?? []).map((r) => r.name)).toContain("broken_rule");
   });
 });
 

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
@@ -18,7 +18,13 @@
  */
 
 import { beforeAll, describe, expect, test } from "bun:test";
-import type { ActionDefinition, Actor, AIService, EntityDefinition } from "@linchkit/core";
+import type {
+  ActionDefinition,
+  Actor,
+  AIService,
+  EntityDefinition,
+  RuleDefinition,
+} from "@linchkit/core";
 import {
   ActionRegistry,
   createOntologyRegistry,
@@ -65,6 +71,52 @@ function buildOntology(): ReturnType<typeof createOntologyRegistry> {
     schemas: entityRegistry,
     actions: actionRegistry,
     rules: [],
+    states: [],
+    views: [],
+  });
+}
+
+// ── update_rule fixtures: an ontology that carries EXISTING rules ──
+
+const submitPurchaseAction: ActionDefinition = {
+  name: "submit_purchase_request",
+  entity: "purchase_request",
+  label: "Submit Purchase Request",
+  description: "Submit a purchase request for approval",
+  input: {},
+  policy: "unrestricted",
+};
+
+/** Declarative rule — updatable end-to-end via the resolver. */
+const warnLargeAmountRule: RuleDefinition = {
+  name: "warn_large_amount",
+  label: "Warn on large amount",
+  description: "Warn when the amount exceeds 5000",
+  trigger: { action: "create_purchase_request" },
+  condition: { field: "amount", operator: "gt", value: 5000 },
+  effect: { type: "warn", message: "Large amount" },
+};
+
+/** CODE-condition rule — the threshold lives in a TS function the AI cannot see. */
+const managerApprovalRule: RuleDefinition = {
+  name: "manager_approval_threshold",
+  label: "Manager approval threshold",
+  description: "Requires manager approval when the amount exceeds 10000",
+  trigger: { action: "submit_purchase_request" },
+  condition: (ctx) => Number((ctx.target as { amount?: number }).amount ?? 0) > 10000,
+  effect: { type: "require_approval", level: "manager" },
+};
+
+function buildOntologyWithRules(): ReturnType<typeof createOntologyRegistry> {
+  const entityRegistry = new EntityRegistry();
+  entityRegistry.register(purchaseSchema);
+  const actionRegistry = new ActionRegistry();
+  actionRegistry.register(createPurchaseAction);
+  actionRegistry.register(submitPurchaseAction);
+  return createOntologyRegistry({
+    schemas: entityRegistry,
+    actions: actionRegistry,
+    rules: [warnLargeAmountRule, managerApprovalRule],
     states: [],
     views: [],
   });
@@ -632,6 +684,250 @@ describe("POST /api/ai/resolve-schema-intent — permission scoping persists not
     // (no_entities_in_scope) — and crucially the unauthorized entity never
     // becomes a governed change.
     expect(body.outcome).toBe("no_match");
+    expect(body.proposalId).toBeUndefined();
+    const after = (await getProposals(server, "purchase_request")).json.data.total;
+    expect(after).toBe(before);
+  });
+});
+
+// ── update_rule: the ontology exposes EXISTING rules ─────────
+
+describe("buildSchemaIntentOntology — existing rules section", () => {
+  const actor: Actor = { type: "human", id: "user-1", groups: [] };
+
+  test("declarative rules expose their full condition; code rules expose kind + description only", () => {
+    const ontology = buildSchemaIntentOntology({ base: buildOntologyWithRules(), actor });
+    const entity = ontology.describeEntity("purchase_request");
+    expect(entity).toBeDefined();
+    if (!entity) throw new Error("expected entity");
+    const rules = entity.rules ?? [];
+    expect(rules.map((r) => r.name).sort()).toEqual([
+      "manager_approval_threshold",
+      "warn_large_amount",
+    ]);
+
+    const declarative = rules.find((r) => r.name === "warn_large_amount");
+    expect(declarative?.conditionKind).toBe("declarative");
+    expect(declarative?.condition).toEqual({ field: "amount", operator: "gt", value: 5000 });
+    expect(declarative?.triggerActions).toEqual(["create_purchase_request"]);
+    expect(declarative?.effectType).toBe("warn");
+
+    const code = rules.find((r) => r.name === "manager_approval_threshold");
+    expect(code?.conditionKind).toBe("code");
+    // The TS function is NEVER serialized into the snapshot.
+    expect(code?.condition).toBeUndefined();
+    expect(code?.description).toBe("Requires manager approval when the amount exceeds 10000");
+    expect(code?.triggerActions).toEqual(["submit_purchase_request"]);
+    expect(code?.effectType).toBe("require_approval");
+  });
+
+  test("action-triggered rules are hidden when the actor cannot run any of their trigger actions", () => {
+    // Grant ONLY create_purchase_request — the submit-triggered code rule must
+    // be filtered out, mirroring the actionNames permission gate.
+    const registry = new PermissionRegistry();
+    registry.register({
+      name: "purchase_creator",
+      label: "Purchase creator",
+      permissions: {},
+      grant: { purchase_request: { actions: { create_purchase_request: true } } },
+    });
+    const scopedActor: Actor = { type: "human", id: "user-1", groups: ["purchase_creator"] };
+    const ontology = buildSchemaIntentOntology({
+      base: buildOntologyWithRules(),
+      permissionRegistry: registry,
+      actor: scopedActor,
+    });
+    const entity = ontology.describeEntity("purchase_request");
+    expect(entity).toBeDefined();
+    if (!entity) throw new Error("expected entity");
+    expect(entity.actionNames).toEqual(["create_purchase_request"]);
+    const ruleNames = (entity.rules ?? []).map((r) => r.name);
+    expect(ruleNames).toContain("warn_large_amount");
+    expect(ruleNames).not.toContain("manager_approval_threshold");
+  });
+});
+
+// ── update_rule: declarative update lands as a governed update draft ──
+
+describe("POST /api/ai/resolve-schema-intent — update_rule (declarative)", () => {
+  let server: ReturnType<typeof createServer>;
+  const ai = fakeAiService({
+    responseContent: JSON.stringify({
+      kind: "update_rule",
+      targetEntity: "purchase_request",
+      ruleName: "warn_large_amount",
+      rule: {
+        name: "warn_large_amount",
+        label: "Warn on large amount",
+        description: "Warn when the amount exceeds 8000",
+        trigger: { action: "create_purchase_request" },
+        condition: { field: "amount", operator: "gt", value: 8000 },
+        effect: { type: "warn", message: "Amount exceeds 8000" },
+      },
+      diff: "Raise the warn threshold from 5000 to 8000.",
+      confidence: 0.9,
+      explanation: "Update the warn threshold to 8000.",
+    }),
+  });
+
+  beforeAll(() => {
+    server = createServer(graphqlSchema, {
+      aiService: ai,
+      ontologyRegistry: buildOntologyWithRules(),
+    });
+  });
+
+  test("returns an update draft and persists a governed update change", async () => {
+    const { status, json } = await postSchemaIntent(server, {
+      prompt: "把大额提醒阈值改成8000",
+    });
+    expect(status).toBe(200);
+    const body = json as {
+      outcome: string;
+      operation?: string;
+      ruleName?: string;
+      diffSummary?: string;
+      requiresCodeChange?: boolean;
+      proposalId?: string;
+      proposalStatus?: string;
+      proposal?: { type: string; status: string; diff: { operation: string } };
+    };
+    expect(body.outcome).toBe("proposal_draft");
+    expect(body.operation).toBe("update");
+    expect(body.ruleName).toBe("warn_large_amount");
+    expect(body.diffSummary).toBe("Raise the warn threshold from 5000 to 8000.");
+    expect(body.requiresCodeChange).toBeUndefined();
+    expect(body.proposal?.type).toBe("update_rule");
+    expect(body.proposal?.status).toBe("draft");
+    expect(body.proposal?.diff.operation).toBe("update");
+    expect(body.proposalStatus).toBe("draft");
+    const proposalId = body.proposalId;
+    expect(typeof proposalId).toBe("string");
+    if (!proposalId) throw new Error("expected a governed proposalId");
+
+    // Governed persistence — the SAME engine /api/proposals serves, with the
+    // exact update change shape (target/operation/name/definition/diff).
+    const byId = await getProposalById(server, proposalId);
+    expect(byId.status).toBe(200);
+    expect(byId.json.data?.status).toBe("draft");
+    const changes = byId.json.data?.changes as Array<{
+      target: string;
+      operation: string;
+      name: string;
+      definition?: Record<string, unknown>;
+      diff?: string;
+    }>;
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.target).toBe("rule");
+    expect(changes[0]?.operation).toBe("update");
+    expect(changes[0]?.name).toBe("warn_large_amount");
+    expect(changes[0]?.diff).toBe("Raise the warn threshold from 5000 to 8000.");
+    expect(changes[0]?.definition?.name).toBe("warn_large_amount");
+    expect(changes[0]?.definition?.condition).toEqual({
+      field: "amount",
+      operator: "gt",
+      value: 8000,
+    });
+  });
+});
+
+// ── update_rule: code-backed rule → honest diff-only update draft ──
+
+describe("POST /api/ai/resolve-schema-intent — update_rule (code-backed)", () => {
+  let server: ReturnType<typeof createServer>;
+  const ai = fakeAiService({
+    responseContent: JSON.stringify({
+      kind: "update_rule",
+      targetEntity: "purchase_request",
+      ruleName: "manager_approval_threshold",
+      // Code-backed: the AI omits `rule` and only describes the change.
+      diff: "Change the manager-approval threshold from 10000 to 20000.",
+      confidence: 0.85,
+      explanation: "把经理审批阈值改成2万。",
+    }),
+  });
+
+  beforeAll(() => {
+    server = createServer(graphqlSchema, {
+      aiService: ai,
+      ontologyRegistry: buildOntologyWithRules(),
+    });
+  });
+
+  test("persists a definition-less governed update change flagged requiresCodeChange", async () => {
+    const { status, json } = await postSchemaIntent(server, {
+      prompt: "把经理审批阈值改成2万",
+    });
+    expect(status).toBe(200);
+    const body = json as {
+      outcome: string;
+      operation?: string;
+      ruleName?: string;
+      diffSummary?: string;
+      requiresCodeChange?: boolean;
+      proposalId?: string;
+    };
+    expect(body.outcome).toBe("proposal_draft");
+    expect(body.operation).toBe("update");
+    expect(body.ruleName).toBe("manager_approval_threshold");
+    expect(body.requiresCodeChange).toBe(true);
+    expect(body.diffSummary).toBe("Change the manager-approval threshold from 10000 to 20000.");
+    const proposalId = body.proposalId;
+    expect(typeof proposalId).toBe("string");
+    if (!proposalId) throw new Error("expected a governed proposalId");
+
+    const byId = await getProposalById(server, proposalId);
+    expect(byId.status).toBe(200);
+    expect(byId.json.data?.status).toBe("draft");
+    const changes = byId.json.data?.changes as Array<{
+      target: string;
+      operation: string;
+      name: string;
+      definition?: unknown;
+      diff?: string;
+    }>;
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.target).toBe("rule");
+    expect(changes[0]?.operation).toBe("update");
+    expect(changes[0]?.name).toBe("manager_approval_threshold");
+    // Honest: NO fabricated declarative definition for a code condition — the
+    // human-readable diff IS the reviewable spec of the change.
+    expect(changes[0]?.definition).toBeUndefined();
+    expect(changes[0]?.diff).toBe("Change the manager-approval threshold from 10000 to 20000.");
+  });
+});
+
+// ── update_rule: unknown rule target persists nothing ────────
+
+describe("POST /api/ai/resolve-schema-intent — update_rule unknown rule", () => {
+  let server: ReturnType<typeof createServer>;
+  const ai = fakeAiService({
+    responseContent: JSON.stringify({
+      kind: "update_rule",
+      targetEntity: "purchase_request",
+      ruleName: "totally_made_up_rule",
+      diff: "x",
+      confidence: 0.9,
+      explanation: "x",
+    }),
+  });
+
+  beforeAll(() => {
+    server = createServer(graphqlSchema, {
+      aiService: ai,
+      ontologyRegistry: buildOntologyWithRules(),
+    });
+  });
+
+  test("a hallucinated rule name is refused → no_match, nothing persisted", async () => {
+    const before = (await getProposals(server, "purchase_request")).json.data.total;
+    const { status, json } = await postSchemaIntent(server, {
+      prompt: "update the made-up rule",
+    });
+    expect(status).toBe(200);
+    const body = json as { outcome: string; reason?: string; proposalId?: unknown };
+    expect(body.outcome).toBe("no_match");
+    expect(body.reason).toBe("unknown_rule");
     expect(body.proposalId).toBeUndefined();
     const after = (await getProposals(server, "purchase_request")).json.data.total;
     expect(after).toBe(before);

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
@@ -3,8 +3,9 @@
  *
  * The governed sibling of `POST /api/ai/resolve-intent`. Where that endpoint
  * turns an utterance into a RUNTIME DATA action proposal, this endpoint turns
- * an utterance into a METAMODEL CHANGE — a new `defineRule()` — surfaced ONLY
- * as an `add_rule` Proposal in `draft` status.
+ * an utterance into a METAMODEL CHANGE — a new `defineRule()` or an UPDATE to
+ * an existing one — surfaced ONLY as an `add_rule` / `update_rule` Proposal in
+ * `draft` status.
  *
  * It is a thin consumer of the canonical `resolveSchemaIntent()` engine from
  * `@linchkit/core/ai`:
@@ -41,6 +42,8 @@ import type {
   SchemaIntentEntity,
   SchemaIntentOntology,
   SchemaIntentOutcome,
+  SchemaIntentProposalDraft,
+  SchemaIntentRule,
 } from "@linchkit/core/ai";
 import { ProposalEngine, resolveSchemaIntent } from "@linchkit/core/ai";
 import {
@@ -109,6 +112,48 @@ export function buildSchemaIntentOntology(opts: {
     return out;
   };
 
+  // Project a registered RuleDefinition into the resolver's rule snapshot.
+  // A CODE condition (a TypeScript function) is NEVER serialized — only its
+  // kind + the rule's description are exposed, so the AI cannot pretend to
+  // edit source it cannot see. Declarative conditions are structured data
+  // and travel whole.
+  const toSchemaIntentRule = (rule: RuleDefinition): SchemaIntentRule => {
+    const isCode = typeof rule.condition === "function";
+    const triggerActions =
+      "action" in rule.trigger
+        ? Array.isArray(rule.trigger.action)
+          ? rule.trigger.action
+          : [rule.trigger.action]
+        : undefined;
+    return {
+      name: rule.name,
+      label: rule.label,
+      description: rule.description,
+      ...(triggerActions ? { triggerActions } : {}),
+      effectType: rule.effect.type,
+      conditionKind: isCode ? "code" : "declarative",
+      ...(isCode ? {} : { condition: rule.condition as SchemaIntentRule["condition"] }),
+    };
+  };
+
+  // Permission gate for rules, mirroring `actionNames`: an action-triggered
+  // rule is visible only when the actor can run at least one of its trigger
+  // actions. Rules with non-action triggers (state/event/schedule) ride on
+  // the entity-level gate, which already passed by the time this runs.
+  const visibleRules = (entityName: string, rules: RuleDefinition[]): SchemaIntentRule[] => {
+    if (!permissionRegistry) return rules.map(toSchemaIntentRule);
+    const allowedNames = new Set(allowedActions(entityName).map((a) => a.name));
+    return rules
+      .filter((rule) => {
+        if (!("action" in rule.trigger)) return true;
+        const actions = Array.isArray(rule.trigger.action)
+          ? rule.trigger.action
+          : [rule.trigger.action];
+        return actions.some((name) => allowedNames.has(name));
+      })
+      .map(toSchemaIntentRule);
+  };
+
   return {
     listEntities: () => visibleEntities(),
     describeEntity: (entityName: string): SchemaIntentEntity | undefined => {
@@ -138,6 +183,8 @@ export function buildSchemaIntentOntology(opts: {
         description: descriptor.description,
         fields,
         actionNames: allowedActions(entityName).map((a) => a.name),
+        // EXISTING rules (includes inherited) — the `update_rule` target list.
+        rules: visibleRules(entityName, descriptor.rules),
       };
     },
   };
@@ -168,10 +215,23 @@ export interface ResolveSchemaIntentResponse {
    * at persist time — always `"draft"` (never auto-submitted / approved here).
    */
   proposalStatus?: string;
+  /**
+   * Present only for `proposal_draft` — `"create"` for a new rule
+   * (`add_rule`), `"update"` for a change to an EXISTING rule (`update_rule`).
+   */
+  operation?: "create" | "update";
   ruleName?: string;
   targetEntity?: string;
   confidence?: number;
   explanation?: string;
+  /** Present only for update drafts — human-readable diff vs the existing rule. */
+  diffSummary?: string;
+  /**
+   * Present only for update drafts of CODE-condition rules. The draft carries
+   * no declarative definition (the condition is a TS function the AI cannot
+   * round-trip); a developer must apply the change in source.
+   */
+  requiresCodeChange?: boolean;
   /** Present only for `clarification`. */
   question?: string;
   bestConfidence?: number;
@@ -197,10 +257,13 @@ function toResponse(
         proposal: outcome.proposal,
         proposalId: governed?.id,
         proposalStatus: governed?.status,
+        operation: outcome.operation,
         ruleName: outcome.ruleName,
         targetEntity: outcome.targetEntity,
         confidence: outcome.confidence,
         explanation: outcome.explanation,
+        ...(outcome.diffSummary !== undefined ? { diffSummary: outcome.diffSummary } : {}),
+        ...(outcome.requiresCodeChange ? { requiresCodeChange: true } : {}),
       };
     case "clarification":
       return {
@@ -220,46 +283,58 @@ function toResponse(
 // ── Translate the resolver draft → governed Proposal ─────────
 
 /**
- * Persist a resolver-produced `add_rule` draft into the shared GOVERNED engine
- * (`packages/core/src/engine/proposal-engine.ts`) — the same instance
- * `/api/proposals` reads from — so the NL draft surfaces in the review pipeline.
+ * Persist a resolver-produced `add_rule` / `update_rule` draft into the shared
+ * GOVERNED engine (`packages/core/src/engine/proposal-engine.ts`) — the same
+ * instance `/api/proposals` reads from — so the NL draft surfaces in the
+ * review pipeline.
  *
  * The resolver runs ALL of its security validation first (prompt-injection
- * sanitize → entity allowlist → strict structural rule allowlist). By the time
- * we reach here the draft carries only a validated, typed `RuleDefinition`; we
- * translate that into a single governed `ProposalChange`
- * (`{ target: "rule", operation: "create", name, definition }`) and create the
- * proposal in `draft` status. It is NEVER submitted, approved, or applied here —
- * graduation is a separate, human-gated path.
+ * sanitize → entity allowlist → existing-rule allowlist → strict structural
+ * rule allowlist). By the time we reach here the draft carries only validated,
+ * typed values; we translate them into a single governed `ProposalChange`:
+ *
+ *  - create: `{ target: "rule", operation: "create", name, definition, diff }`
+ *  - update: `{ target: "rule", operation: "update", name, definition, diff }`
+ *    where `diff` is the human-readable summary of what changes. An update of
+ *    a CODE-condition rule carries NO definition (the resolver flags it
+ *    `requiresCodeChange` — the diff is the reviewable spec; a developer
+ *    applies it in source).
+ *
+ * The proposal lands in `draft` status. It is NEVER submitted, approved, or
+ * applied here — graduation is a separate, human-gated path.
  *
  * Returns `undefined` when the draft does not carry a usable rule definition
- * (defensive — the resolver only emits `proposal_draft` with a built rule, but
- * we never want a malformed change to reach the engine).
+ * for a definition-bearing path (defensive — the resolver only emits
+ * `proposal_draft` with a built rule, but we never want a malformed change to
+ * reach the engine).
  */
 function persistGovernedRuleDraft(opts: {
   engine: GovernedProposalEngine;
-  draft: Proposal;
-  ruleName: string;
-  targetEntity: string;
-  explanation: string;
+  outcome: SchemaIntentProposalDraft;
   reasoning: string;
   /** The actor who requested the resolution — recorded for the audit trail. */
   actor: Actor;
 }): ProposalDefinition | undefined {
-  const { engine, draft, ruleName, targetEntity, explanation, reasoning, actor } = opts;
+  const { engine, outcome, reasoning, actor } = opts;
+  const { proposal: draft, ruleName, targetEntity, explanation, operation } = outcome;
+  const diffOnly = outcome.requiresCodeChange === true;
 
   // The validated rule definition is the resolver draft's diff definition.
   // Optional-chain `diff` defensively against runtime drift in the draft shape.
-  const definition = draft.diff?.definition;
-  if (!definition || typeof definition !== "object") return undefined;
-  const ruleDefinition = definition as RuleDefinition;
+  // Code-backed updates legitimately carry no definition (diff-only).
+  const rawDefinition = draft.diff?.definition;
+  const definition =
+    rawDefinition && typeof rawDefinition === "object"
+      ? (rawDefinition as RuleDefinition)
+      : undefined;
+  if (!definition && !diffOnly) return undefined;
 
   const change: ProposalChange = {
     target: "rule",
-    operation: "create",
+    operation,
     name: ruleName,
-    definition: ruleDefinition,
-    diff: explanation,
+    ...(definition ? { definition } : {}),
+    diff: outcome.diffSummary ?? explanation,
   };
 
   return engine.createProposal({
@@ -275,7 +350,7 @@ function persistGovernedRuleDraft(opts: {
     // capability/grouping key, mirroring the PatternDetector path in
     // proposal-api.ts (capability = entity name).
     capability: targetEntity,
-    // A new business rule is an additive, minor change.
+    // Adding or updating a single business rule is a minor change.
     changeType: "minor",
     changes: [change],
   });
@@ -398,10 +473,7 @@ export function mountResolveSchemaIntentRoute(app: Elysia, options: ServerOption
     if (outcome.kind === "proposal_draft") {
       governed = persistGovernedRuleDraft({
         engine: governedEngine,
-        draft: outcome.proposal,
-        ruleName: outcome.ruleName,
-        targetEntity: outcome.targetEntity,
-        explanation: outcome.explanation,
+        outcome,
         reasoning: parsed.data.prompt,
         actor,
       });

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
@@ -27,34 +27,28 @@
  */
 
 import type {
-  ActionDefinition,
   Actor,
   AIService,
-  FieldDefinition,
-  OntologyRegistry,
-  PermissionRegistry,
   ProposalChange,
   ProposalDefinition,
   RuleDefinition,
 } from "@linchkit/core";
-import type {
-  Proposal,
-  SchemaIntentEntity,
-  SchemaIntentOntology,
-  SchemaIntentOutcome,
-  SchemaIntentProposalDraft,
-  SchemaIntentRule,
-} from "@linchkit/core/ai";
-import { ProposalEngine, resolveSchemaIntent } from "@linchkit/core/ai";
+import type { Proposal, SchemaIntentOutcome, SchemaIntentProposalDraft } from "@linchkit/core/ai";
 import {
-  checkActionPermission,
-  type ProposalEngine as GovernedProposalEngine,
-} from "@linchkit/core/server";
+  ProposalEngine,
+  REQUIRES_CODE_CHANGE_MARKER,
+  resolveSchemaIntent,
+} from "@linchkit/core/ai";
+import type { ProposalEngine as GovernedProposalEngine } from "@linchkit/core/server";
 import type { Elysia } from "elysia";
 import { z } from "zod";
 import { getSharedProposalEngine } from "../proposal-api";
 import type { ServerOptions } from "../server";
+import { buildSchemaIntentOntology } from "./ai-schema-intent-ontology";
 import { resolveActor, serviceUnavailable } from "./shared";
+
+// Re-export so existing consumers/tests keep importing from the route module.
+export { buildSchemaIntentOntology } from "./ai-schema-intent-ontology";
 
 // ── Request shape (Zod) ──────────────────────────────────────
 
@@ -67,128 +61,6 @@ const resolveSchemaIntentRequestSchema = z
     prompt: z.string().min(1, "prompt must be a non-empty string"),
   })
   .strict();
-
-// ── Permission-scoped Ontology snapshot ─────────────────────
-
-/**
- * Build the structural `SchemaIntentOntology` the resolver consumes from the
- * full `OntologyRegistry`, scoped to entities the calling actor can act on.
- *
- * An entity is exposed only when the actor can execute at least one of its
- * actions (matching the permission convention in `permission-middleware.ts`:
- * the action's `entity` is the capability name). When no `permissionRegistry`
- * is wired in (typical dev runs) we pass everything through — same permissive
- * default as `ai-resolve-intent.ts`.
- *
- * Exported for unit testing the permission gate in isolation (both
- * `listEntities` and `describeEntity` must enforce it).
- */
-export function buildSchemaIntentOntology(opts: {
-  base: OntologyRegistry;
-  permissionRegistry?: PermissionRegistry;
-  actor: Actor;
-}): SchemaIntentOntology {
-  const { base, permissionRegistry, actor } = opts;
-
-  const allowedActions = (entityName: string): ActionDefinition[] => {
-    const all = base.actionsFor(entityName);
-    if (!permissionRegistry) return all;
-    const allowed: ActionDefinition[] = [];
-    for (const action of all) {
-      const result = checkActionPermission(permissionRegistry, actor, action.entity, action.name);
-      if (result.allowed) allowed.push(action);
-    }
-    return allowed;
-  };
-
-  const visibleEntities = (): string[] => {
-    const out: string[] = [];
-    for (const name of base.listEntities()) {
-      // With no permission registry, every entity is visible. Otherwise an
-      // entity is visible only if the actor can run at least one of its
-      // actions — there is nothing to attach a rule trigger to otherwise.
-      if (!permissionRegistry || allowedActions(name).length > 0) out.push(name);
-    }
-    return out;
-  };
-
-  // Project a registered RuleDefinition into the resolver's rule snapshot.
-  // A CODE condition (a TypeScript function) is NEVER serialized — only its
-  // kind + the rule's description are exposed, so the AI cannot pretend to
-  // edit source it cannot see. Declarative conditions are structured data
-  // and travel whole.
-  const toSchemaIntentRule = (rule: RuleDefinition): SchemaIntentRule => {
-    const isCode = typeof rule.condition === "function";
-    const triggerActions =
-      "action" in rule.trigger
-        ? Array.isArray(rule.trigger.action)
-          ? rule.trigger.action
-          : [rule.trigger.action]
-        : undefined;
-    return {
-      name: rule.name,
-      label: rule.label,
-      description: rule.description,
-      ...(triggerActions ? { triggerActions } : {}),
-      effectType: rule.effect.type,
-      conditionKind: isCode ? "code" : "declarative",
-      ...(isCode ? {} : { condition: rule.condition as SchemaIntentRule["condition"] }),
-    };
-  };
-
-  // Permission gate for rules, mirroring `actionNames`: an action-triggered
-  // rule is visible only when the actor can run at least one of its trigger
-  // actions. Rules with non-action triggers (state/event/schedule) ride on
-  // the entity-level gate, which already passed by the time this runs.
-  const visibleRules = (entityName: string, rules: RuleDefinition[]): SchemaIntentRule[] => {
-    if (!permissionRegistry) return rules.map(toSchemaIntentRule);
-    const allowedNames = new Set(allowedActions(entityName).map((a) => a.name));
-    return rules
-      .filter((rule) => {
-        if (!("action" in rule.trigger)) return true;
-        const actions = Array.isArray(rule.trigger.action)
-          ? rule.trigger.action
-          : [rule.trigger.action];
-        return actions.some((name) => allowedNames.has(name));
-      })
-      .map(toSchemaIntentRule);
-  };
-
-  return {
-    listEntities: () => visibleEntities(),
-    describeEntity: (entityName: string): SchemaIntentEntity | undefined => {
-      // Enforce the SAME permission gate the visible-entity list uses. Without
-      // this, calling describeEntity() directly with an entity the actor cannot
-      // act on would leak its full description (least-privilege violation) —
-      // listEntities() filters, but describeEntity() must too.
-      if (permissionRegistry && allowedActions(entityName).length === 0) {
-        return undefined;
-      }
-      const descriptor = base.describe(entityName);
-      if (!descriptor) return undefined;
-      const fields: SchemaIntentEntity["fields"] = [];
-      for (const [name, raw] of Object.entries(descriptor.fields)) {
-        const field = raw as FieldDefinition;
-        fields.push({
-          name,
-          type: field.type,
-          required: field.required === true,
-          label: field.label,
-          description: field.description,
-        });
-      }
-      return {
-        name: descriptor.name,
-        label: descriptor.label,
-        description: descriptor.description,
-        fields,
-        actionNames: allowedActions(entityName).map((a) => a.name),
-        // EXISTING rules (includes inherited) — the `update_rule` target list.
-        rules: visibleRules(entityName, descriptor.rules),
-      };
-    },
-  };
-}
 
 // ── Wire-format response ─────────────────────────────────────
 
@@ -227,9 +99,12 @@ export interface ResolveSchemaIntentResponse {
   /** Present only for update drafts — human-readable diff vs the existing rule. */
   diffSummary?: string;
   /**
-   * Present only for update drafts of CODE-condition rules. The draft carries
-   * no declarative definition (the condition is a TS function the AI cannot
-   * round-trip); a developer must apply the change in source.
+   * Present only for diff-only update drafts (CODE-condition rules and any
+   * other non-round-trippable rule — composite condition, non-action trigger,
+   * non-declarative effect). The draft carries no declarative definition; a
+   * developer must apply the change in source. The persisted governed
+   * proposal carries the same signal as a `REQUIRES_CODE_CHANGE_MARKER`
+   * prefix on the change diff + description.
    */
   requiresCodeChange?: boolean;
   /** Present only for `clarification`. */
@@ -329,13 +204,25 @@ function persistGovernedRuleDraft(opts: {
       : undefined;
   if (!definition && !diffOnly) return undefined;
 
+  // A diff-only draft is an HONEST developer change-request: it has no
+  // definition BY DESIGN (the rule cannot be rebuilt declaratively). The
+  // `requiresCodeChange` flag exists only in the HTTP response, so the
+  // PERSISTED proposal carries a stable text marker on the change's diff and
+  // the proposal description — the fields the review UI renders — letting a
+  // reviewer in /admin/proposals distinguish it from a malformed change.
+  // (Text-only on purpose: ProposalChange has no structured extension point.)
+  const diffText = outcome.diffSummary ?? explanation;
   const change: ProposalChange = {
     target: "rule",
     operation,
     name: ruleName,
     ...(definition ? { definition } : {}),
-    diff: outcome.diffSummary ?? explanation,
+    diff: diffOnly ? `${REQUIRES_CODE_CHANGE_MARKER} ${diffText}` : diffText,
   };
+
+  const codeChangeNote = diffOnly
+    ? `\n\n${REQUIRES_CODE_CHANGE_MARKER} This update targets a rule that cannot be rebuilt declaratively; it intentionally carries no definition — a developer must apply the described change in source.`
+    : "";
 
   return engine.createProposal({
     title: explanation,
@@ -343,7 +230,7 @@ function persistGovernedRuleDraft(opts: {
     // trail, plus the requesting actor for the audit trail (governance: record
     // WHO initiated the AI resolution). The utterance is never interpolated into
     // a privileged context — this string is display/audit metadata only.
-    description: `${reasoning}\n\n(Requested by ${actor.type}:${actor.id})`,
+    description: `${reasoning}\n\n(Requested by ${actor.type}:${actor.id})${codeChangeNote}`,
     // The change originates from an AI resolution acting on the user's behalf.
     author: { type: "ai", id: "schema-intent-resolver", name: "Schema Intent Resolver" },
     // The rule attaches to its target entity — used as the governed

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-schema-intent-ontology.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-schema-intent-ontology.ts
@@ -1,0 +1,179 @@
+/**
+ * Spec 52 "说→有" — permission-scoped Ontology snapshot for the schema-intent
+ * resolver.
+ *
+ * Extracted from `ai-resolve-schema-intent.ts` so the route file stays under
+ * the repo's 500-line ceiling. This module owns the projection from the full
+ * `OntologyRegistry` into the structural `SchemaIntentOntology` the resolver
+ * consumes — including the EXISTING-rules snapshot (`update_rule` target
+ * list) and its permission gates.
+ */
+
+import type {
+  ActionDefinition,
+  Actor,
+  FieldDefinition,
+  OntologyRegistry,
+  PermissionRegistry,
+  RuleDefinition,
+} from "@linchkit/core";
+import type {
+  SchemaIntentEntity,
+  SchemaIntentOntology,
+  SchemaIntentRule,
+  SchemaIntentRuleEffect,
+} from "@linchkit/core/ai";
+import { checkActionPermission } from "@linchkit/core/server";
+
+/**
+ * Build the structural `SchemaIntentOntology` the resolver consumes from the
+ * full `OntologyRegistry`, scoped to entities the calling actor can act on.
+ *
+ * An entity is exposed only when the actor can execute at least one of its
+ * actions (matching the permission convention in `permission-middleware.ts`:
+ * the action's `entity` is the capability name). When no `permissionRegistry`
+ * is wired in (typical dev runs) we pass everything through — same permissive
+ * default as `ai-resolve-intent.ts`.
+ *
+ * Exported for unit testing the permission gate in isolation (both
+ * `listEntities` and `describeEntity` must enforce it).
+ */
+export function buildSchemaIntentOntology(opts: {
+  base: OntologyRegistry;
+  permissionRegistry?: PermissionRegistry;
+  actor: Actor;
+}): SchemaIntentOntology {
+  const { base, permissionRegistry, actor } = opts;
+
+  const allowedActions = (entityName: string): ActionDefinition[] => {
+    const all = base.actionsFor(entityName);
+    if (!permissionRegistry) return all;
+    const allowed: ActionDefinition[] = [];
+    for (const action of all) {
+      const result = checkActionPermission(permissionRegistry, actor, action.entity, action.name);
+      if (result.allowed) allowed.push(action);
+    }
+    return allowed;
+  };
+
+  const visibleEntities = (): string[] => {
+    const out: string[] = [];
+    for (const name of base.listEntities()) {
+      // With no permission registry, every entity is visible. Otherwise an
+      // entity is visible only if the actor can run at least one of its
+      // actions — there is nothing to attach a rule trigger to otherwise.
+      if (!permissionRegistry || allowedActions(name).length > 0) out.push(name);
+    }
+    return out;
+  };
+
+  // Project a registered RuleDefinition into the resolver's rule snapshot.
+  // A CODE condition (a TypeScript function) is NEVER serialized — only its
+  // kind + the rule's description are exposed, so the AI cannot pretend to
+  // edit source it cannot see. Declarative conditions are structured data
+  // and travel whole. `priority` + the declarative effect payload travel too
+  // so an update round-trip never silently resets / fabricates them, and
+  // `roundTrippable` marks whether the FULL rule can be rebuilt declaratively
+  // (the resolver takes the honest diff-only path otherwise).
+  const toSchemaIntentRule = (rule: RuleDefinition): SchemaIntentRule => {
+    const isCode = typeof rule.condition === "function";
+    const triggerActions =
+      "action" in rule.trigger
+        ? Array.isArray(rule.trigger.action)
+          ? rule.trigger.action
+          : [rule.trigger.action]
+        : undefined;
+    // Only the declarative payload fields the resolver's buildEffect consumes
+    // (message / level / setFields) — never execute_action / trigger_flow
+    // params, which are not declaratively rebuildable anyway.
+    const effect: SchemaIntentRuleEffect = { type: rule.effect.type };
+    if ("message" in rule.effect && rule.effect.message !== undefined) {
+      effect.message = rule.effect.message;
+    }
+    if ("level" in rule.effect) effect.level = rule.effect.level;
+    if ("setFields" in rule.effect) effect.setFields = rule.effect.setFields;
+    // The declarative rebuild path (buildRuleDefinition) can only express:
+    // a SINGLE-action trigger, a SIMPLE (non-composite/not) condition, and a
+    // block/warn/require_approval/enrich effect. Anything else must take the
+    // diff-only path or the rebuild would silently flatten/replace parts the
+    // user never asked to change.
+    const hasSingleActionTrigger =
+      "action" in rule.trigger && typeof rule.trigger.action === "string";
+    const hasSimpleCondition =
+      !isCode &&
+      typeof rule.condition === "object" &&
+      rule.condition !== null &&
+      "field" in rule.condition;
+    const hasDeclarativeEffect =
+      rule.effect.type === "block" ||
+      rule.effect.type === "warn" ||
+      rule.effect.type === "require_approval" ||
+      rule.effect.type === "enrich";
+    const roundTrippable = hasSingleActionTrigger && hasSimpleCondition && hasDeclarativeEffect;
+    return {
+      name: rule.name,
+      label: rule.label,
+      description: rule.description,
+      ...(triggerActions ? { triggerActions } : {}),
+      effectType: rule.effect.type,
+      effect,
+      ...(rule.priority !== undefined ? { priority: rule.priority } : {}),
+      conditionKind: isCode ? "code" : "declarative",
+      ...(isCode ? {} : { condition: rule.condition as SchemaIntentRule["condition"] }),
+      roundTrippable,
+    };
+  };
+
+  // Permission gate for rules, mirroring `actionNames`: an action-triggered
+  // rule is visible only when the actor can run at least one of its trigger
+  // actions. Rules with non-action triggers (state/event/schedule) ride on
+  // the entity-level gate, which already passed by the time this runs.
+  const visibleRules = (entityName: string, rules: RuleDefinition[]): SchemaIntentRule[] => {
+    if (!permissionRegistry) return rules.map(toSchemaIntentRule);
+    const allowedNames = new Set(allowedActions(entityName).map((a) => a.name));
+    return rules
+      .filter((rule) => {
+        if (!("action" in rule.trigger)) return true;
+        const actions = Array.isArray(rule.trigger.action)
+          ? rule.trigger.action
+          : [rule.trigger.action];
+        return actions.some((name) => allowedNames.has(name));
+      })
+      .map(toSchemaIntentRule);
+  };
+
+  return {
+    listEntities: () => visibleEntities(),
+    describeEntity: (entityName: string): SchemaIntentEntity | undefined => {
+      // Enforce the SAME permission gate the visible-entity list uses. Without
+      // this, calling describeEntity() directly with an entity the actor cannot
+      // act on would leak its full description (least-privilege violation) —
+      // listEntities() filters, but describeEntity() must too.
+      if (permissionRegistry && allowedActions(entityName).length === 0) {
+        return undefined;
+      }
+      const descriptor = base.describe(entityName);
+      if (!descriptor) return undefined;
+      const fields: SchemaIntentEntity["fields"] = [];
+      for (const [name, raw] of Object.entries(descriptor.fields)) {
+        const field = raw as FieldDefinition;
+        fields.push({
+          name,
+          type: field.type,
+          required: field.required === true,
+          label: field.label,
+          description: field.description,
+        });
+      }
+      return {
+        name: descriptor.name,
+        label: descriptor.label,
+        description: descriptor.description,
+        fields,
+        actionNames: allowedActions(entityName).map((a) => a.name),
+        // EXISTING rules (includes inherited) — the `update_rule` target list.
+        rules: visibleRules(entityName, descriptor.rules),
+      };
+    },
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-schema-intent-ontology.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-schema-intent-ontology.ts
@@ -77,8 +77,11 @@ export function buildSchemaIntentOntology(opts: {
   // (the resolver takes the honest diff-only path otherwise).
   const toSchemaIntentRule = (rule: RuleDefinition): SchemaIntentRule => {
     const isCode = typeof rule.condition === "function";
+    // `rule.trigger` is guarded everywhere it is narrowed with `in`: a
+    // malformed rule can carry an undefined/null trigger at runtime despite
+    // the static type, and `"action" in undefined` throws.
     const triggerActions =
-      "action" in rule.trigger
+      rule.trigger && "action" in rule.trigger
         ? Array.isArray(rule.trigger.action)
           ? rule.trigger.action
           : [rule.trigger.action]
@@ -97,8 +100,9 @@ export function buildSchemaIntentOntology(opts: {
     // block/warn/require_approval/enrich effect. Anything else must take the
     // diff-only path or the rebuild would silently flatten/replace parts the
     // user never asked to change.
-    const hasSingleActionTrigger =
-      "action" in rule.trigger && typeof rule.trigger.action === "string";
+    const hasSingleActionTrigger = Boolean(
+      rule.trigger && "action" in rule.trigger && typeof rule.trigger.action === "string",
+    );
     const hasSimpleCondition =
       !isCode &&
       typeof rule.condition === "object" &&
@@ -133,7 +137,9 @@ export function buildSchemaIntentOntology(opts: {
     const allowedNames = new Set(allowedActions(entityName).map((a) => a.name));
     return rules
       .filter((rule) => {
-        if (!("action" in rule.trigger)) return true;
+        // A malformed (trigger-less) rule rides the entity-level gate, same
+        // as non-action triggers — `in` on undefined/null would throw.
+        if (!rule.trigger || !("action" in rule.trigger)) return true;
         const actions = Array.isArray(rule.trigger.action)
           ? rule.trigger.action
           : [rule.trigger.action];

--- a/packages/core/__tests__/proposal-engine.test.ts
+++ b/packages/core/__tests__/proposal-engine.test.ts
@@ -178,6 +178,43 @@ describe("ProposalEngine", () => {
       expect(result.validation?.valid).toBe(false);
       expect(engine2.get(proposal.id)?.status).toBe("draft"); // stays in draft
     });
+
+    it("reports the real rule name for a diff-only update_rule proposal", () => {
+      // Diff-only updates (code-backed / non-round-trippable rules) carry NO
+      // definition — the security change record must still name the real
+      // target via the diff's explicit targetName, not "unknown".
+      const seenTargets: string[] = [];
+      const engine2 = new ProposalEngine({
+        validatorConfig: {
+          customRules: [
+            {
+              name: "capture_target",
+              validate: (change) => {
+                seenTargets.push(change.target);
+                return undefined;
+              },
+            },
+          ],
+        },
+      });
+
+      const proposal = engine2.createProposal({
+        type: "update_rule",
+        description: "Raise the manager approval threshold",
+        reasoning: "把经理审批阈值改成2万",
+        confidence: 0.85,
+        diff: {
+          target: "rule",
+          operation: "update",
+          targetName: "manager_approval_threshold",
+          summary: "Change the manager-approval threshold from 10000 to 20000.",
+        },
+      });
+
+      const result = engine2.submit(proposal.id);
+      expect(result.success).toBe(true);
+      expect(seenTargets).toEqual(["manager_approval_threshold"]);
+    });
   });
 
   // ── Lifecycle: approve ─────────────────────────────────

--- a/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from "bun:test";
 import type { AICompletionOptions, AICompletionResult, AIService } from "../../types/ai";
 import { ProposalEngine } from "../proposal-engine";
 import { resolveSchemaIntent } from "../schema-intent-resolver";
-import type { SchemaIntentOntology } from "../schema-intent-types";
+import type { SchemaIntentEntity, SchemaIntentOntology } from "../schema-intent-types";
 
 // ── Ontology fixture ─────────────────────────────────────────
 
@@ -50,6 +50,49 @@ const emptyOntology: SchemaIntentOntology = {
   listEntities: () => [],
   describeEntity: () => undefined,
 };
+
+/**
+ * Ontology whose entity carries EXISTING rules — one declarative (updatable
+ * end-to-end) and one CODE-backed (condition is a TS function the resolver
+ * must never pretend to round-trip).
+ */
+function makeOntologyWithRules(): SchemaIntentOntology {
+  const purchaseRequest: SchemaIntentEntity = {
+    name: "purchase_request",
+    label: "Purchase Request",
+    description: "A request to purchase goods or services",
+    fields: [
+      { name: "amount", type: "number", required: true, label: "Amount" },
+      { name: "department", type: "string", required: true, label: "Department" },
+      { name: "status", type: "string", required: false, label: "Status" },
+    ],
+    actionNames: ["create_purchase_request", "submit_purchase_request"],
+    rules: [
+      {
+        name: "warn_large_amount",
+        label: "Warn on large amount",
+        description: "Warn when the amount exceeds 5000",
+        triggerActions: ["create_purchase_request"],
+        effectType: "warn",
+        conditionKind: "declarative",
+        condition: { field: "amount", operator: "gt", value: 5000 },
+      },
+      {
+        name: "manager_approval_threshold",
+        label: "Manager approval threshold",
+        description: "Requires manager approval when the amount exceeds 10000",
+        triggerActions: ["submit_purchase_request"],
+        effectType: "require_approval",
+        conditionKind: "code",
+      },
+    ],
+  };
+  const byName: Record<string, SchemaIntentEntity> = { purchase_request: purchaseRequest };
+  return {
+    listEntities: () => Object.keys(byName),
+    describeEntity: (name) => byName[name],
+  };
+}
 
 // ── Fake AIService ──────────────────────────────────────────
 
@@ -584,5 +627,328 @@ describe("resolveSchemaIntent — security & degradation", () => {
     if (outcome.kind !== "no_match") throw new Error("expected no_match");
     expect(outcome.reason).toBe("ai_unavailable");
     expect(engine.size).toBe(0);
+  });
+});
+
+// ── update_rule (existing-rule update drafts) ────────────────
+
+describe("resolveSchemaIntent — update_rule proposal draft", () => {
+  it("exposes existing rules in the system prompt (declarative condition whole, code as kind only)", async () => {
+    const engine = new ProposalEngine();
+    const { service, calls } = makeFakeAi(JSON.stringify({ kind: "no_match", explanation: "x" }));
+    await resolveSchemaIntent(
+      { utterance: "change the warn threshold to 8000" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
+    // The existing-rules section is present with both rules.
+    expect(systemPrompt).toContain('"existingRules"');
+    expect(systemPrompt).toContain("warn_large_amount");
+    expect(systemPrompt).toContain("manager_approval_threshold");
+    // The declarative rule carries its full condition…
+    expect(systemPrompt).toContain('"conditionKind": "declarative"');
+    expect(systemPrompt).toContain('"value": 5000');
+    // …the code rule exposes its kind + description, never a condition body.
+    expect(systemPrompt).toContain('"conditionKind": "code"');
+  });
+
+  it("drafts a governed update_rule Proposal for a declarative rule", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          description: "Warn when the amount exceeds 8000",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 8000 },
+          effect: { type: "warn", message: "Amount exceeds 8000" },
+        },
+        diff: "Raise the warn threshold from 5000 to 8000.",
+        confidence: 0.9,
+        explanation: "Update the warn threshold to 8000.",
+      }),
+    );
+
+    const outcome = await resolveSchemaIntent(
+      { utterance: "把大额提醒阈值改成8000" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.operation).toBe("update");
+    expect(outcome.ruleName).toBe("warn_large_amount");
+    expect(outcome.targetEntity).toBe("purchase_request");
+    expect(outcome.diffSummary).toBe("Raise the warn threshold from 5000 to 8000.");
+    expect(outcome.requiresCodeChange).toBeUndefined();
+
+    const p = outcome.proposal;
+    expect(p.type).toBe("update_rule");
+    // The "never applies" guarantee: the engine stops at draft.
+    expect(p.status).toBe("draft");
+    expect(p.diff.target).toBe("rule");
+    expect(p.diff.operation).toBe("update");
+    const def = p.diff.definition as Record<string, unknown>;
+    expect(def.name).toBe("warn_large_amount");
+    expect(def.condition).toEqual({ field: "amount", operator: "gt", value: 8000 });
+    expect(engine.size).toBe(1);
+    expect(engine.list("draft").length).toBe(1);
+  });
+
+  it("pins the updated definition to the existing rule name (rename out of scope)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          // AI tries to rename — must be pinned back to the existing name.
+          name: "warn_really_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 9000 },
+          effect: { type: "warn", message: "Amount exceeds 9000" },
+        },
+        diff: "Raise the threshold to 9000.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise the warn threshold to 9000" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.ruleName).toBe("warn_large_amount");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.name).toBe("warn_large_amount");
+  });
+
+  it("drafts a diff-only update for a CODE-condition rule (no fabricated definition)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "manager_approval_threshold",
+        // No `rule` — the condition is code-backed; the AI only describes the change.
+        diff: "Change the manager-approval threshold from 10000 to 20000.",
+        confidence: 0.85,
+        explanation: "把经理审批阈值改成2万。",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "把经理审批阈值改成2万" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.operation).toBe("update");
+    expect(outcome.ruleName).toBe("manager_approval_threshold");
+    expect(outcome.requiresCodeChange).toBe(true);
+    expect(outcome.diffSummary).toBe("Change the manager-approval threshold from 10000 to 20000.");
+
+    const p = outcome.proposal;
+    expect(p.type).toBe("update_rule");
+    expect(p.status).toBe("draft");
+    expect(p.diff.operation).toBe("update");
+    // Honest: NO declarative definition is fabricated for a code condition.
+    expect(p.diff.definition).toBeUndefined();
+    expect(p.diff.summary).toBe("Change the manager-approval threshold from 10000 to 20000.");
+  });
+
+  it("ignores an AI-fabricated definition for a CODE-condition rule (diff-only draft)", async () => {
+    // Even if the AI disobeys and returns a declarative `rule` for a
+    // code-backed target, the resolver must NOT persist it as the definition.
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "manager_approval_threshold",
+        rule: {
+          name: "manager_approval_threshold",
+          label: "Manager approval threshold",
+          trigger: { action: "submit_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 20000 },
+          effect: { type: "require_approval", level: "manager" },
+        },
+        diff: "Change the threshold to 20000.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the manager approval threshold to 20000" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.requiresCodeChange).toBe(true);
+    expect(outcome.proposal.diff.definition).toBeUndefined();
+  });
+
+  it("refuses a CODE-condition update with no diff and no explanation", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "manager_approval_threshold",
+        confidence: 0.9,
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the manager approval threshold" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("no_match");
+    if (outcome.kind !== "no_match") throw new Error("expected no_match");
+    expect(outcome.reason).toBe("invalid_rule");
+    expect(engine.size).toBe(0);
+  });
+
+  it("refuses an update targeting a rule that does not exist (allowlist)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "totally_made_up_rule",
+        rule: {
+          name: "totally_made_up_rule",
+          label: "x",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 1 },
+          effect: { type: "warn", message: "x" },
+        },
+        diff: "x",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "update the made-up rule" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("no_match");
+    if (outcome.kind !== "no_match") throw new Error("expected no_match");
+    expect(outcome.reason).toBe("unknown_rule");
+    expect(engine.size).toBe(0);
+  });
+
+  it("refuses an update when the entity exposes no rules", async () => {
+    // makeOntology() has no `rules` — nothing is updatable.
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        diff: "x",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "update the warn rule" },
+      { provider: service, ontology: makeOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("no_match");
+    if (outcome.kind !== "no_match") throw new Error("expected no_match");
+    expect(outcome.reason).toBe("unknown_rule");
+    expect(engine.size).toBe(0);
+  });
+
+  it("refuses an invalid updated definition for a declarative rule", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          // Unknown field → strict structural validation must refuse.
+          condition: { field: "nonexistent", operator: "gt", value: 8000 },
+          effect: { type: "warn", message: "x" },
+        },
+        diff: "x",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the warn rule" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("no_match");
+    if (outcome.kind !== "no_match") throw new Error("expected no_match");
+    expect(outcome.reason).toBe("invalid_rule");
+    expect(engine.size).toBe(0);
+  });
+
+  it("demotes a low-confidence update_rule to clarification (no draft minted)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 8000 },
+          effect: { type: "warn", message: "x" },
+        },
+        diff: "x",
+        confidence: 0.1,
+        explanation: "unsure",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "maybe change some threshold" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("clarification");
+    expect(engine.size).toBe(0);
+  });
+
+  it("add_rule drafts still report operation create (regression)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "add_rule",
+        targetEntity: "purchase_request",
+        rule: {
+          name: "block_overlimit_amount",
+          label: "Block over-limit amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 10000 },
+          effect: { type: "block", message: "too big" },
+        },
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "Block purchase requests over 10000" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.operation).toBe("create");
+    expect(outcome.proposal.diff.operation).toBe("create");
+    expect(outcome.diffSummary).toBeUndefined();
+    expect(outcome.requiresCodeChange).toBeUndefined();
   });
 });

--- a/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
@@ -1500,13 +1500,18 @@ describe("resolveSchemaIntent — prompt serializes the full sanitized rule snap
           triggerActions: ["create_purchase_request"],
           effectType: "warn",
           // Runtime-malformed payloads despite the static types: non-string
-          // effect fields would crash sanitizeText (.replace), and a null
-          // nested condition would crash the `in` narrowing.
+          // effect fields would crash sanitizeText (.replace), a null nested
+          // condition would crash the `in` narrowing, and a SimpleCondition
+          // missing its `field` would crash sanitizeText on undefined.
           effect: { type: undefined, message: 123, level: { x: 1 } } as never,
           conditionKind: "declarative",
           condition: {
             operator: "and",
-            conditions: [{ field: "amount", operator: "gt", value: 1 }, null],
+            conditions: [
+              { field: "amount", operator: "gt", value: 1 },
+              null,
+              { operator: "gt", value: 5000 },
+            ],
           } as never,
           roundTrippable: false,
         },

--- a/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
@@ -1200,6 +1200,98 @@ describe("resolveSchemaIntent — update round-trip preservation (priority/effec
     const def = outcome.proposal.diff.definition as Record<string, unknown>;
     expect(def.effect).toEqual({ type: "block", message: "Blocked over 5000" });
   });
+
+  it("merges the back-fill even when the AI OMITS the effect type (partial payload)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 5000 },
+          // Partial payload: `type` omitted entirely. The merge must still
+          // run (omitted type = same type), not skip and fail validation.
+          effect: { message: "New warning message" },
+        },
+        diff: "Change the warning message.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the warning text" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.effect).toEqual({ type: "warn", message: "New warning message" });
+  });
+
+  it("a partial setFields update preserves the snapshot's untouched keys (deep merge)", async () => {
+    // Local enrich fixture: the snapshot sets TWO fields; the AI returns only
+    // the one it changed. A shallow merge would REPLACE the whole map and
+    // silently drop `department` — the one-level deep merge must keep it.
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      fields: [
+        { name: "amount", type: "number", required: true },
+        { name: "department", type: "string", required: true },
+        { name: "status", type: "string", required: false },
+      ],
+      actionNames: ["create_purchase_request"],
+      rules: [
+        {
+          name: "enrich_defaults",
+          label: "Enrich defaults",
+          triggerActions: ["create_purchase_request"],
+          effectType: "enrich",
+          effect: { type: "enrich", setFields: { status: "draft", department: "ops" } },
+          conditionKind: "declarative",
+          condition: { field: "amount", operator: "gt", value: 0 },
+          roundTrippable: true,
+        },
+      ],
+    };
+    const ontology: SchemaIntentOntology = {
+      listEntities: () => ["purchase_request"],
+      describeEntity: () => entity,
+    };
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "enrich_defaults",
+        rule: {
+          name: "enrich_defaults",
+          label: "Enrich defaults",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 0 },
+          // Only the CHANGED key — `department` is never mentioned.
+          effect: { type: "enrich", setFields: { status: "approved" } },
+        },
+        diff: "Change the default status to approved.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the default status to approved" },
+      { provider: service, ontology, proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.effect).toEqual({
+      type: "enrich",
+      setFields: { status: "approved", department: "ops" },
+    });
+  });
 });
 
 describe("resolveSchemaIntent — non-round-trippable rules take the diff-only path", () => {
@@ -1346,5 +1438,93 @@ describe("resolveSchemaIntent — prompt serializes the full sanitized rule snap
     expect(systemPrompt).not.toContain("\\u0007");
     // The composite condition itself is serialized whole (structured data).
     expect(systemPrompt).toContain('"operator": "and"');
+  });
+
+  it("sanitizes string leaves nested inside OBJECT values (setFields / condition values)", async () => {
+    const engine = new ProposalEngine();
+    const { service, calls } = makeFakeAi(JSON.stringify({ kind: "no_match", explanation: "x" }));
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      fields: [{ name: "amount", type: "number", required: true }],
+      actionNames: ["create_purchase_request"],
+      rules: [
+        {
+          name: "enrich_meta",
+          label: "Enrich meta",
+          triggerActions: ["create_purchase_request"],
+          effectType: "enrich",
+          // An OBJECT setFields value + a nested-object condition value — a
+          // prior NL-drafted rule is a prompt-injection carrier, so string
+          // leaves inside plain objects (keys included) must be stripped too.
+          effect: {
+            type: "enrich",
+            setFields: { meta: { note: "inj\u0007ected", "ba\u0007d_key": ["de\u0000ep"] } },
+          },
+          conditionKind: "declarative",
+          condition: { field: "amount", operator: "eq", value: { nested: "va\u0000lue" } },
+          roundTrippable: false,
+        },
+      ],
+    };
+    const ontology: SchemaIntentOntology = {
+      listEntities: () => ["purchase_request"],
+      describeEntity: () => entity,
+    };
+    await resolveSchemaIntent(
+      { utterance: "change the enrich rule" },
+      { provider: service, ontology, proposalEngine: engine },
+    );
+    const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
+    expect(systemPrompt).toContain('"note": "injected"');
+    expect(systemPrompt).toContain('"bad_key"');
+    expect(systemPrompt).toContain('"deep"');
+    expect(systemPrompt).toContain('"nested": "value"');
+    expect(systemPrompt).not.toContain("\\u0000");
+    expect(systemPrompt).not.toContain("\\u0007");
+  });
+
+  it("never throws on a malformed rule snapshot (null nested condition, non-string effect fields)", async () => {
+    const engine = new ProposalEngine();
+    const { service, calls } = makeFakeAi(JSON.stringify({ kind: "no_match", explanation: "x" }));
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      fields: [{ name: "amount", type: "number", required: true }],
+      actionNames: ["create_purchase_request"],
+      rules: [
+        {
+          name: "broken_rule",
+          label: "Broken rule",
+          triggerActions: ["create_purchase_request"],
+          effectType: "warn",
+          // Runtime-malformed payloads despite the static types: non-string
+          // effect fields would crash sanitizeText (.replace), and a null
+          // nested condition would crash the `in` narrowing.
+          effect: { type: undefined, message: 123, level: { x: 1 } } as never,
+          conditionKind: "declarative",
+          condition: {
+            operator: "and",
+            conditions: [{ field: "amount", operator: "gt", value: 1 }, null],
+          } as never,
+          roundTrippable: false,
+        },
+      ],
+    };
+    const ontology: SchemaIntentOntology = {
+      listEntities: () => ["purchase_request"],
+      describeEntity: () => entity,
+    };
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the broken rule" },
+      { provider: service, ontology, proposalEngine: engine },
+    );
+    // The pipeline survives: the prompt is built (the AI got called) and the
+    // canned no_match reply flows through instead of an exception path.
+    expect(outcome.kind).toBe("no_match");
+    expect(calls.length).toBe(1);
+    const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
+    expect(systemPrompt).toContain("broken_rule");
+    // Non-string effect fields are guarded: type falls back to "", non-string
+    // message/level are omitted rather than serialized raw.
+    expect(systemPrompt).not.toContain('"message": 123');
   });
 });

--- a/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
@@ -760,6 +760,9 @@ describe("resolveSchemaIntent — update_rule proposal draft", () => {
     expect(p.diff.operation).toBe("update");
     // Honest: NO declarative definition is fabricated for a code condition.
     expect(p.diff.definition).toBeUndefined();
+    // The diff still names the real rule explicitly so downstream security
+    // change records never fall through to "unknown".
+    expect(p.diff.targetName).toBe("manager_approval_threshold");
     expect(p.diff.summary).toBe("Change the manager-approval threshold from 10000 to 20000.");
   });
 
@@ -1526,5 +1529,44 @@ describe("resolveSchemaIntent — prompt serializes the full sanitized rule snap
     // Non-string effect fields are guarded: type falls back to "", non-string
     // message/level are omitted rather than serialized raw.
     expect(systemPrompt).not.toContain('"message": 123');
+  });
+
+  it("never throws on a malformed composite condition (conditions: null)", async () => {
+    const engine = new ProposalEngine();
+    const { service, calls } = makeFakeAi(JSON.stringify({ kind: "no_match", explanation: "x" }));
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      fields: [{ name: "amount", type: "number", required: true }],
+      actionNames: ["create_purchase_request"],
+      rules: [
+        {
+          name: "broken_composite",
+          label: "Broken composite",
+          triggerActions: ["create_purchase_request"],
+          effectType: "warn",
+          effect: { type: "warn", message: "x" },
+          conditionKind: "declarative",
+          // Runtime-malformed composite despite the static type: it passes
+          // the `"conditions" in cond` narrowing but `.map` would throw on a
+          // null `conditions` array.
+          condition: { operator: "and", conditions: null } as never,
+          roundTrippable: false,
+        },
+      ],
+    };
+    const ontology: SchemaIntentOntology = {
+      listEntities: () => ["purchase_request"],
+      describeEntity: () => entity,
+    };
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the broken composite rule" },
+      { provider: service, ontology, proposalEngine: engine },
+    );
+    // Prompt building survives — the malformed composite is serialized as-is
+    // instead of crashing the resolver.
+    expect(outcome.kind).toBe("no_match");
+    expect(calls.length).toBe(1);
+    const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
+    expect(systemPrompt).toContain("broken_composite");
   });
 });

--- a/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
@@ -923,6 +923,62 @@ describe("resolveSchemaIntent — update_rule proposal draft", () => {
     expect(engine.size).toBe(0);
   });
 
+  it("re-pins the governed name to the EXISTING registered name after build normalization", async () => {
+    // A registered rule whose name is NOT canonical snake_case: the builder's
+    // normalizeRuleName would lowercase it, so without the post-build re-pin
+    // the governed change would name a rule that does not exist.
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      fields: [{ name: "amount", type: "number", required: true }],
+      actionNames: ["create_purchase_request"],
+      rules: [
+        {
+          name: "warnBig",
+          label: "Warn big",
+          triggerActions: ["create_purchase_request"],
+          effectType: "warn",
+          effect: { type: "warn", message: "big" },
+          conditionKind: "declarative",
+          condition: { field: "amount", operator: "gt", value: 5000 },
+          roundTrippable: true,
+        },
+      ],
+    };
+    const ontology: SchemaIntentOntology = {
+      listEntities: () => ["purchase_request"],
+      describeEntity: () => entity,
+    };
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warnBig",
+        rule: {
+          name: "warnBig",
+          label: "Warn big",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 8000 },
+          effect: { type: "warn", message: "big" },
+        },
+        diff: "Raise to 8000.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise warnBig to 8000" },
+      { provider: service, ontology, proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.ruleName).toBe("warnBig");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    // Normalization would have produced "warnbig" — the re-pin restores the
+    // registered name so the governed update targets the real rule.
+    expect(def.name).toBe("warnBig");
+  });
+
   it("add_rule drafts still report operation create (regression)", async () => {
     const engine = new ProposalEngine();
     const { service } = makeFakeAi(
@@ -950,5 +1006,345 @@ describe("resolveSchemaIntent — update_rule proposal draft", () => {
     expect(outcome.proposal.diff.operation).toBe("create");
     expect(outcome.diffSummary).toBeUndefined();
     expect(outcome.requiresCodeChange).toBeUndefined();
+  });
+});
+
+// ── update_rule: round-trip preservation + non-round-trippable rules ──
+
+/**
+ * Ontology whose entity carries the snapshots the new review-integrity paths
+ * need: a fully-snapshotted declarative rule (priority + effect payload), a
+ * composite-condition rule and a schedule-triggered rule (both
+ * `roundTrippable: false` — the declarative rebuild cannot express them).
+ */
+function makeRoundTripOntology(): SchemaIntentOntology {
+  const purchaseRequest: SchemaIntentEntity = {
+    name: "purchase_request",
+    label: "Purchase Request",
+    fields: [
+      { name: "amount", type: "number", required: true, label: "Amount" },
+      { name: "department", type: "string", required: true, label: "Department" },
+    ],
+    actionNames: ["create_purchase_request", "submit_purchase_request"],
+    rules: [
+      {
+        name: "warn_large_amount",
+        label: "Warn on large amount",
+        description: "Warn when the amount exceeds 5000",
+        triggerActions: ["create_purchase_request"],
+        effectType: "warn",
+        effect: { type: "warn", message: "Original warning message" },
+        priority: 30,
+        conditionKind: "declarative",
+        condition: { field: "amount", operator: "gt", value: 5000 },
+        roundTrippable: true,
+      },
+      {
+        name: "composite_guard",
+        label: "Composite guard",
+        description: "Block large ops purchases",
+        triggerActions: ["create_purchase_request"],
+        effectType: "block",
+        effect: { type: "block", message: "blocked" },
+        conditionKind: "declarative",
+        condition: {
+          operator: "and",
+          conditions: [
+            { field: "amount", operator: "gt", value: 1000 },
+            { field: "department", operator: "eq", value: "ops" },
+          ],
+        },
+        roundTrippable: false,
+      },
+      {
+        name: "schedule_warn_stale",
+        label: "Warn stale requests",
+        description: "Scheduled warning for stale requests",
+        // No triggerActions — schedule trigger.
+        effectType: "warn",
+        effect: { type: "warn", message: "stale" },
+        conditionKind: "declarative",
+        condition: { field: "amount", operator: "gt", value: 0 },
+        roundTrippable: false,
+      },
+    ],
+  };
+  const byName: Record<string, SchemaIntentEntity> = { purchase_request: purchaseRequest };
+  return {
+    listEntities: () => Object.keys(byName),
+    describeEntity: (name) => byName[name],
+  };
+}
+
+describe("resolveSchemaIntent — update round-trip preservation (priority/effect)", () => {
+  it("back-fills priority and the effect message from the existing rule when the AI omits them", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 8000 },
+          // Same effect type, message OMITTED — must NOT be fabricated; the
+          // existing message survives. `priority` omitted — must not reset.
+          effect: { type: "warn" },
+        },
+        diff: "Raise the warn threshold from 5000 to 8000.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise the warn threshold to 8000" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.condition).toEqual({ field: "amount", operator: "gt", value: 8000 });
+    // Issue under test: only the threshold changed — priority and the effect
+    // message are preserved verbatim, matching the human-readable diff.
+    expect(def.priority).toBe(30);
+    expect(def.effect).toEqual({ type: "warn", message: "Original warning message" });
+  });
+
+  it("uses the existing effect verbatim when the AI omits the effect entirely", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 9000 },
+          // No effect at all — back-filled from the snapshot.
+        },
+        diff: "Raise the threshold to 9000.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise the warn threshold to 9000" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.effect).toEqual({ type: "warn", message: "Original warning message" });
+  });
+
+  it("AI-changed effect fields win over the back-fill (same effect type)", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 5000 },
+          effect: { type: "warn", message: "New warning message" },
+        },
+        diff: "Change the warning message.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the warning text" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.effect).toEqual({ type: "warn", message: "New warning message" });
+  });
+
+  it("a deliberate effect-TYPE change is passed through unmerged and fully validated", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 5000 },
+          // warn → block: a deliberate change; the old warn message must NOT
+          // leak into the new effect via the merge.
+          effect: { type: "block", message: "Blocked over 5000" },
+        },
+        diff: "Escalate the warn to a hard block.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "make it a hard block" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.effect).toEqual({ type: "block", message: "Blocked over 5000" });
+  });
+});
+
+describe("resolveSchemaIntent — non-round-trippable rules take the diff-only path", () => {
+  it("a composite-condition rule update never rebuilds declaratively (no flattened conjuncts)", async () => {
+    const engine = new ProposalEngine();
+    // The AI disobeys and fabricates a SIMPLE condition for the composite
+    // rule — the resolver must take the honest diff-only path regardless.
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "composite_guard",
+        rule: {
+          name: "composite_guard",
+          label: "Composite guard",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 2000 },
+          effect: { type: "block", message: "blocked" },
+        },
+        diff: "Raise the amount conjunct from 1000 to 2000.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise the composite guard amount to 2000" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.operation).toBe("update");
+    expect(outcome.requiresCodeChange).toBe(true);
+    expect(outcome.diffSummary).toBe("Raise the amount conjunct from 1000 to 2000.");
+    // No definition — a declarative rebuild would have FLATTENED the AND.
+    expect(outcome.proposal.diff.definition).toBeUndefined();
+  });
+
+  it("a non-action-trigger (schedule) rule update never rebuilds declaratively", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "schedule_warn_stale",
+        rule: {
+          name: "schedule_warn_stale",
+          label: "Warn stale requests",
+          // The builder could only emit an ACTION trigger — accepting this
+          // would silently swap the trigger kind.
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 10 },
+          effect: { type: "warn", message: "stale" },
+        },
+        diff: "Raise the stale threshold to 10.",
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise the stale warning threshold to 10" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.requiresCodeChange).toBe(true);
+    expect(outcome.proposal.diff.definition).toBeUndefined();
+    expect(outcome.proposal.diff.summary).toBe("Raise the stale threshold to 10.");
+  });
+
+  it("a non-round-trippable update with no diff and no explanation is refused", async () => {
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "composite_guard",
+        confidence: 0.9,
+      }),
+    );
+    const outcome = await resolveSchemaIntent(
+      { utterance: "change the composite guard" },
+      { provider: service, ontology: makeRoundTripOntology(), proposalEngine: engine },
+    );
+    expect(outcome.kind).toBe("no_match");
+    if (outcome.kind !== "no_match") throw new Error("expected no_match");
+    expect(outcome.reason).toBe("invalid_rule");
+    expect(engine.size).toBe(0);
+  });
+});
+
+// ── Prompt snapshot: priority/effect serialization + condition sanitization ──
+
+describe("resolveSchemaIntent — prompt serializes the full sanitized rule snapshot", () => {
+  it("serializes priority, the effect payload, and roundTrippable; sanitizes condition/effect strings", async () => {
+    const engine = new ProposalEngine();
+    const { service, calls } = makeFakeAi(JSON.stringify({ kind: "no_match", explanation: "x" }));
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      fields: [
+        { name: "amount", type: "number", required: true },
+        { name: "department", type: "string", required: true },
+      ],
+      actionNames: ["create_purchase_request"],
+      rules: [
+        {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          triggerActions: ["create_purchase_request"],
+          effectType: "warn",
+          // Control characters in the effect message and the condition value —
+          // a prior NL-drafted rule is a carrier into future prompts; both
+          // must be stripped like labels/descriptions are.
+          effect: { type: "warn", message: "warn\u0007message" },
+          priority: 30,
+          conditionKind: "declarative",
+          condition: {
+            operator: "and",
+            conditions: [
+              { field: "amount", operator: "gt", value: 5000 },
+              { field: "department", operator: "eq", value: "bad\u0000dept" },
+            ],
+          },
+          roundTrippable: false,
+        },
+      ],
+    };
+    const ontology: SchemaIntentOntology = {
+      listEntities: () => ["purchase_request"],
+      describeEntity: () => entity,
+    };
+    await resolveSchemaIntent(
+      { utterance: "change the warn threshold" },
+      { provider: service, ontology, proposalEngine: engine },
+    );
+    const systemPrompt = calls[0]?.messages.find((m) => m.role === "system")?.content ?? "";
+    // Priority + full effect payload reach the AI so it can round-trip them.
+    expect(systemPrompt).toContain('"priority": 30');
+    expect(systemPrompt).toContain('"roundTrippable": false');
+    // String leaves are sanitized — control characters are stripped, never
+    // serialized (JSON.stringify would emit \u0000 / \u0007 escapes).
+    expect(systemPrompt).toContain('"message": "warnmessage"');
+    expect(systemPrompt).toContain('"value": "baddept"');
+    expect(systemPrompt).not.toContain("\\u0000");
+    expect(systemPrompt).not.toContain("\\u0007");
+    // The composite condition itself is serialized whole (structured data).
+    expect(systemPrompt).toContain('"operator": "and"');
   });
 });

--- a/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-resolver.test.ts
@@ -652,6 +652,42 @@ describe("resolveSchemaIntent — update_rule proposal draft", () => {
     expect(systemPrompt).toContain('"conditionKind": "code"');
   });
 
+  it("back-fills an omitted trigger from the existing rule on update", async () => {
+    // LLMs frequently omit fields they treat as "unchanged". Without the
+    // back-fill, buildTrigger(undefined) fails and the whole update surfaces
+    // as no_match("invalid_rule").
+    const engine = new ProposalEngine();
+    const { service } = makeFakeAi(
+      JSON.stringify({
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "warn_large_amount",
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          description: "Warn when the amount exceeds 8000",
+          // trigger intentionally omitted — must back-fill from the snapshot.
+          condition: { field: "amount", operator: "gt", value: 8000 },
+          effect: { type: "warn", message: "Amount exceeds 8000" },
+        },
+        diff: "Raise the warn threshold from 5000 to 8000.",
+        confidence: 0.9,
+        explanation: "Update the warn threshold to 8000.",
+      }),
+    );
+
+    const outcome = await resolveSchemaIntent(
+      { utterance: "raise the warn threshold to 8000" },
+      { provider: service, ontology: makeOntologyWithRules(), proposalEngine: engine },
+    );
+
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const def = outcome.proposal.diff.definition as Record<string, unknown>;
+    expect(def.trigger).toEqual({ action: "create_purchase_request" });
+    expect(def.condition).toEqual({ field: "amount", operator: "gt", value: 8000 });
+  });
+
   it("drafts a governed update_rule Proposal for a declarative rule", async () => {
     const engine = new ProposalEngine();
     const { service } = makeFakeAi(

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -241,6 +241,7 @@ export type {
   SchemaIntentOutcome,
   SchemaIntentProposalDraft,
   SchemaIntentResolverOptions,
+  SchemaIntentRule,
 } from "./schema-intent-types";
 // Usage Meter (Spec 36 M2+)
 export type {

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -229,6 +229,7 @@ export type {
   SchemaIntentMessages,
 } from "./schema-intent-resolver";
 export {
+  REQUIRES_CODE_CHANGE_MARKER,
   resolveSchemaIntent,
   SCHEMA_INTENT_MESSAGES,
   SCHEMA_INTENT_MIN_CONFIDENCE,
@@ -242,6 +243,7 @@ export type {
   SchemaIntentProposalDraft,
   SchemaIntentResolverOptions,
   SchemaIntentRule,
+  SchemaIntentRuleEffect,
 } from "./schema-intent-types";
 // Usage Meter (Spec 36 M2+)
 export type {

--- a/packages/core/src/ai/proposal-code-generator.ts
+++ b/packages/core/src/ai/proposal-code-generator.ts
@@ -37,6 +37,11 @@ const typeGuidance: Record<ProposalType, string> = {
     "Include: name, label, description, priority, trigger (action), condition, effect.",
     "Effect types: block, enrich, validate.",
   ].join("\n"),
+  update_rule: [
+    "Update an EXISTING RuleDefinition (defineRule()) in place.",
+    "Keep the rule's name unchanged; modify only what the proposal diff describes.",
+    "Emit the FULL updated definition: name, label, description, priority, trigger, condition, effect.",
+  ].join("\n"),
   add_automation: [
     "Generate an EventHandlerDefinition for reactive event handling.",
     "Include: name, description, listen (event type), handler function.",

--- a/packages/core/src/ai/proposal-engine.ts
+++ b/packages/core/src/ai/proposal-engine.ts
@@ -62,6 +62,12 @@ export interface ProposalDiff {
   operation: "create" | "update";
   /** The generated definition (for create/update) */
   definition?: RuleDefinition | EventHandlerDefinition | Record<string, unknown>;
+  /**
+   * Name of the EXISTING definition an update targets. Carried explicitly
+   * because diff-only updates (non-round-trippable rules) intentionally have
+   * no `definition` to read the name from.
+   */
+  targetName?: string;
   /** Human-readable summary of the change */
   summary: string;
 }
@@ -486,11 +492,14 @@ export class ProposalEngine {
       add_default: "modify_schema",
     };
 
-    const targetName = proposal.diff.definition
-      ? "name" in (proposal.diff.definition as Record<string, unknown>)
-        ? String((proposal.diff.definition as Record<string, unknown>).name)
-        : "unknown"
-      : "unknown";
+    // Prefer the definition's own name; diff-only updates carry no
+    // definition, so fall back to the diff's explicit target name before
+    // giving up — the security record should name the real rule.
+    const definition = proposal.diff.definition as Record<string, unknown> | undefined;
+    const targetName =
+      definition && "name" in definition
+        ? String(definition.name)
+        : (proposal.diff.targetName ?? "unknown");
 
     return [
       {

--- a/packages/core/src/ai/proposal-engine.ts
+++ b/packages/core/src/ai/proposal-engine.ts
@@ -31,7 +31,12 @@ import { validateProposalExtended } from "./proposal-validator-extended";
 
 // ── Proposal types ───────────────────────────────────────
 
-export type ProposalType = "add_rule" | "add_automation" | "modify_schema" | "add_default";
+export type ProposalType =
+  | "add_rule"
+  | "update_rule"
+  | "add_automation"
+  | "modify_schema"
+  | "add_default";
 
 export type AIProposalStatus =
   | "draft"
@@ -475,6 +480,7 @@ export class ProposalEngine {
   private toSecurityChanges(proposal: Proposal): SecurityProposalChange[] {
     const typeMapping: Record<ProposalType, SecurityProposalChange["type"]> = {
       add_rule: "create_rule",
+      update_rule: "modify_rule",
       add_automation: "create_flow",
       modify_schema: "modify_schema",
       add_default: "modify_schema",

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -17,10 +17,11 @@
  *    embedded inside catalog string fields.
  */
 
+import type { CompositeCondition, DeclarativeCondition, SimpleCondition } from "../types/rule";
 // Reuse the intent resolver's tolerant JSON extractor — same parser, no
 // second implementation to keep in sync.
 import { extractJsonCandidate } from "./intent-prompt";
-import type { SchemaIntentEntity } from "./schema-intent-types";
+import type { SchemaIntentEntity, SchemaIntentRuleEffect } from "./schema-intent-types";
 
 // ── System prompt builder ────────────────────────────────────
 
@@ -28,6 +29,55 @@ import type { SchemaIntentEntity } from "./schema-intent-types";
 function sanitizeText(value: string): string {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional control-character removal
   return value.replace(/[\x00-\x08\x0B-\x1F\x7F]/g, "");
+}
+
+/** Sanitize string leaves of an arbitrary value (scalars / arrays). */
+function sanitizeStringLeaves(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeText(value);
+  if (Array.isArray(value)) return value.map(sanitizeStringLeaves);
+  return value;
+}
+
+/**
+ * Recursively sanitize the string leaves of a declarative condition before it
+ * is serialized into the prompt. Condition values can carry user-dictated
+ * text (a prior NL-drafted rule is a carrier into future prompts), so they
+ * get the same control-character stripping as labels/descriptions.
+ */
+function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
+  // Structural narrowing: composite carries `conditions`, not carries `condition`.
+  if ("conditions" in cond) {
+    return { operator: cond.operator, conditions: cond.conditions.map(sanitizeCondition) };
+  }
+  if ("condition" in cond) {
+    // Input is Simple | Composite, so the sanitized output is too.
+    return {
+      operator: "not",
+      condition: sanitizeCondition(cond.condition) as SimpleCondition | CompositeCondition,
+    };
+  }
+  return {
+    field: sanitizeText(cond.field),
+    operator: cond.operator,
+    ...(cond.value !== undefined ? { value: sanitizeStringLeaves(cond.value) } : {}),
+  };
+}
+
+/** Sanitize the string fields of an existing rule's effect payload. */
+function sanitizeEffect(effect: SchemaIntentRuleEffect): SchemaIntentRuleEffect {
+  let setFields: Record<string, unknown> | undefined;
+  if (effect.setFields) {
+    setFields = {};
+    for (const [key, value] of Object.entries(effect.setFields)) {
+      setFields[sanitizeText(key)] = sanitizeStringLeaves(value);
+    }
+  }
+  return {
+    type: sanitizeText(effect.type),
+    ...(effect.message !== undefined ? { message: sanitizeText(effect.message) } : {}),
+    ...(effect.level !== undefined ? { level: sanitizeText(effect.level) } : {}),
+    ...(setFields ? { setFields } : {}),
+  };
 }
 
 /**
@@ -60,8 +110,15 @@ export function buildSchemaIntentSystemPrompt(
       description: r.description ? sanitizeText(r.description) : undefined,
       triggerActions: r.triggerActions,
       effectType: r.effectType,
+      // Full sanitized effect payload + priority so an update can keep
+      // unchanged fields IDENTICAL instead of fabricating replacements.
+      ...(r.effect ? { effect: sanitizeEffect(r.effect) } : {}),
+      ...(r.priority !== undefined ? { priority: r.priority } : {}),
       conditionKind: r.conditionKind,
-      condition: r.condition,
+      // Condition string leaves get the same control-character stripping as
+      // labels/descriptions (prior NL-drafted rules are a prompt carrier).
+      condition: r.condition ? sanitizeCondition(r.condition) : undefined,
+      ...(r.roundTrippable !== undefined ? { roundTrippable: r.roundTrippable } : {}),
     })),
   }));
   const catalogJson = JSON.stringify(safe, null, 2);
@@ -121,14 +178,17 @@ B) The user wants to CHANGE an EXISTING rule (the request clearly refers to one 
      "explanation": "<one short sentence for the review card, in the user's language>"
    }
 
-   - If the existing rule's \`conditionKind\` is "declarative": return the FULL updated
-     definition in \`rule\` (keep everything you are not changing identical to the
-     existing rule, including its name).
-   - If the existing rule's \`conditionKind\` is "code": its condition is a TypeScript
-     function you CANNOT see or edit. OMIT \`rule\` entirely — return only \`ruleName\`
-     and a precise \`diff\` describing the intended change (e.g. the new threshold);
-     a developer will apply it in source. NEVER invent a declarative condition for
-     a code-backed rule.
+   - If the existing rule's \`conditionKind\` is "declarative" AND its \`roundTrippable\`
+     is not false: return the FULL updated definition in \`rule\`. Keep everything you
+     are not changing IDENTICAL to the existing rule — its name, \`priority\`, and the
+     \`effect\` payload (message / level / setFields) are all provided in
+     \`existingRules\`; copy them verbatim unless the user asked to change them.
+   - If the existing rule's \`conditionKind\` is "code" OR its \`roundTrippable\` is
+     false: the rule cannot be faithfully rebuilt from what you can see (a code
+     condition, a composite condition, a non-action trigger, or a non-declarative
+     effect). OMIT \`rule\` entirely — return only \`ruleName\` and a precise \`diff\`
+     describing the intended change (e.g. the new threshold); a developer will apply
+     it in source. NEVER invent a replacement definition for such a rule.
 
 C) Ambiguous / low confidence — ASK A CLARIFYING QUESTION:
    {

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -130,11 +130,17 @@ export function buildSchemaIntentSystemPrompt(
     // are structured data (safe to serialize); code conditions expose their
     // description only (conditionKind: "code"), never function source.
     existingRules: (e.rules ?? []).map((r) => ({
-      name: r.name,
+      // Identifiers are sanitized too: by convention they carry no control
+      // characters, but a malicious overlay / custom OntologyRegistry could
+      // craft them, and prior NL-drafted rules are a prompt carrier —
+      // defence-in-depth is cheap here.
+      name: typeof r.name === "string" ? sanitizeText(r.name) : "",
       label: r.label ? sanitizeText(r.label) : undefined,
       description: r.description ? sanitizeText(r.description) : undefined,
-      triggerActions: r.triggerActions,
-      effectType: r.effectType,
+      triggerActions: Array.isArray(r.triggerActions)
+        ? r.triggerActions.map((a) => (typeof a === "string" ? sanitizeText(a) : ""))
+        : r.triggerActions,
+      effectType: typeof r.effectType === "string" ? sanitizeText(r.effectType) : r.effectType,
       // Full sanitized effect payload + priority so an update can keep
       // unchanged fields IDENTICAL instead of fabricating replacements.
       ...(r.effect ? { effect: sanitizeEffect(r.effect) } : {}),

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -59,6 +59,10 @@ function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
   if (!cond || typeof cond !== "object") return cond;
   // Structural narrowing: composite carries `conditions`, not carries `condition`.
   if ("conditions" in cond) {
+    // Defensive: a malformed composite can carry a non-array `conditions`
+    // (e.g. null) at runtime despite the static type — `.map` would throw,
+    // so the value is returned untouched like other malformed shapes.
+    if (!Array.isArray(cond.conditions)) return cond;
     return { operator: cond.operator, conditions: cond.conditions.map(sanitizeCondition) };
   }
   if ("condition" in cond) {

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -51,6 +51,18 @@ export function buildSchemaIntentSystemPrompt(
       description: f.description ? sanitizeText(f.description) : undefined,
     })),
     actions: e.actionNames,
+    // EXISTING rules — the `update_rule` target list. Declarative conditions
+    // are structured data (safe to serialize); code conditions expose their
+    // description only (conditionKind: "code"), never function source.
+    existingRules: (e.rules ?? []).map((r) => ({
+      name: r.name,
+      label: r.label ? sanitizeText(r.label) : undefined,
+      description: r.description ? sanitizeText(r.description) : undefined,
+      triggerActions: r.triggerActions,
+      effectType: r.effectType,
+      conditionKind: r.conditionKind,
+      condition: r.condition,
+    })),
   }));
   const catalogJson = JSON.stringify(safe, null, 2);
 
@@ -97,14 +109,35 @@ A) A rule you can confidently draft:
      - require_approval: { "type": "require_approval", "level": "<approver level>", "message": "<optional>" }
      - enrich:           { "type": "enrich", "setFields": { "<field>": <value> } }
 
-B) Ambiguous / low confidence — ASK A CLARIFYING QUESTION:
+B) The user wants to CHANGE an EXISTING rule (the request clearly refers to one of the
+   entity's \`existingRules\` by name, label, or description):
+   {
+     "kind": "update_rule",
+     "targetEntity": "<entity name from the catalog above>",
+     "ruleName": "<the EXISTING rule's name from existingRules — never invent one>",
+     "rule": { <the FULL UPDATED rule definition, same shape as in (A)> },
+     "diff": "<one short human-readable sentence describing exactly what changes vs the existing rule>",
+     "confidence": <number in [0, 1]>,
+     "explanation": "<one short sentence for the review card, in the user's language>"
+   }
+
+   - If the existing rule's \`conditionKind\` is "declarative": return the FULL updated
+     definition in \`rule\` (keep everything you are not changing identical to the
+     existing rule, including its name).
+   - If the existing rule's \`conditionKind\` is "code": its condition is a TypeScript
+     function you CANNOT see or edit. OMIT \`rule\` entirely — return only \`ruleName\`
+     and a precise \`diff\` describing the intended change (e.g. the new threshold);
+     a developer will apply it in source. NEVER invent a declarative condition for
+     a code-backed rule.
+
+C) Ambiguous / low confidence — ASK A CLARIFYING QUESTION:
    {
      "kind": "clarification",
      "question": "<plain-language question to the user>",
      "confidence": <best confidence considered, < ${minConfidence}>
    }
 
-C) No rule fits (off-topic, or the request is about creating an entity/field/view
+D) No rule fits (off-topic, or the request is about creating an entity/field/view
    rather than a rule, which is out of scope here):
    {
      "kind": "no_match",
@@ -119,8 +152,11 @@ Rules:
  4. Pick \`kind: "add_rule"\` ONLY for a genuine business rule (a validation, a guard, an
     approval gate, an auto-fill). If the user is asking to create a new entity, field, or view,
     return \`kind: "no_match"\` — that is out of scope for this resolver.
- 5. Pick \`kind: "clarification"\` when overall confidence is below ${minConfidence}.
- 6. Return STRICT JSON only — no prose outside the JSON, no Markdown fences.
+ 5. Pick \`kind: "update_rule"\` ONLY when the request clearly targets one of the entity's
+    \`existingRules\`; \`ruleName\` MUST be that rule's exact name. Renaming or deleting a rule
+    is out of scope — return \`kind: "no_match"\` for those.
+ 6. Pick \`kind: "clarification"\` when overall confidence is below ${minConfidence}.
+ 7. Return STRICT JSON only — no prose outside the JSON, no Markdown fences.
 `;
 }
 
@@ -139,9 +175,13 @@ export interface ParsedRuleShape {
 
 /** Parsed (but not yet reconciled) AI response. */
 export interface ParsedSchemaIntent {
-  kind: "add_rule" | "clarification" | "no_match";
+  kind: "add_rule" | "update_rule" | "clarification" | "no_match";
   targetEntity?: string;
   rule?: ParsedRuleShape;
+  /** `update_rule` only — the EXISTING rule's name (validated downstream). */
+  ruleName?: string;
+  /** `update_rule` only — human-readable diff summary vs the existing rule. */
+  diff?: string;
   confidence?: number;
   explanation?: string;
   question?: string;
@@ -171,6 +211,8 @@ export function parseSchemaIntentResponse(raw: string): ParsedSchemaIntent | nul
     kind,
     targetEntity: typeof rec.targetEntity === "string" ? rec.targetEntity : undefined,
     rule: rec.rule && typeof rec.rule === "object" ? (rec.rule as ParsedRuleShape) : undefined,
+    ruleName: typeof rec.ruleName === "string" ? rec.ruleName : undefined,
+    diff: typeof rec.diff === "string" ? rec.diff : undefined,
     confidence: typeof rec.confidence === "number" ? rec.confidence : undefined,
     explanation: typeof rec.explanation === "string" ? rec.explanation : undefined,
     question: typeof rec.question === "string" ? rec.question : undefined,
@@ -180,7 +222,12 @@ export function parseSchemaIntentResponse(raw: string): ParsedSchemaIntent | nul
 /** Infer the discriminant, tolerating a missing `kind` field. */
 function inferKind(rec: Record<string, unknown>): ParsedSchemaIntent["kind"] | null {
   const declared = rec.kind;
-  if (declared === "add_rule" || declared === "clarification" || declared === "no_match") {
+  if (
+    declared === "add_rule" ||
+    declared === "update_rule" ||
+    declared === "clarification" ||
+    declared === "no_match"
+  ) {
     return declared;
   }
   if (declared !== undefined) return null; // unknown kind → malformed

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -31,10 +31,19 @@ function sanitizeText(value: string): string {
   return value.replace(/[\x00-\x08\x0B-\x1F\x7F]/g, "");
 }
 
-/** Sanitize string leaves of an arbitrary value (scalars / arrays). */
+/** Sanitize string leaves of an arbitrary value (scalars / arrays / plain objects). */
 function sanitizeStringLeaves(value: unknown): unknown {
   if (typeof value === "string") return sanitizeText(value);
   if (Array.isArray(value)) return value.map(sanitizeStringLeaves);
+  if (value && typeof value === "object") {
+    // Recurse into plain-object values (e.g. an enrich setFields value or a
+    // nested condition value) so no string leaf reaches the prompt raw. A
+    // FRESH object is built from own enumerable entries only — keys are
+    // sanitized too, and nothing from the prototype chain travels.
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [sanitizeText(key), sanitizeStringLeaves(entry)]),
+    );
+  }
   return value;
 }
 
@@ -45,6 +54,9 @@ function sanitizeStringLeaves(value: unknown): unknown {
  * get the same control-character stripping as labels/descriptions.
  */
 function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
+  // Defensive: a malformed registered rule can carry a null / non-object
+  // condition at runtime despite the static type — `in` would throw on it.
+  if (!cond || typeof cond !== "object") return cond;
   // Structural narrowing: composite carries `conditions`, not carries `condition`.
   if ("conditions" in cond) {
     return { operator: cond.operator, conditions: cond.conditions.map(sanitizeCondition) };
@@ -63,19 +75,25 @@ function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
   };
 }
 
-/** Sanitize the string fields of an existing rule's effect payload. */
+/**
+ * Sanitize the string fields of an existing rule's effect payload. Each leaf
+ * is typeof-guarded: a malformed registered rule can carry non-string values
+ * at runtime despite the static type, and `sanitizeText` would throw on them
+ * (`.replace` is string-only) — non-string message/level are omitted, a
+ * non-string type falls back to "".
+ */
 function sanitizeEffect(effect: SchemaIntentRuleEffect): SchemaIntentRuleEffect {
   let setFields: Record<string, unknown> | undefined;
-  if (effect.setFields) {
+  if (effect.setFields && typeof effect.setFields === "object") {
     setFields = {};
     for (const [key, value] of Object.entries(effect.setFields)) {
       setFields[sanitizeText(key)] = sanitizeStringLeaves(value);
     }
   }
   return {
-    type: sanitizeText(effect.type),
-    ...(effect.message !== undefined ? { message: sanitizeText(effect.message) } : {}),
-    ...(effect.level !== undefined ? { level: sanitizeText(effect.level) } : {}),
+    type: typeof effect.type === "string" ? sanitizeText(effect.type) : "",
+    ...(typeof effect.message === "string" ? { message: sanitizeText(effect.message) } : {}),
+    ...(typeof effect.level === "string" ? { level: sanitizeText(effect.level) } : {}),
     ...(setFields ? { setFields } : {}),
   };
 }

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -53,6 +53,18 @@ function sanitizeStringLeaves(value: unknown): unknown {
  * text (a prior NL-drafted rule is a carrier into future prompts), so they
  * get the same control-character stripping as labels/descriptions.
  */
+/**
+ * Sanitize an operator leaf while preserving its declared literal type.
+ * Statically operators are enum-constrained (the non-string branch is
+ * impossible), but a malformed runtime snapshot could carry an arbitrary
+ * value — the `unknown` hop applies the runtime guard without tsc collapsing
+ * the literal type to `never`.
+ */
+function sanitizeOperator<T>(operator: T): T {
+  const raw: unknown = operator;
+  return (typeof raw === "string" ? sanitizeText(raw) : operator) as T;
+}
+
 function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
   // Defensive: a malformed registered rule can carry a null / non-object
   // condition at runtime despite the static type — `in` would throw on it.
@@ -63,7 +75,14 @@ function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
     // (e.g. null) at runtime despite the static type — `.map` would throw,
     // so the value is returned untouched like other malformed shapes.
     if (!Array.isArray(cond.conditions)) return cond;
-    return { operator: cond.operator, conditions: cond.conditions.map(sanitizeCondition) };
+    return {
+      // Operators are enum-constrained by the types, but a malformed snapshot
+      // could carry an arbitrary string — sanitize like the other leaves. The
+      // `unknown` hop avoids tsc collapsing the literal type to `never` in the
+      // (statically impossible, runtime-possible) non-string branch.
+      operator: sanitizeOperator(cond.operator),
+      conditions: cond.conditions.map(sanitizeCondition),
+    };
   }
   if ("condition" in cond) {
     // Input is Simple | Composite, so the sanitized output is too.
@@ -77,7 +96,7 @@ function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
     // through overlays / a custom OntologyRegistry) must not throw inside
     // sanitizeText's .replace — same never-throws contract as the guards above.
     field: typeof cond.field === "string" ? sanitizeText(cond.field) : "",
-    operator: cond.operator,
+    operator: sanitizeOperator(cond.operator),
     ...(cond.value !== undefined ? { value: sanitizeStringLeaves(cond.value) } : {}),
   };
 }

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -73,7 +73,10 @@ function sanitizeCondition(cond: DeclarativeCondition): DeclarativeCondition {
     };
   }
   return {
-    field: sanitizeText(cond.field),
+    // typeof guard: a malformed SimpleCondition without a `field` (possible
+    // through overlays / a custom OntologyRegistry) must not throw inside
+    // sanitizeText's .replace — same never-throws contract as the guards above.
+    field: typeof cond.field === "string" ? sanitizeText(cond.field) : "",
     operator: cond.operator,
     ...(cond.value !== undefined ? { value: sanitizeStringLeaves(cond.value) } : {}),
   };

--- a/packages/core/src/ai/schema-intent-resolver.ts
+++ b/packages/core/src/ai/schema-intent-resolver.ts
@@ -348,7 +348,9 @@ function draftRuleUpdate(opts: {
       confidence,
       // NO definition — the rule cannot be rebuilt faithfully from what the
       // AI saw. The summary is the reviewable spec of the change.
-      diff: { target: "rule", operation: "update", summary },
+      // `targetName` carries the rule name so downstream security change
+      // records still report the real target without a definition.
+      diff: { target: "rule", operation: "update", targetName: existing.name, summary },
     });
     return {
       kind: "proposal_draft",
@@ -386,7 +388,13 @@ function draftRuleUpdate(opts: {
     description: explanation,
     reasoning: utterance,
     confidence,
-    diff: { target: "rule", operation: "update", definition: ruleDef, summary },
+    diff: {
+      target: "rule",
+      operation: "update",
+      definition: ruleDef,
+      targetName: existing.name,
+      summary,
+    },
   });
   return {
     kind: "proposal_draft",

--- a/packages/core/src/ai/schema-intent-resolver.ts
+++ b/packages/core/src/ai/schema-intent-resolver.ts
@@ -45,12 +45,13 @@
  */
 
 import type { AIMessage, AIService } from "../types/ai";
+import type { RuleDefinition } from "../types/rule";
 import { sanitizePrompt } from "./prompt-sanitizer";
 import type { ProposalEngine } from "./proposal-engine";
 // System prompt + response parser live in a sibling module (mirrors the
 // intent-resolver.ts / intent-prompt.ts split) so this file stays focused on
 // the pipeline + the governed Proposal mint.
-import type { ParsedSchemaIntent } from "./schema-intent-prompt";
+import type { ParsedRuleShape, ParsedSchemaIntent } from "./schema-intent-prompt";
 import { buildSchemaIntentSystemPrompt, parseSchemaIntentResponse } from "./schema-intent-prompt";
 // Rule reconciliation + validation lives in a sibling module so this file
 // stays under the 500-line ceiling and focuses on the pipeline.
@@ -60,12 +61,25 @@ import type {
   SchemaIntentOntology,
   SchemaIntentOutcome,
   SchemaIntentResolverOptions,
+  SchemaIntentRule,
 } from "./schema-intent-types";
 
 // ── Tunable defaults ─────────────────────────────────────────
 
 /** Confidence floor below which we ask a clarifying question instead of drafting. */
 export const SCHEMA_INTENT_MIN_CONFIDENCE = 0.4;
+
+/**
+ * Stable text marker persisted on a governed diff-only update draft (the
+ * `requiresCodeChange` outcome flag exists only in the HTTP response — the
+ * PERSISTED proposal needs its own signal). Callers prepend it to the
+ * governed change's `diff` / proposal description so a reviewer reading
+ * /admin/proposals can distinguish an HONEST developer change-request
+ * (no definition BY DESIGN) from a malformed change. Text-only on purpose:
+ * `ProposalChange` has no structured extension point and core types are not
+ * widened for this.
+ */
+export const REQUIRES_CODE_CHANGE_MARKER = "[requires-code-change]";
 
 // ── User-facing messages (centralized for future i18n) ───────
 
@@ -282,14 +296,19 @@ export async function resolveSchemaIntent(
  *
  *  1. The targeted rule MUST exist on the entity's rule list (allowlist —
  *     the AI cannot update a rule it was not shown).
- *  2. Declarative rule: the AI's FULL updated definition passes the same
- *     strict structural validation as add_rule (`buildRuleDefinition`), and
- *     the name is pinned to the existing rule's name (renames out of scope).
- *  3. CODE-condition rule: the condition is a TS function the AI cannot
- *     round-trip, so no declarative definition is fabricated. The draft
- *     carries ONLY the human-readable diff summary and is flagged
+ *  2. Round-trippable declarative rule: the AI's FULL updated definition
+ *     passes the same strict structural validation as add_rule
+ *     (`buildRuleDefinition`); `priority` and unchanged effect fields are
+ *     BACK-FILLED from the existing snapshot (robust against AI omissions),
+ *     and the name is pinned to the existing rule's name (renames out of
+ *     scope) — re-pinned AFTER the build so name normalization can never
+ *     diverge from the registered name.
+ *  3. Non-round-trippable rule (CODE condition, composite/not condition,
+ *     non-action trigger, non-declarative effect): the builder cannot rebuild
+ *     the definition faithfully, so none is fabricated. The draft carries
+ *     ONLY the human-readable diff summary and is flagged
  *     `requiresCodeChange` — an honest, governed change REQUEST a developer
- *     applies in source. A code update without any diff/explanation is
+ *     applies in source. Such an update without any diff/explanation is
  *     refused (there is nothing actionable to review).
  */
 function draftRuleUpdate(opts: {
@@ -311,8 +330,13 @@ function draftRuleUpdate(opts: {
     parsed.explanation?.trim() || `Update rule "${existing.name}" on ${entity.name}`;
   const diffSummary = parsed.diff?.trim() || "";
 
-  if (existing.conditionKind === "code") {
-    // Honest path for code-backed rules: no fabricated declarative condition.
+  // Diff-only path: code-backed rules AND declarative rules the builder
+  // cannot rebuild faithfully (composite/not conditions, non-action triggers,
+  // non-declarative effects — `roundTrippable: false` in the snapshot). A
+  // declarative rebuild of those would silently flatten conjuncts or swap the
+  // trigger kind, so the honest draft carries the diff summary only.
+  if (existing.conditionKind === "code" || existing.roundTrippable === false) {
+    // Honest path for non-round-trippable rules: no fabricated definition.
     const summary = diffSummary || parsed.explanation?.trim() || "";
     if (!summary) {
       return noMatch("invalid_rule", SCHEMA_INTENT_MESSAGES.missingUpdateDiff);
@@ -322,8 +346,8 @@ function draftRuleUpdate(opts: {
       description: explanation,
       reasoning: utterance,
       confidence,
-      // NO definition — the rule's condition lives in TypeScript source the
-      // AI never saw. The summary is the reviewable spec of the change.
+      // NO definition — the rule cannot be rebuilt faithfully from what the
+      // AI saw. The summary is the reviewable spec of the change.
       diff: { target: "rule", operation: "update", summary },
     });
     return {
@@ -341,32 +365,72 @@ function draftRuleUpdate(opts: {
 
   // Declarative rule — same strict structural validation as add_rule. The
   // name is pinned to the EXISTING rule's name before validation so an
-  // AI-side rename (out of scope) can never slip through as a new rule.
+  // AI-side rename (out of scope) can never slip through as a new rule, and
+  // `priority` / unchanged effect fields are back-filled from the existing
+  // snapshot so an AI omission never silently resets them.
   const built = buildRuleDefinition(
-    parsed.rule ? { ...parsed.rule, name: existing.name } : undefined,
+    parsed.rule ? backfillUpdateShape(parsed.rule, existing) : undefined,
     entity,
   );
   if (!built.ok) {
     return noMatch("invalid_rule", SCHEMA_INTENT_MESSAGES.invalidRule(built.reason));
   }
+  // Re-pin AFTER the build: `normalizeRuleName` runs inside the builder, so a
+  // registered name that normalization would alter could otherwise make the
+  // built name diverge from the pinned target. The governed change must name
+  // the EXISTING rule, always.
+  const ruleDef: RuleDefinition = { ...built.rule, name: existing.name };
   const summary = diffSummary || explanation;
   const proposal = engine.createProposal({
     type: "update_rule",
     description: explanation,
     reasoning: utterance,
     confidence,
-    diff: { target: "rule", operation: "update", definition: built.rule, summary },
+    diff: { target: "rule", operation: "update", definition: ruleDef, summary },
   });
   return {
     kind: "proposal_draft",
     proposal,
     operation: "update",
-    ruleName: built.rule.name,
+    ruleName: ruleDef.name,
     targetEntity: entity.name,
     confidence,
     explanation,
     diffSummary: summary,
   };
+}
+
+/**
+ * Merge the AI-returned update shape with the EXISTING rule snapshot so
+ * fields the AI did not change survive verbatim (review-integrity — the
+ * persisted definition must match the human-readable diff):
+ *
+ *  - `name` is pinned to the existing rule's name (renames out of scope).
+ *  - `priority` falls back to the existing value when the AI omits it.
+ *  - Effect payload: when the AI omits the effect entirely the existing
+ *    payload is used verbatim; when the AI keeps the SAME effect type,
+ *    payload fields it omitted (message / level / setFields) are back-filled
+ *    from the snapshot. A deliberate effect-type change is passed through
+ *    unmerged (the builder validates its required fields).
+ */
+function backfillUpdateShape(rule: ParsedRuleShape, existing: SchemaIntentRule): ParsedRuleShape {
+  const out: ParsedRuleShape = { ...rule, name: existing.name };
+  if (out.priority === undefined && existing.priority !== undefined) {
+    out.priority = existing.priority;
+  }
+  const existingEffect = existing.effect;
+  if (existingEffect) {
+    if (out.effect === undefined) {
+      out.effect = { ...existingEffect };
+    } else if (
+      typeof out.effect === "object" &&
+      out.effect !== null &&
+      (out.effect as Record<string, unknown>).type === existingEffect.type
+    ) {
+      out.effect = { ...existingEffect, ...(out.effect as Record<string, unknown>) };
+    }
+  }
+  return out;
 }
 
 // ── Catalog construction ─────────────────────────────────────

--- a/packages/core/src/ai/schema-intent-resolver.ts
+++ b/packages/core/src/ai/schema-intent-resolver.ts
@@ -1,23 +1,30 @@
 /**
- * Schema Intent Resolver — NL utterance → governed `add_rule` ProposalDraft
- * (Spec 52 "说→有", first slice).
+ * Schema Intent Resolver — NL utterance → governed `add_rule` / `update_rule`
+ * ProposalDraft (Spec 52 "说→有").
  *
  * The bridge that was missing: the existing `resolveIntent()` (intent-
  * resolver.ts) turns an utterance into a RUNTIME DATA action; this resolver
- * turns an utterance into a METAMODEL CHANGE — specifically a new
- * `defineRule()` — surfaced ONLY as a governed `add_rule` Proposal in
+ * turns an utterance into a METAMODEL CHANGE — a new `defineRule()` or an
+ * UPDATE to an existing one — surfaced ONLY as a governed Proposal in
  * `draft` status via `ProposalEngine.createProposal()`.
  *
  * Pipeline (mirrors intent-resolver.ts):
- *   sanitize → build entity catalog → build focused system prompt
- *   → call provider → parse + validate AI JSON → reconcile rule against
- *   the ontology → `ProposalEngine.createProposal({ type: 'add_rule', ... })`
- *   → emit `SchemaIntentOutcome` (proposal_draft / clarification / no_match).
+ *   sanitize → build entity catalog (incl. existing rules) → build focused
+ *   system prompt → call provider → parse + validate AI JSON → reconcile rule
+ *   against the ontology → `ProposalEngine.createProposal(...)` → emit
+ *   `SchemaIntentOutcome` (proposal_draft / clarification / no_match).
  *
  * Hard rules (repo principle "AI Never Modifies Production Directly"):
  *  - NEVER submits, approves, or applies. The returned Proposal is ALWAYS
  *    `draft`. Graduating it (draft→pending→…) is a separate, human-gated path.
- *  - `add_rule` ONLY. Entity/field/view creation is out of scope (later slices).
+ *  - `add_rule` + `update_rule` ONLY (no rename/delete). Entity/field/view
+ *    creation is out of scope (later slices).
+ *  - An `update_rule` may only target a rule present in the ontology's rule
+ *    list (allowlist — the AI cannot update what it cannot see). A rule whose
+ *    condition is CODE (a TS function) cannot be round-tripped declaratively;
+ *    its update draft carries NO definition, only a human-readable diff
+ *    summary, and is flagged `requiresCodeChange` (honest change REQUEST —
+ *    a developer applies it in source).
  *  - Single-shot. No multi-turn, no history replay.
  *
  * Security posture (this is a prompt-injection-sensitive path):
@@ -43,6 +50,7 @@ import type { ProposalEngine } from "./proposal-engine";
 // System prompt + response parser live in a sibling module (mirrors the
 // intent-resolver.ts / intent-prompt.ts split) so this file stays focused on
 // the pipeline + the governed Proposal mint.
+import type { ParsedSchemaIntent } from "./schema-intent-prompt";
 import { buildSchemaIntentSystemPrompt, parseSchemaIntentResponse } from "./schema-intent-prompt";
 // Rule reconciliation + validation lives in a sibling module so this file
 // stays under the 500-line ceiling and focuses on the pipeline.
@@ -70,7 +78,10 @@ export const SCHEMA_INTENT_MESSAGES = {
   aiMalformedResponse: "AI returned malformed JSON; could not parse the schema intent.",
   noRuleDrafted: "AI did not propose a rule for this request.",
   unknownEntity: (entity: string) => `AI proposed a rule for unknown entity "${entity}".`,
+  unknownRule: (rule: string, entity: string) =>
+    `AI proposed an update to unknown rule "${rule}" on entity "${entity}".`,
   invalidRule: (detail: string) => `AI proposed an invalid rule: ${detail}.`,
+  missingUpdateDiff: "AI proposed a code-backed rule update without describing what should change",
   lowConfidenceClarification:
     "I'm not sure what rule you want. Could you describe the condition and what should happen when it matches?",
 } as const;
@@ -198,7 +209,7 @@ export async function resolveSchemaIntent(
     };
   }
 
-  // kind === "add_rule"
+  // kind === "add_rule" | "update_rule"
   const confidence = clampConfidence(parsed.confidence);
   if (confidence < minConfidence) {
     return {
@@ -213,6 +224,17 @@ export async function resolveSchemaIntent(
   const entity = catalogIndex.get(targetEntity);
   if (!entity) {
     return noMatch("unknown_entity", SCHEMA_INTENT_MESSAGES.unknownEntity(targetEntity));
+  }
+
+  // Step 8/9 — update path: reconcile against an EXISTING rule, then mint.
+  if (parsed.kind === "update_rule") {
+    return draftRuleUpdate({
+      parsed,
+      entity,
+      confidence,
+      utterance,
+      engine: deps.proposalEngine,
+    });
   }
 
   // Step 8 — Validate + reconcile the proposed rule against the entity.
@@ -244,10 +266,106 @@ export async function resolveSchemaIntent(
   return {
     kind: "proposal_draft",
     proposal,
+    operation: "create",
     ruleName: ruleDef.name,
     targetEntity: entity.name,
     confidence,
     explanation,
+  };
+}
+
+// ── Update-rule reconciliation + mint ────────────────────────
+
+/**
+ * Turn a parsed `update_rule` intent into a governed `update_rule` draft
+ * Proposal, mirroring the add_rule path's validation discipline:
+ *
+ *  1. The targeted rule MUST exist on the entity's rule list (allowlist —
+ *     the AI cannot update a rule it was not shown).
+ *  2. Declarative rule: the AI's FULL updated definition passes the same
+ *     strict structural validation as add_rule (`buildRuleDefinition`), and
+ *     the name is pinned to the existing rule's name (renames out of scope).
+ *  3. CODE-condition rule: the condition is a TS function the AI cannot
+ *     round-trip, so no declarative definition is fabricated. The draft
+ *     carries ONLY the human-readable diff summary and is flagged
+ *     `requiresCodeChange` — an honest, governed change REQUEST a developer
+ *     applies in source. A code update without any diff/explanation is
+ *     refused (there is nothing actionable to review).
+ */
+function draftRuleUpdate(opts: {
+  parsed: ParsedSchemaIntent;
+  entity: SchemaIntentEntity;
+  confidence: number;
+  utterance: string;
+  engine: ProposalEngine;
+}): SchemaIntentOutcome {
+  const { parsed, entity, confidence, utterance, engine } = opts;
+
+  const targetRuleName = (parsed.ruleName ?? "").trim();
+  const existing = (entity.rules ?? []).find((rule) => rule.name === targetRuleName);
+  if (!existing) {
+    return noMatch("unknown_rule", SCHEMA_INTENT_MESSAGES.unknownRule(targetRuleName, entity.name));
+  }
+
+  const explanation =
+    parsed.explanation?.trim() || `Update rule "${existing.name}" on ${entity.name}`;
+  const diffSummary = parsed.diff?.trim() || "";
+
+  if (existing.conditionKind === "code") {
+    // Honest path for code-backed rules: no fabricated declarative condition.
+    const summary = diffSummary || parsed.explanation?.trim() || "";
+    if (!summary) {
+      return noMatch("invalid_rule", SCHEMA_INTENT_MESSAGES.missingUpdateDiff);
+    }
+    const proposal = engine.createProposal({
+      type: "update_rule",
+      description: explanation,
+      reasoning: utterance,
+      confidence,
+      // NO definition — the rule's condition lives in TypeScript source the
+      // AI never saw. The summary is the reviewable spec of the change.
+      diff: { target: "rule", operation: "update", summary },
+    });
+    return {
+      kind: "proposal_draft",
+      proposal,
+      operation: "update",
+      ruleName: existing.name,
+      targetEntity: entity.name,
+      confidence,
+      explanation,
+      diffSummary: summary,
+      requiresCodeChange: true,
+    };
+  }
+
+  // Declarative rule — same strict structural validation as add_rule. The
+  // name is pinned to the EXISTING rule's name before validation so an
+  // AI-side rename (out of scope) can never slip through as a new rule.
+  const built = buildRuleDefinition(
+    parsed.rule ? { ...parsed.rule, name: existing.name } : undefined,
+    entity,
+  );
+  if (!built.ok) {
+    return noMatch("invalid_rule", SCHEMA_INTENT_MESSAGES.invalidRule(built.reason));
+  }
+  const summary = diffSummary || explanation;
+  const proposal = engine.createProposal({
+    type: "update_rule",
+    description: explanation,
+    reasoning: utterance,
+    confidence,
+    diff: { target: "rule", operation: "update", definition: built.rule, summary },
+  });
+  return {
+    kind: "proposal_draft",
+    proposal,
+    operation: "update",
+    ruleName: built.rule.name,
+    targetEntity: entity.name,
+    confidence,
+    explanation,
+    diffSummary: summary,
   };
 }
 

--- a/packages/core/src/ai/schema-intent-resolver.ts
+++ b/packages/core/src/ai/schema-intent-resolver.ts
@@ -1,6 +1,6 @@
 /**
  * Schema Intent Resolver — NL utterance → governed `add_rule` / `update_rule`
- * ProposalDraft (Spec 52 "说→有").
+ * ProposalDraft (Spec 52 "describe-to-exists").
  *
  * The bridge that was missing: the existing `resolveIntent()` (intent-
  * resolver.ts) turns an utterance into a RUNTIME DATA action; this resolver

--- a/packages/core/src/ai/schema-intent-resolver.ts
+++ b/packages/core/src/ai/schema-intent-resolver.ts
@@ -415,6 +415,9 @@ function draftRuleUpdate(opts: {
  *
  *  - `name` is pinned to the existing rule's name (renames out of scope).
  *  - `priority` falls back to the existing value when the AI omits it.
+ *  - `trigger` falls back to the existing rule's trigger actions when the AI
+ *    omits it (LLMs frequently leave out fields they treat as "unchanged",
+ *    and `buildTrigger(undefined)` would otherwise fail the whole update).
  *  - Effect payload: when the AI omits the effect entirely the existing
  *    payload is used verbatim; when the AI keeps the SAME effect type (or
  *    omits `type` — a partial update payload), payload fields it omitted
@@ -428,6 +431,16 @@ function backfillUpdateShape(rule: ParsedRuleShape, existing: SchemaIntentRule):
   const out: ParsedRuleShape = { ...rule, name: existing.name };
   if (out.priority === undefined && existing.priority !== undefined) {
     out.priority = existing.priority;
+  }
+  if (
+    out.trigger === undefined &&
+    Array.isArray(existing.triggerActions) &&
+    existing.triggerActions.length > 0
+  ) {
+    out.trigger = {
+      action:
+        existing.triggerActions.length === 1 ? existing.triggerActions[0] : existing.triggerActions,
+    };
   }
   const existingEffect = existing.effect;
   if (existingEffect) {

--- a/packages/core/src/ai/schema-intent-resolver.ts
+++ b/packages/core/src/ai/schema-intent-resolver.ts
@@ -408,10 +408,13 @@ function draftRuleUpdate(opts: {
  *  - `name` is pinned to the existing rule's name (renames out of scope).
  *  - `priority` falls back to the existing value when the AI omits it.
  *  - Effect payload: when the AI omits the effect entirely the existing
- *    payload is used verbatim; when the AI keeps the SAME effect type,
- *    payload fields it omitted (message / level / setFields) are back-filled
- *    from the snapshot. A deliberate effect-type change is passed through
- *    unmerged (the builder validates its required fields).
+ *    payload is used verbatim; when the AI keeps the SAME effect type (or
+ *    omits `type` — a partial update payload), payload fields it omitted
+ *    (message / level / setFields) are back-filled from the snapshot, and
+ *    `setFields` merges ONE level deep so a partial setFields (only the
+ *    changed keys) never silently drops the snapshot's other entries. A
+ *    deliberate effect-type change is passed through unmerged (the builder
+ *    validates its required fields).
  */
 function backfillUpdateShape(rule: ParsedRuleShape, existing: SchemaIntentRule): ParsedRuleShape {
   const out: ParsedRuleShape = { ...rule, name: existing.name };
@@ -422,15 +425,35 @@ function backfillUpdateShape(rule: ParsedRuleShape, existing: SchemaIntentRule):
   if (existingEffect) {
     if (out.effect === undefined) {
       out.effect = { ...existingEffect };
-    } else if (
-      typeof out.effect === "object" &&
-      out.effect !== null &&
-      (out.effect as Record<string, unknown>).type === existingEffect.type
-    ) {
-      out.effect = { ...existingEffect, ...(out.effect as Record<string, unknown>) };
+    } else if (typeof out.effect === "object" && out.effect !== null) {
+      const aiEffect = out.effect as Record<string, unknown>;
+      // Merge when the AI kept the same effect type OR omitted `type`
+      // entirely (a partial payload). A type CHANGE skips the merge so
+      // stale fields never leak into the new effect shape.
+      if (aiEffect.type === undefined || aiEffect.type === existingEffect.type) {
+        const merged: Record<string, unknown> = {
+          ...existingEffect,
+          ...aiEffect,
+          // The merge only runs for same-or-omitted type, so the existing
+          // type always wins (covers an explicit `type: undefined` too).
+          type: existingEffect.type,
+        };
+        // `setFields` back-fills one level deep: a partial AI payload
+        // carrying only the changed keys must not REPLACE the snapshot's
+        // whole map (that would silently drop untouched entries).
+        if (isPlainRecord(existingEffect.setFields) && isPlainRecord(aiEffect.setFields)) {
+          merged.setFields = { ...existingEffect.setFields, ...aiEffect.setFields };
+        }
+        out.effect = merged;
+      }
     }
   }
   return out;
+}
+
+/** Narrow to a plain object record (not null, not an array). */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 // ── Catalog construction ─────────────────────────────────────

--- a/packages/core/src/ai/schema-intent-types.ts
+++ b/packages/core/src/ai/schema-intent-types.ts
@@ -12,8 +12,9 @@
  *     `draft` status. Nothing is ever auto-submitted or applied — that is
  *     the repo principle "AI Never Modifies Production Directly".
  *
- * Scope of this first slice (intentionally narrow):
- *   - `add_rule` ONLY. Entity / field / view creation are later slices.
+ * Scope (intentionally narrow):
+ *   - `add_rule` + `update_rule` ONLY (no rename/delete, no multi-rule edits).
+ *     Entity / field / view creation are later slices.
  *   - Single-shot (no multi-turn). The resolver returns one of three
  *     outcomes and stops.
  *   - Stops at `draft`. The caller never submits/applies from this path.
@@ -22,29 +23,42 @@
  * mirroring the four-state shape of `Intent`, collapsed to the three
  * outcomes meaningful for a schema-change proposal:
  *
- *   - `SchemaIntentProposalDraft` — a governed `add_rule` Proposal (draft).
+ *   - `SchemaIntentProposalDraft` — a governed `add_rule` / `update_rule`
+ *     Proposal (draft).
  *   - `SchemaIntentClarification` — low confidence; ask the user a question.
  *   - `SchemaIntentNoMatch`       — graceful degradation / no usable rule.
  */
 
+import type { DeclarativeCondition } from "../types/rule";
 import type { Proposal } from "./proposal-engine";
 
 // ── Proposal-draft outcome ───────────────────────────────────
 
 /**
- * A confident schema-change intent that produced a governed `add_rule`
- * Proposal. The Proposal is created via `ProposalEngine.createProposal()`
- * and is ALWAYS in `draft` status — the resolver never submits or applies
- * it. The caller surfaces it for human review (Spec 15 §8 Proposal UI).
+ * A confident schema-change intent that produced a governed `add_rule` or
+ * `update_rule` Proposal. The Proposal is created via
+ * `ProposalEngine.createProposal()` and is ALWAYS in `draft` status — the
+ * resolver never submits or applies it. The caller surfaces it for human
+ * review (Spec 15 §8 Proposal UI).
  */
 export interface SchemaIntentProposalDraft {
   kind: "proposal_draft";
   /**
    * The governed draft Proposal. `proposal.status` is always `"draft"` and
-   * `proposal.type` is always `"add_rule"` for this slice.
+   * `proposal.type` is `"add_rule"` or `"update_rule"`.
    */
   proposal: Proposal;
-  /** Generated rule name (also present inside `proposal.diff.definition`). */
+  /**
+   * What the draft does to the rule: `"create"` mints a new rule
+   * (`add_rule`), `"update"` modifies an EXISTING rule (`update_rule`).
+   * Mirrors `proposal.diff.operation`.
+   */
+  operation: "create" | "update";
+  /**
+   * Rule name. For `create` this is the generated name; for `update` it is
+   * the EXISTING rule's name (validated against the ontology's rule list —
+   * renames are out of scope).
+   */
   ruleName: string;
   /** Entity the proposed rule is attached to (validated against the ontology). */
   targetEntity: string;
@@ -52,6 +66,20 @@ export interface SchemaIntentProposalDraft {
   confidence: number;
   /** Short human-readable summary suitable for the Proposal review card. */
   explanation: string;
+  /**
+   * Present only for `update` — the human-readable diff summary describing
+   * what changes versus the existing rule (carried into the governed
+   * `ProposalChange.diff` field).
+   */
+  diffSummary?: string;
+  /**
+   * Present only for `update` of a CODE-condition rule. The existing rule's
+   * condition is a TypeScript function the AI cannot round-trip into a
+   * declarative definition, so the draft carries NO definition — only the
+   * `diffSummary` describing the intended change. A developer must apply
+   * the change in source; the draft is an honest, governed change REQUEST.
+   */
+  requiresCodeChange?: boolean;
 }
 
 // ── Clarification outcome ────────────────────────────────────
@@ -90,6 +118,7 @@ export interface SchemaIntentNoMatch {
     | "ai_malformed_response"
     | "no_entities_in_scope"
     | "unknown_entity"
+    | "unknown_rule"
     | "invalid_rule"
     | "no_rule_drafted";
   /** Human-readable explanation, suitable for surfacing in the UI. */
@@ -110,6 +139,32 @@ export type SchemaIntentOutcome =
   | SchemaIntentNoMatch;
 
 // ── Ontology snapshot the resolver consumes ──────────────────
+
+/**
+ * One EXISTING rule's grounding metadata, exposed so the AI can target it
+ * with an `update_rule` intent (the AI can't update what it can't see).
+ *
+ * Declarative rules expose their full condition (the AI returns an updated
+ * one). CODE-condition rules (a TypeScript function) are NOT round-trippable
+ * — they expose `conditionKind: "code"` and their description only, never
+ * the function source, so the AI cannot pretend to edit code it cannot see.
+ */
+export interface SchemaIntentRule {
+  name: string;
+  label?: string;
+  description?: string;
+  /**
+   * Action name(s) from the rule's trigger, when it is an action trigger.
+   * Absent for stateChange / fieldChange / event / schedule triggers.
+   */
+  triggerActions?: string[];
+  /** The rule's effect type (`block`, `warn`, `require_approval`, …). */
+  effectType: string;
+  /** Whether the condition is declarative (editable) or code (opaque). */
+  conditionKind: "declarative" | "code";
+  /** The declarative condition. Present only when `conditionKind` is `"declarative"`. */
+  condition?: DeclarativeCondition;
+}
 
 /**
  * One entity's grounding metadata passed to the prompt builder so the AI
@@ -134,6 +189,12 @@ export interface SchemaIntentEntity {
    * entity exposes no actions.
    */
   actionNames: string[];
+  /**
+   * EXISTING rules attached to this entity — the `update_rule` target list.
+   * Optional so legacy ontology snapshots (and test fixtures) that predate
+   * update support keep working; absent/empty means nothing is updatable.
+   */
+  rules?: SchemaIntentRule[];
 }
 
 /**

--- a/packages/core/src/ai/schema-intent-types.ts
+++ b/packages/core/src/ai/schema-intent-types.ts
@@ -73,11 +73,13 @@ export interface SchemaIntentProposalDraft {
    */
   diffSummary?: string;
   /**
-   * Present only for `update` of a CODE-condition rule. The existing rule's
-   * condition is a TypeScript function the AI cannot round-trip into a
-   * declarative definition, so the draft carries NO definition — only the
-   * `diffSummary` describing the intended change. A developer must apply
-   * the change in source; the draft is an honest, governed change REQUEST.
+   * Present only for `update` of a NON-round-trippable rule: a CODE
+   * condition (a TypeScript function the AI cannot see), a composite/not
+   * condition, a non-action trigger, or a non-declarative effect — anything
+   * the declarative rebuild path cannot express faithfully. The draft
+   * carries NO definition — only the `diffSummary` describing the intended
+   * change. A developer must apply the change in source; the draft is an
+   * honest, governed change REQUEST.
    */
   requiresCodeChange?: boolean;
 }
@@ -141,6 +143,23 @@ export type SchemaIntentOutcome =
 // ── Ontology snapshot the resolver consumes ──────────────────
 
 /**
+ * Sanitized projection of an existing rule's effect payload — the declarative
+ * fields `buildEffect` consumes when round-tripping an update (message for
+ * block/warn, level for require_approval, setFields for enrich). Exposed in
+ * the snapshot so the AI can keep unchanged effect fields IDENTICAL instead
+ * of fabricating replacements (review-integrity: the diff must be honest).
+ * Non-declarative effect payloads (execute_action / trigger_flow) carry only
+ * `type` — such rules are never offered for declarative rebuild (see
+ * `roundTrippable`).
+ */
+export interface SchemaIntentRuleEffect {
+  type: string;
+  message?: string;
+  level?: string;
+  setFields?: Record<string, unknown>;
+}
+
+/**
  * One EXISTING rule's grounding metadata, exposed so the AI can target it
  * with an `update_rule` intent (the AI can't update what it can't see).
  *
@@ -160,10 +179,30 @@ export interface SchemaIntentRule {
   triggerActions?: string[];
   /** The rule's effect type (`block`, `warn`, `require_approval`, …). */
   effectType: string;
+  /**
+   * Sanitized effect payload (message / level / setFields) so an update can
+   * round-trip unchanged effect fields faithfully instead of fabricating
+   * replacements. Optional for legacy snapshots / test fixtures.
+   */
+  effect?: SchemaIntentRuleEffect;
+  /** The rule's evaluation priority, preserved verbatim across updates. */
+  priority?: number;
   /** Whether the condition is declarative (editable) or code (opaque). */
   conditionKind: "declarative" | "code";
   /** The declarative condition. Present only when `conditionKind` is `"declarative"`. */
   condition?: DeclarativeCondition;
+  /**
+   * Whether the FULL rule can be rebuilt declaratively from an AI-returned
+   * definition. `false` for rules the rebuild path cannot express faithfully:
+   * composite/not conditions (the builder only rebuilds simple conditions),
+   * non-action triggers (stateChange / fieldChange / event / schedule — the
+   * builder only emits `{action}`), and non-declarative effects
+   * (execute_action / trigger_flow). Such rules take the SAME honest
+   * diff-only path as code-backed rules — the draft carries no definition,
+   * only the human-readable diff (`requiresCodeChange`). Absent (legacy
+   * snapshots) means round-trippable when `conditionKind` is `"declarative"`.
+   */
+  roundTrippable?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What

The "说→有" loop could only CREATE rules; the north-star scenario (Spec 72, issue #566) needs *"把经理审批阈值改成2万"* to draft a governed update against the EXISTING `manager_approval_threshold` rule. The proposal layer already supports `{target:"rule", operation:"update"}` — this closes the resolver gap, with the review-integrity guarantees a governance path demands.

## How

- **Existing rules enter the AI's ontology** — name/label/description/trigger/priority + the **declarative effect payload** (message/level/setFields), permission-filtered like actions; code-backed rules expose kind+description ONLY (never function source). Condition string leaves + effect messages are recursively sanitized before prompt serialization (prior NL-drafted rules are otherwise an injection carrier into future prompts).
- **`update_rule` outcome** — validates the updated declarative definition with the same strict path as add_rule; the rule name is **pinned to the existing rule (re-pinned after `normalizeRuleName`)** so an AI rename can't mint a new rule; the resolver **back-fills unchanged priority/effect fields from the registered rule** so AI omissions can't silently reset them while the diff claims only a threshold changed.
- **Honest non-round-trippable handling** — code-backed conditions, composite/not conditions, non-action triggers, and non-declarative effects (`roundTrippable: false`) take a **diff-only** draft (`requiresCodeChange`), never a fabricated declarative rebuild that would flatten conjuncts or swap trigger kinds; a fabricated definition returned anyway is discarded. The marker persists on the governed change diff + proposal description (`REQUIRES_CODE_CHANGE_MARKER`) so reviewers can distinguish a developer change-request from a malformed change — Phase-1 validation untouched (fail-closed: these drafts cannot graduate).
- add_rule behavior unchanged (`operation:"create"`, regression-tested); `no_match`/`clarification` arms preserved.

## Known remaining gaps (documented on #566, deliberately NOT weakened here)

ProposalFileWriter writes updates as NEW dated files (duplicate registration) and definition-less drafts fail Phase-1 `MISSING_DEFINITION` — the materialization half of #566.

## Review

Cross-model pass (claude CLI) verified all security gates (permission filter, name pinning, fabricated-definition discard, no ungated execution path: `update_rule → modify_rule` is require-approval + high risk, only `delete_rule` is forbidden) and flagged 5 review-integrity issues — **all fixed** (round-2 commit): snapshot completeness + back-fill, lossy round-trip honesty, condition sanitization, post-build re-pin, persisted marker.

## Tests

27 new across the two rounds (resolver + route, in-process `app.handle`, provider-seam mocks per existing pattern). `bun run check` / `typecheck` clean; full `bun run test` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI intent resolver now supports updating existing rules, returns operation metadata (create/update), diff summaries, and a requires-code-change flag.
  * Declarative updates are intelligently merged to preserve unchanged properties; code-backed or non-roundtrippable rules produce diff-only drafts.

* **Tests**
  * Expanded end-to-end and unit tests covering update flows, round-trip behavior, sanitization, and refusal/no-match scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->