### PR TITLE
feat(adapter-server): start non-HTTP transports in dev:server — MCP reachable out of the box (#573)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-mcp-transport.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-mcp-transport.test.ts
@@ -1,0 +1,269 @@
+/**
+ * #573 — dev:server mounts the MCP transport.
+ *
+ * Proves the generic `extensions.transports` seam the dev-server entry point
+ * now uses (`startDevTransports`) makes the MCP channel reachable out of the
+ * box with the purchase-demo-shaped config, WITHOUT binding any socket.
+ *
+ * Strategy (no listening socket — bound sockets segfault the batched runner):
+ *   1. `collectDevTransports` includes the MCP transport, excludes the HTTP one
+ *      (the HTTP server is started directly by dev.ts; re-starting its factory
+ *      would double-bind the port).
+ *   2. `buildDevTransportContext` over the SAME `assembleDevSchema` runtime
+ *      yields a TransportContext carrying everything the MCP transport reads
+ *      (commandLayer, registries, ontology, config, AI boundary helpers).
+ *   3. The MCP server built from that bridged context — driven over an
+ *      in-process `InMemoryTransport` (the real MCP wire, no socket) — exposes
+ *      the tool surface AND blocks `approve_purchase_request` for the default
+ *      `ai_agent` actor via the manager-approval threshold rule (the same proof
+ *      as the #565 harness).
+ *
+ * The MCP transport factory is invoked too (in stdio mode, also socket-free) to
+ * assert it is startable through the bridged context.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createCapAdapterMcp, createMcpAdapter } from "@linchkit/cap-adapter-mcp";
+import {
+  type ActionDefinition,
+  type CapabilityDefinition,
+  type CodeCondition,
+  defineAction,
+  defineCapability,
+  defineEntity,
+  type EntityDefinition,
+  type LinchKitConfig,
+  type RuleDefinition,
+  type StateDefinition,
+} from "@linchkit/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { assembleDevSchema } from "../src/assemble-schema";
+import { buildDevEvolutionRuntime, buildDevOntologyRegistry } from "../src/dev-app";
+import { buildDevTransportContext, collectDevTransports } from "../src/start-dev-transports";
+
+// ── Minimal purchase capability (mirrors cap-purchase-demo's core) ────────
+
+const THRESHOLD = 10000;
+
+const purchaseRequestEntity: EntityDefinition = defineEntity({
+  name: "purchase_request",
+  label: "Purchase Request",
+  description: "A purchase request awaiting approval",
+  fields: {
+    title: { type: "string", label: "Title", required: true },
+    amount: { type: "number", label: "Amount", required: true },
+    status: { type: "string", label: "Status" },
+  },
+});
+
+const purchaseLifecycle: StateDefinition = {
+  name: "purchase_lifecycle",
+  entity: "purchase_request",
+  field: "status",
+  initial: "pending",
+  states: ["pending", "approved", "rejected"],
+  transitions: [
+    { from: "pending", to: "approved", action: "approve_purchase_request" },
+    { from: "pending", to: "rejected", action: "reject_purchase_request" },
+  ],
+};
+
+const approveAction: ActionDefinition = defineAction({
+  name: "approve_purchase_request",
+  entity: "purchase_request",
+  label: "Approve Purchase Request",
+  description: "Approve a pending purchase request",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  stateTransition: { from: "pending", to: "approved" },
+});
+
+const MANAGER_GROUPS = ["purchase_manager", "manager", "admin"];
+
+const overThresholdNonManager: CodeCondition = ({ actor, record }) => {
+  const groups = actor.groups ?? [];
+  const isManager = groups.some((g) => MANAGER_GROUPS.includes(g));
+  if (record == null) return !isManager;
+  const raw = (record as { amount?: unknown }).amount;
+  const amount = typeof raw === "number" ? raw : Number.NaN;
+  if (!Number.isFinite(amount)) return !isManager;
+  if (amount <= THRESHOLD) return false;
+  return !isManager;
+};
+
+const managerApprovalThresholdRule: RuleDefinition = {
+  name: "manager_approval_threshold",
+  label: "Manager Approval Threshold",
+  description: `Purchase requests over ${THRESHOLD} may only be approved by a manager.`,
+  trigger: { action: "approve_purchase_request" },
+  condition: overThresholdNonManager,
+  effect: {
+    type: "block",
+    message: `Amounts over ${THRESHOLD} require manager approval`,
+  },
+};
+
+const HIGH_VALUE_ID = "pr-high-value";
+
+const purchaseCapability: CapabilityDefinition = defineCapability({
+  name: "cap-purchase-test",
+  label: "Purchase (test)",
+  type: "business",
+  category: "demo",
+  version: "0.0.1",
+  entities: [purchaseRequestEntity],
+  actions: [approveAction],
+  states: [purchaseLifecycle],
+  rules: [managerApprovalThresholdRule],
+  seed: {
+    purchase_request: [
+      { id: HIGH_VALUE_ID, title: "New laptops", amount: 25000, status: "pending" },
+    ],
+  },
+});
+
+// ── Demo-shaped config: adapter-server-less, MCP in SSE mode on :3002 ──────
+// (We never start the SSE socket here; the SSE config just proves the
+//  ConfigRegistry carries the declared transport mode through the bridge.)
+
+const mcpCapability = createCapAdapterMcp({ config: { transport: "sse", ssePort: 3002 } });
+
+const capabilities: CapabilityDefinition[] = [mcpCapability, purchaseCapability];
+
+const config: LinchKitConfig = {
+  server: { port: 3001, host: "0.0.0.0" },
+  capabilities,
+};
+
+// ── Boot the SAME assembleDevSchema runtime dev.ts uses ───────────────────
+
+let client: Client;
+let assembled: ReturnType<typeof assembleDevSchema>;
+
+beforeAll(async () => {
+  assembled = assembleDevSchema(capabilities);
+
+  // Seed the in-memory store from capability seed data (dev.ts does this too).
+  const { InMemoryStore } = await import("@linchkit/core/server");
+  if (assembled.runtime.dataProvider instanceof InMemoryStore) {
+    for (const [entity, records] of Object.entries(assembled.contributions.seed)) {
+      assembled.runtime.dataProvider.seed(entity, records);
+    }
+  }
+
+  const ontologyRegistry = buildDevOntologyRegistry(assembled);
+  const evolutionRuntime = buildDevEvolutionRuntime({
+    capabilities,
+    assembled,
+    ontologyRegistry,
+  });
+
+  // The exact bridge dev.ts now performs to start non-HTTP transports.
+  const transportCtx = await buildDevTransportContext({
+    config,
+    capabilities,
+    assembled,
+    ontologyRegistry,
+    evolutionRuntime,
+  });
+
+  // Build the MCP server from the bridged context — same args the MCP transport
+  // factory passes — and drive it over an in-process JSON-RPC pipe (no socket).
+  const { server } = await createMcpAdapter({
+    commandLayer: transportCtx.commandLayer,
+    entityRegistry: transportCtx.entityRegistry,
+    // biome-ignore lint/style/noNonNullAssertion: bridged context always sets executor
+    actionRegistry: transportCtx.executor!.registry,
+    ontologyRegistry: transportCtx.ontologyRegistry,
+    aiBoundary: transportCtx.aiBoundary,
+    aiAuditLogger: transportCtx.aiAuditLogger,
+    executionLogger: transportCtx.executionLogger,
+    overlayRegistry: transportCtx.overlayRegistry,
+    name: "linchkit",
+    version: "1.0.0",
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: "dev-mcp-test-client", version: "1.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+});
+
+afterAll(async () => {
+  if (client) await client.close();
+});
+
+describe("#573 dev:server mounts the MCP transport via the generic seam", () => {
+  test("collectDevTransports includes MCP and excludes the HTTP transport", () => {
+    const transports = collectDevTransports(capabilities);
+    const names = transports.map((t) => t.name);
+    expect(names).toContain("mcp");
+    expect(names).not.toContain("http");
+  });
+
+  test("the MCP transport factory is startable through the bridged context (stdio, no socket)", async () => {
+    const ontologyRegistry = buildDevOntologyRegistry(assembled);
+    const evolutionRuntime = buildDevEvolutionRuntime({
+      capabilities,
+      assembled,
+      ontologyRegistry,
+    });
+
+    // stdio mode keeps this socket-free; the SSE-mode demo capability carries a
+    // socket factory, so build a transient stdio MCP capability for the start
+    // assertion instead of binding :3002.
+    const stdioMcp = createCapAdapterMcp({ config: { transport: "stdio" } });
+    const transport = stdioMcp.extensions?.transports?.find((t) => t.name === "mcp");
+    expect(transport).toBeDefined();
+
+    const ctx = await buildDevTransportContext({
+      config: { ...config, capabilities: [stdioMcp, purchaseCapability] },
+      capabilities: [stdioMcp, purchaseCapability],
+      assembled,
+      ontologyRegistry,
+      evolutionRuntime,
+    });
+
+    // biome-ignore lint/style/noNonNullAssertion: asserted defined above
+    const lifecycle = await transport!.factory(ctx);
+    expect(typeof lifecycle.start).toBe("function");
+    expect(typeof lifecycle.stop).toBe("function");
+    // Do NOT call start() — stdio start binds process stdio. Building the
+    // lifecycle through the bridged context already proves the seam carries
+    // everything the factory needs.
+  });
+
+  test("MCP tool surface is reachable (entity + approve action + introspection)", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("approve_purchase_request");
+    expect(names).toContain("list_entities");
+    expect(names).toContain("list_actions");
+
+    const entities = await client.callTool({ name: "list_entities", arguments: {} });
+    const content = entities.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]?.text ?? "[]") as Array<{ name: string }>;
+    expect(parsed.some((e) => e.name === "purchase_request")).toBe(true);
+  });
+
+  test("approve_purchase_request as the default ai_agent actor is BLOCKED by the threshold rule", async () => {
+    const result = await client.callTool({
+      name: "approve_purchase_request",
+      arguments: { id: HIGH_VALUE_ID },
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]?.text ?? "{}") as {
+      success?: boolean;
+      data?: { error?: string; context?: { constraint?: string } };
+    };
+
+    // The MCP default actor is `{ type: "ai", groups: ["ai_agent"] }` — not a
+    // manager — so the manager-approval-threshold rule blocks the over-threshold
+    // request before any write (same proof as the #565 harness). A rule block
+    // surfaces as `{ success: false, data: { error, context.constraint } }`.
+    expect(parsed.success).toBe(false);
+    expect(parsed.data?.context?.constraint).toBe("rule_block");
+    expect(parsed.data?.error ?? "").toContain("manager approval");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -38,11 +38,13 @@
   },
   "devDependencies": {
     "@linchkit/cap-adapter-ag-ui": "workspace:*",
+    "@linchkit/cap-adapter-mcp": "workspace:*",
     "@linchkit/cap-ai-provider": "workspace:*",
     "@linchkit/cap-chatter": "workspace:*",
     "@linchkit/cap-dry-run": "workspace:*",
     "@linchkit/cap-permission": "workspace:*",
     "@linchkit/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "typescript": "^6.0.2"
   },
   "linchkit": {

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -13,6 +13,7 @@ import { loadConfig } from "./config-loader";
 import { resolveDevRoleActor } from "./dev-actor-resolver";
 import { buildDevEvolutionRuntime, buildDevOntologyRegistry } from "./dev-app";
 import { createServer } from "./server";
+import { startDevTransports } from "./start-dev-transports";
 import { wireAITraceSink } from "./wire-ai-trace-sink";
 
 // ── Resolve project root ────────────────────────────────
@@ -176,6 +177,22 @@ const server = createServer(graphqlSchema, {
 
 server.listen(port);
 
+// ── Start non-HTTP transports (e.g. MCP) ─────────────────
+// The HTTP/GraphQL server above is the `http` transport, started directly.
+// Every OTHER transport a capability contributes through the generic
+// `extensions.transports` seam (e.g. cap-adapter-mcp's SSE transport on :3002
+// in the purchase demo config) is started here — mirroring the `linch dev` CLI
+// path — so the MCP channel is reachable out of the box without a hard runtime
+// import of cap-adapter-mcp (#573). Non-throwing per-transport: a failure is
+// logged and skipped so the HTTP server (already listening) stays up.
+const transportLifecycles = await startDevTransports({
+  config,
+  capabilities: config.capabilities ?? [],
+  assembled,
+  ontologyRegistry,
+  evolutionRuntime,
+});
+
 // ── Startup summary ──────────────────────────────────────
 
 const aiSummary = config.ai
@@ -189,6 +206,9 @@ console.log(`  GraphQL:    http://${host}:${port}/graphql`);
 console.log(`  Health:     http://${host}:${port}/health`);
 console.log(`  REST API:   http://${host}:${port}/api/actions/:name`);
 console.log(`  Exec Logs:  http://${host}:${port}/api/executions`);
+if (transportLifecycles.length > 0) {
+  console.log(`  Transports: ${transportLifecycles.length} extra started (e.g. MCP)`);
+}
 console.log(`───────────────────────────────────`);
 const capNames = (config.capabilities ?? []).map((c) => c.name).join(", ") || "none";
 const mwCount = capContributions.middlewares.length;

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -193,6 +193,28 @@ const transportLifecycles = await startDevTransports({
   evolutionRuntime,
 });
 
+// Stop the started transports gracefully on shutdown. Without this, the SSE
+// server (e.g. MCP on :3002) keeps its socket open across a fast `bun --watch`
+// restart and the next boot hits EADDRINUSE; clients also miss a clean close.
+if (transportLifecycles.length > 0) {
+  let shuttingDown = false;
+  const stopTransports = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    for (const lifecycle of transportLifecycles) {
+      try {
+        await lifecycle.stop();
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error(`Failed to stop a dev transport: ${error.message}`);
+      }
+    }
+    process.exit(0);
+  };
+  process.once("SIGINT", stopTransports);
+  process.once("SIGTERM", stopTransports);
+}
+
 // ── Startup summary ──────────────────────────────────────
 
 const aiSummary = config.ai

--- a/addons/adapter-server/cap-adapter-server/src/start-dev-transports.ts
+++ b/addons/adapter-server/cap-adapter-server/src/start-dev-transports.ts
@@ -108,10 +108,46 @@ export async function buildDevTransportContext(
   await overlayRegistry.initialize();
 
   // AI boundary + audit logger — the MCP adapter wires these into its AI
-  // security tools. Built minimally over the assembled AI service (noop unless
-  // one was configured), mirroring dev-wiring.ts's lightweight construction.
-  const aiAuditLogger = new AIAuditLogger();
-  const aiBoundary = new AIBoundary({ aiService: runtime.ai ?? createNoopAIService() });
+  // security tools. Mirrors dev-wiring.ts so AI calls made through non-HTTP
+  // transports (MCP) are audited and their usage logged, closing the
+  // observability gap a bare construction would leave versus the `linch dev` path.
+  const aiAuditLogger = new AIAuditLogger({
+    onAuditEntry: (entry) => {
+      consoleLogger.debug(
+        `AI audit: ${entry.eventType} risk=${entry.riskLevel}${entry.actionName ? ` action=${entry.actionName}` : ""}`,
+      );
+    },
+  });
+  const aiBoundary = new AIBoundary({
+    aiService: runtime.ai ?? createNoopAIService(),
+    onUsageRecord: (record) => {
+      // Forward usage records to the audit logger as AI call events.
+      aiAuditLogger.logCall({
+        actorId: record.actorId,
+        tenantId: record.tenantId,
+        agentModel: record.model,
+        input: `[${record.source}] ${record.actionName ?? "unknown"}`,
+        output: record.status,
+        actionName: record.actionName,
+        tokenUsage: {
+          inputTokens: record.inputTokens,
+          outputTokens: record.outputTokens,
+          totalTokens: record.totalTokens,
+        },
+        metadata: {
+          cost: record.cost,
+          duration: record.duration,
+          policyName: record.policyName,
+          blockReason: record.blockReason,
+        },
+      });
+    },
+    onBudgetAlert: (tenantId, budget, threshold) => {
+      consoleLogger.warn(
+        `AI budget alert: tenant=${tenantId ?? "global"} threshold=${threshold} costToday=$${budget.costToday.toFixed(2)}`,
+      );
+    },
+  });
 
   return {
     commandLayer: runtime.commandLayer,
@@ -154,7 +190,20 @@ export async function startDevTransports(
   const transports = collectDevTransports(input.capabilities);
   if (transports.length === 0) return [];
 
-  const transportCtx = await buildDevTransportContext(input);
+  // Context creation can throw (e.g. ConfigRegistry validation). The HTTP dev
+  // server is already listening by this point, so a failure here must not crash
+  // the process — log and skip all transports, mirroring the per-transport
+  // non-throwing contract below.
+  let transportCtx: TransportContext;
+  try {
+    transportCtx = await buildDevTransportContext(input);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    consoleLogger.error(`Failed to build dev transport context: ${error.message}`, {
+      error: error.stack,
+    });
+    return [];
+  }
   const lifecycles: TransportLifecycle[] = [];
 
   for (const transport of transports) {

--- a/addons/adapter-server/cap-adapter-server/src/start-dev-transports.ts
+++ b/addons/adapter-server/cap-adapter-server/src/start-dev-transports.ts
@@ -1,0 +1,176 @@
+/**
+ * Dev transport bridge — starts capability-contributed transports OTHER than
+ * the main HTTP server on the `bun run dev:server` path.
+ *
+ * Background
+ * ----------
+ * `bun run dev:server` (this package's `src/dev.ts`) assembles the runtime and
+ * starts the HTTP/GraphQL server directly via `createServer(...)` +
+ * `server.listen(port)`. It historically ignored every OTHER transport a
+ * capability contributes through the generic `extensions.transports` seam — so
+ * with the purchase demo config (which registers `cap-adapter-mcp` with the SSE
+ * transport on :3002) the MCP channel was simply never mounted in dev (#573).
+ *
+ * The canonical `linch dev` CLI path (packages/cli/src/commands/dev.ts) already
+ * iterates `collectCapabilityDefinitions(...).transports` and calls
+ * `transport.factory(transportCtx)` → `lifecycle.start()` for each one. This
+ * helper brings the SAME generic seam to the dev-server entry point WITHOUT a
+ * hard runtime import of cap-adapter-mcp: the MCP transport factory rides in on
+ * the loaded capability list, exactly like it does under `linch dev`.
+ *
+ * The HTTP transport ("http", contributed by cap-adapter-server itself) is
+ * deliberately skipped here — `dev.ts` already binds the HTTP server on its
+ * port, and re-starting the http transport factory would double-bind it.
+ */
+
+import type {
+  CapabilityDefinition,
+  LinchKitConfig,
+  OntologyRegistry,
+  TransportAdapterDefinition,
+  TransportContext,
+  TransportLifecycle,
+} from "@linchkit/core";
+import { ConfigRegistry } from "@linchkit/core";
+import type { EvolutionRuntime } from "@linchkit/core/server";
+import {
+  AIAuditLogger,
+  AIBoundary,
+  consoleLogger,
+  createNoopAIService,
+  DefaultOverlayRegistry,
+  InMemoryOverlayStore,
+} from "@linchkit/core/server";
+import type { AssembledDevSchema } from "./assemble-schema";
+
+/** Transport name owned by cap-adapter-server — its HTTP server is started directly by dev.ts. */
+const HTTP_TRANSPORT_NAME = "http";
+
+/** Inputs needed to bridge the assembled dev runtime into a TransportContext. */
+export interface StartDevTransportsInput {
+  /** Raw loaded config — used to build the ConfigRegistry transports read from. */
+  config: LinchKitConfig;
+  /** Loaded capability definitions (carry `extensions.transports`). */
+  capabilities: CapabilityDefinition[];
+  /** The assembled dev schema (runtime context, contributions). */
+  assembled: AssembledDevSchema;
+  /** Unified semantic layer (already built by dev.ts). */
+  ontologyRegistry: OntologyRegistry;
+  /** Evolution runtime (already built by dev.ts) — surfaces InsightEngine to MCP. */
+  evolutionRuntime: EvolutionRuntime;
+}
+
+/**
+ * Collect transports contributed by capabilities, excluding the HTTP transport
+ * (started directly by dev.ts) so we never double-bind the HTTP port.
+ */
+export function collectDevTransports(
+  capabilities: CapabilityDefinition[],
+): TransportAdapterDefinition[] {
+  const transports: TransportAdapterDefinition[] = [];
+  for (const cap of capabilities) {
+    if (!cap.extensions?.transports) continue;
+    for (const transport of cap.extensions.transports) {
+      if (transport.name === HTTP_TRANSPORT_NAME) continue;
+      transports.push(transport);
+    }
+  }
+  return transports;
+}
+
+/**
+ * Build a TransportContext from the assembled dev runtime.
+ *
+ * Mirrors the subset of `dev-wiring.ts`'s `transportCtx` that the dev-server
+ * path can supply DB-free. Transport factories (e.g. cap-adapter-mcp) read
+ * `commandLayer`, `executor`, `entityRegistry`, `ontologyRegistry`,
+ * `executionLogger`, `evolutionRuntime`, `overlayRegistry`, the AI boundary
+ * helpers, and — for their declarative config — `config` (a ConfigRegistry).
+ *
+ * `overlayRegistry` is an in-memory instance here (no DB on the dev-server
+ * path); MCP introspection still resolves and simply reports no overlay fields.
+ */
+export async function buildDevTransportContext(
+  input: StartDevTransportsInput,
+): Promise<TransportContext> {
+  const { config, capabilities, assembled, ontologyRegistry, evolutionRuntime } = input;
+  const { runtime, contributions } = assembled;
+
+  // ConfigRegistry — resolves env vars + applies Zod defaults so a transport's
+  // `config.from(ctx)` accessor (e.g. capAdapterMcpConfig.from) returns the
+  // capability's declared config (transport: "sse", ssePort: 3002 in the demo).
+  const configRegistry = ConfigRegistry.create(config, capabilities);
+
+  // In-memory overlay registry — matches the dev-server path's DB-free shape.
+  // Transports treat it as optional; MCP introspection resolves it and reports
+  // no overlay fields when none are registered.
+  const overlayRegistry = new DefaultOverlayRegistry(new InMemoryOverlayStore());
+  await overlayRegistry.initialize();
+
+  // AI boundary + audit logger — the MCP adapter wires these into its AI
+  // security tools. Built minimally over the assembled AI service (noop unless
+  // one was configured), mirroring dev-wiring.ts's lightweight construction.
+  const aiAuditLogger = new AIAuditLogger();
+  const aiBoundary = new AIBoundary({ aiService: runtime.ai ?? createNoopAIService() });
+
+  return {
+    commandLayer: runtime.commandLayer,
+    executor: runtime.executor,
+    entityRegistry: runtime.entityRegistry,
+    entities: contributions.entities,
+    actions: assembled.allActions,
+    views: contributions.views,
+    states: contributions.states,
+    middlewares: contributions.middlewares,
+    config: configRegistry,
+    dataProvider: runtime.dataProvider,
+    eventBus: runtime.eventBus,
+    executionLogger: runtime.executionLogger,
+    approvalEngine: runtime.approvalEngine,
+    links: contributions.relations,
+    capabilities,
+    ontologyRegistry,
+    overlayRegistry,
+    aiBoundary,
+    aiAuditLogger,
+    aiService: runtime.ai,
+    aiConfig: config.ai,
+    evolutionRuntime,
+  };
+}
+
+/**
+ * Start every capability-contributed transport except the HTTP server.
+ *
+ * Non-throwing per-transport: a single transport that fails to start is logged
+ * and skipped so the HTTP dev server (already listening) stays up — mirroring
+ * the `linch dev` CLI path's per-transport try/catch.
+ *
+ * @returns The started lifecycle handles (for graceful shutdown by the caller).
+ */
+export async function startDevTransports(
+  input: StartDevTransportsInput,
+): Promise<TransportLifecycle[]> {
+  const transports = collectDevTransports(input.capabilities);
+  if (transports.length === 0) return [];
+
+  const transportCtx = await buildDevTransportContext(input);
+  const lifecycles: TransportLifecycle[] = [];
+
+  for (const transport of transports) {
+    try {
+      consoleLogger.info(`Starting transport: ${transport.label ?? transport.name}...`);
+      const lifecycle = await transport.factory(transportCtx);
+      await lifecycle.start();
+      lifecycles.push(lifecycle);
+      consoleLogger.info(`Transport ${transport.name} started.`);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      consoleLogger.error(`Failed to start transport "${transport.name}": ${error.message}`, {
+        error: error.stack,
+      });
+    }
+  }
+
+  return lifecycles;
+}


### PR DESCRIPTION
## What

`bun run dev:server` assembled the runtime but only started the HTTP/GraphQL server, leaving the **MCP channel unreachable in dev** — the #565 multi-channel walkthrough had to boot a standalone harness to drive MCP at all. This wires the MCP transport (and any other capability-contributed transport) into the dev server so the chain is drivable **from MCP out of the box**.

## How

Uses the generic `extensions.transports` seam — the same one the `linch dev` CLI path already iterates — **not** a hard runtime import of `cap-adapter-mcp`:

- `start-dev-transports.ts` (new): `collectDevTransports` (excludes `http`, already bound), `buildDevTransportContext` (bridges `RuntimeContext` + ontology + evolution + config/overlay registries + AI boundary into a `TransportContext`), `startDevTransports` (non-throwing per transport — a failed transport is logged + skipped so the HTTP server stays up).
- `dev.ts`: starts the transports right after `server.listen(port)`; reports the count in the startup summary.
- The purchase demo config already registers cap-adapter-mcp's SSE transport on `:3002`, so it now starts automatically.

## Acceptance proof

`dev-mcp-transport.test.ts` boots the **same** `assembleDevSchema` runtime, drives the MCP server over an in-process `InMemoryTransport` (**no socket bind** — avoids the batched-runner segfault), and asserts:
- MCP transport is collected; `http` is excluded.
- The MCP tool surface is reachable through the bridged context.
- `approve_purchase_request` as the default `ai_agent` actor is **BLOCKED by the threshold rule** (`success:false`, `rule_block`, "manager approval") — same proof as the #565 harness.

## Dependencies (flagged)

Two **test-only devDeps** on `cap-adapter-server`, **no new supply-chain**:
- `@linchkit/cap-adapter-mcp: workspace:*` — workspace package (sibling addon), not external.
- `@modelcontextprotocol/sdk: ^1.29.0` — already locked at `1.29.0` (via adapter-mcp); resolves to the same version. `bun.lock` unchanged.

No new **runtime** dependency — the runtime path uses the generic seam only. Precedent: `cap-adapter-ag-ui` / `cap-chatter` are already devDeps here.

## Verification

Clean `origin/main`: `check` + `typecheck` clean; `adapter-server` 909 pass, `adapter-mcp` 206 pass. A pre-existing `cap-mcp-ui` "Admin route mcp already registered" singleton clash on the full single-process `./addons/` run is unrelated — this PR adds zero new failures.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
