### PR TITLE
feat(core,adapter-server): graduate NL-drafted relation as first-class change (#580)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-schema-intent.test.ts
@@ -427,12 +427,13 @@ describe("POST /api/ai/resolve-schema-intent — add_entity governed persistence
     expect(changes[0]?.name).toBe("product");
   });
 
-  test("surfaces a drafted relation in the response, yet STRIPS it from the governed change", async () => {
+  test("surfaces a drafted relation in the response and emits it as a second governed `relation` change", async () => {
     // The AI drafts a NEW entity that relates to an EXISTING one. The relation
-    // must (a) round-trip in the HTTP response for the review UI, and (b) be
-    // ABSENT from the governed change's definition — entity targets are not
-    // materialized to code yet, so carrying the relation through graduation is a
-    // tracked follow-up (#580). This test pins both halves of that contract.
+    // must (a) round-trip in the HTTP response for the review UI, (b) be ABSENT
+    // from the ENTITY change's definition (that change stays a clean
+    // EntityDefinition), and (c) be carried as a SECOND, first-class `relation`
+    // governed change so graduation emits both defineEntity() and
+    // defineRelation() (#580). This test pins all three halves of that contract.
     const relAi = fakeAiService({
       responseContent: JSON.stringify({
         kind: "add_entity",
@@ -485,21 +486,49 @@ describe("POST /api/ai/resolve-schema-intent — add_entity governed persistence
     expect(body.relation?.fromName).toBe("line_items");
     expect(body.relation?.toName).toBe("purchase_request");
 
-    // (b) The governed change carries the ENTITY only — its definition has NO
-    // `relation` key. This is the deliberate, deferred strip (#580), pinned here
-    // so a future change that accidentally leaks the relation into the governed
-    // definition fails loudly instead of silently changing the graduation shape.
+    // (b) The governed proposal carries TWO changes: the ENTITY change (whose
+    // definition has NO `relation` key — it stays a clean EntityDefinition) and
+    // (c) a first-class `relation` change carrying the full RelationDefinition,
+    // so graduation emits both defineEntity() and defineRelation() (#580).
     const list = await getProposals(relServer, "purchase_item");
     const found = list.json.data.items.find((p) => p.id === body.proposalId);
     if (!found) throw new Error("expected the governed entity draft in /api/proposals");
     const changes = found.changes as Array<{
       target: string;
+      operation: string;
+      name: string;
       definition?: Record<string, unknown>;
     }>;
-    expect(changes).toHaveLength(1);
-    expect(changes[0]?.target).toBe("entity");
-    expect(changes[0]?.definition).toBeDefined();
-    expect(changes[0]?.definition && "relation" in changes[0].definition).toBe(false);
+    expect(changes).toHaveLength(2);
+
+    // (b) Entity change first, clean of the relation extra.
+    const entityChange = changes.find((c) => c.target === "entity");
+    expect(entityChange).toBeDefined();
+    expect(entityChange?.operation).toBe("create");
+    expect(entityChange?.definition).toBeDefined();
+    expect(entityChange?.definition && "relation" in entityChange.definition).toBe(false);
+
+    // (c) Relation change carrying the full RelationDefinition (graduates to
+    // defineRelation()).
+    const relationChange = changes.find((c) => c.target === "relation");
+    expect(relationChange).toBeDefined();
+    expect(relationChange?.operation).toBe("create");
+    expect(relationChange?.name).toBe("purchase_request_items");
+    const relDef = relationChange?.definition as
+      | {
+          name?: string;
+          from?: string;
+          to?: string;
+          cardinality?: string;
+          fromName?: string;
+          toName?: string;
+        }
+      | undefined;
+    expect(relDef?.from).toBe("purchase_request");
+    expect(relDef?.to).toBe("purchase_item");
+    expect(relDef?.cardinality).toBe("one_to_many");
+    expect(relDef?.fromName).toBe("line_items");
+    expect(relDef?.toName).toBe("purchase_request");
   });
 });
 

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
@@ -32,6 +32,7 @@ import type {
   EntityDefinition,
   ProposalChange,
   ProposalDefinition,
+  RelationDefinition,
   RuleDefinition,
 } from "@linchkit/core";
 import type {
@@ -280,25 +281,27 @@ function persistGovernedRuleDraft(opts: {
  * (issue #575). The resolver runs ALL of its structural validation first
  * (snake_case singular name, no system-field collisions, valid field types,
  * valid relation endpoints). By the time we reach here the draft carries a
- * validated, typed `EntityDefinition`; we translate it into a single governed
- * `ProposalChange` (`{ target: "entity", operation: "create", name, definition }`)
- * in `draft` status. It is NEVER submitted, approved, or applied here.
+ * validated, typed `EntityDefinition`; we translate it into a governed
+ * `entity` `ProposalChange`
+ * (`{ target: "entity", operation: "create", name, definition }`) in `draft`
+ * status. It is NEVER submitted, approved, or applied here.
  *
- * A drafted relation rides along inside the resolver draft's definition, but it
- * is NOT carried into the governed change: the governed `entity` change records
- * the entity ONLY (the relation is stripped below). The relation still surfaces
- * in the HTTP response (`outcome.relation`) for the review UI, but it does NOT
- * reach the graduation path. Note this is not a live regression today — entity
- * targets are not materialized to code yet (only `"action"` is in the
- * materializer's MATERIALIZABLE_TARGETS), so neither the entity NOR its relation
- * graduates. Carrying the relation through as a first-class governed change
- * needs a `"relation"` ProposalChangeTarget and is a tracked follow-up (#580).
+ * A drafted relation rides along inside the resolver draft's definition
+ * (`{ ...entityDef, relation }`). It is carried into the governed proposal as a
+ * SECOND, first-class `relation` change
+ * (`{ target: "relation", operation: "create", name, definition }`, #580) so
+ * graduation emits BOTH `defineEntity(...)` and `defineRelation(...)`. The
+ * relation is still removed from the `entity` change's definition (that change
+ * carries a clean `EntityDefinition`); it also still surfaces in the HTTP
+ * response (`outcome.relation`) for the review UI. The two changes are pushed
+ * entity-first, then relation when present.
  *
  * Always returns a persisted governed `ProposalDefinition` (mirroring
  * `persistGovernedRuleDraft`). If the draft somehow lacks a usable entity
- * definition it THROWS rather than returning `undefined` — a silent undefined
+ * definition — or carries a relation that is present but malformed — it THROWS
+ * rather than returning `undefined` / silently dropping: a silent undefined
  * would let the route report a successful `entity_proposal_draft` while nothing
- * was actually governed.
+ * was governed, and a silently-dropped relation would regress the #580 contract.
  */
 function persistGovernedEntityDraft(opts: {
   engine: GovernedProposalEngine;
@@ -320,13 +323,13 @@ function persistGovernedEntityDraft(opts: {
     );
   }
   // The resolver draft carries a drafted relation alongside the entity
-  // (`{ ...entityDef, relation }`). The governed `entity` change's `definition`
-  // must be a clean `EntityDefinition`, so strip the relation extra here — the
-  // relation surfaces separately in the API response (`outcome.relation`) for the
-  // review UI; persisting it as its own governed change is a deferred follow-up
-  // (#580). The HTTP test pins this strip (governed definition has no `relation`
-  // key) so the deferral is a tested contract, not a silent drop.
-  const { relation: _relation, ...entityRest } = definition as Record<string, unknown>;
+  // (`{ ...entityDef, relation }`). Separate the relation from the entity here:
+  // the governed `entity` change's `definition` must be a clean `EntityDefinition`
+  // (relation removed), while the relation becomes its OWN first-class governed
+  // `relation` change below (#580) so graduation emits both `defineEntity(...)`
+  // and `defineRelation(...)`. The relation also still surfaces in the API
+  // response (`outcome.relation`) for the review UI.
+  const { relation: relationDef, ...entityRest } = definition as Record<string, unknown>;
   // Minimal structural assertion before the unchecked cast. The resolver
   // validated this upstream, but persisting a governed EntityDefinition is
   // integrity-critical, so guard against future drift in the stored shape rather
@@ -342,13 +345,41 @@ function persistGovernedEntityDraft(opts: {
   }
   const entityDefinition = entityRest as unknown as EntityDefinition;
 
-  const change: ProposalChange = {
+  const entityChange: ProposalChange = {
     target: "entity",
     operation: "create",
     name: entityName,
     definition: entityDefinition,
     diff: explanation,
   };
+
+  const changes: ProposalChange[] = [entityChange];
+
+  // Carry the drafted relation as a SECOND, first-class governed change so it
+  // graduates to `defineRelation(...)` source (#580). The resolver already
+  // validated the relation endpoints upstream; mirror the entity guard and
+  // assert the minimal RelationDefinition shape (non-null object with a string
+  // `name`) before trusting the cast. If the relation is PRESENT but malformed,
+  // THROW rather than silently drop — a silent drop would regress the #580
+  // contract while still reporting a successful entity_proposal_draft.
+  if (relationDef !== undefined && relationDef !== null) {
+    if (
+      typeof relationDef !== "object" ||
+      typeof (relationDef as Record<string, unknown>).name !== "string"
+    ) {
+      throw new Error(
+        `persistGovernedEntityDraft: relation present but malformed — expected an object with a string name (entityName=${entityName})`,
+      );
+    }
+    const relationDefinition = relationDef as unknown as RelationDefinition;
+    changes.push({
+      target: "relation",
+      operation: "create",
+      name: relationDefinition.name,
+      definition: relationDefinition,
+      diff: explanation,
+    });
+  }
 
   return engine.createProposal({
     title: explanation,
@@ -358,7 +389,7 @@ function persistGovernedEntityDraft(opts: {
     capability: entityName,
     // A new entity is an additive, minor change.
     changeType: "minor",
-    changes: [change],
+    changes,
   });
 }
 

--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -138,6 +138,46 @@ describe("ProposalFileWriter.writeApprovedProposal", () => {
     expect(contents).toContain("Capability:");
   });
 
+  it("writes a relation change to the relations/ subdir as defineRelation (#580)", async () => {
+    const writer = new ProposalFileWriter({ rootDir: tmpDir });
+    const relationChange: ProposalChange = {
+      target: "relation",
+      operation: "create",
+      name: "purchase_request_items",
+      definition: {
+        name: "purchase_request_items",
+        from: "purchase_request",
+        to: "purchase_item",
+        cardinality: "one_to_many",
+        fromName: "line_items",
+        toName: "purchase_request",
+      },
+    };
+    const proposal = makeApprovedProposal({ changes: [relationChange] });
+
+    const written = await writer.writeApprovedProposal(proposal);
+
+    const expected = join(
+      tmpDir,
+      "addons",
+      "demo",
+      "cap-life-demo",
+      "src",
+      "relations",
+      `${TEST_PREFIX}.purchase_request_items.relation.ts`,
+    );
+    expect(written).toEqual([expected]);
+    expect(existsSync(expected)).toBe(true);
+
+    const contents = await readFile(expected, "utf8");
+    expect(contents).toContain('import { defineRelation } from "@linchkit/core";');
+    expect(contents).toContain("export default defineRelation(");
+    expect(contents).toContain('"name": "purchase_request_items"');
+    expect(contents).toContain('"from": "purchase_request"');
+    expect(contents).toContain('"to": "purchase_item"');
+    expect(contents).toContain('"cardinality": "one_to_many"');
+  });
+
   it("writes AI-materialized generatedSource verbatim, not the codegen output (G5)", async () => {
     const writer = new ProposalFileWriter({ rootDir: tmpDir });
     const GENERATED = [

--- a/packages/core/src/engine/proposal-file-writer.ts
+++ b/packages/core/src/engine/proposal-file-writer.ts
@@ -74,6 +74,7 @@ type WritableChangeTarget = Exclude<ProposalChangeTarget, "revert">;
 /** Map a change target to its subdirectory (relative to `<cap>/src/`). */
 const TARGET_SUBDIR: Record<WritableChangeTarget, string> = {
   entity: "entities",
+  relation: "relations",
   action: "actions",
   rule: "rules",
   view: "views",
@@ -86,6 +87,7 @@ const TARGET_SUBDIR: Record<WritableChangeTarget, string> = {
 /** Map a change target to its file-name discriminator. */
 const TARGET_KIND_SUFFIX: Record<WritableChangeTarget, string> = {
   entity: "entity",
+  relation: "relation",
   action: "action",
   rule: "rule",
   view: "view",
@@ -98,6 +100,7 @@ const TARGET_KIND_SUFFIX: Record<WritableChangeTarget, string> = {
 /** Map a change target to its `defineXxx` factory name. */
 const TARGET_FACTORY: Record<WritableChangeTarget, string> = {
   entity: "defineEntity",
+  relation: "defineRelation",
   action: "defineAction",
   rule: "defineRule",
   view: "defineView",

--- a/packages/core/src/life-system/proposal-preanalysis/impact-analyzer.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/impact-analyzer.ts
@@ -24,10 +24,18 @@ const DEFAULT_SAMPLE_LIMIT = 5;
 
 /**
  * Targets that touch stored records. Any other target (view, action, event, rule,
- * flow) is code-only for the purposes of first-order impact estimation.
+ * flow, relation) is code-only for the purposes of first-order impact estimation.
  *
  * `overlay` is included because overlays may change how existing records are
  * interpreted (validation, visibility) even when they don't rewrite rows.
+ *
+ * `relation` is intentionally EXCLUDED: like the `entity`-create case below, the
+ * NL resolver only ever drafts a relation-CREATE alongside a brand-new entity, so
+ * there are no pre-existing rows to probe (the new entity has none, and the junction
+ * table — for many_to_many — does not exist yet). A relation create is additive and
+ * non-breaking; classifying it as a data target would only probe an empty/absent
+ * table. (Mirrors why a NEW entity is excluded via `isImpactableChange` rather than
+ * `DATA_TARGETS`: an entity UPDATE can still hit rows, but a create cannot.)
  */
 const DATA_TARGETS: ReadonlySet<ProposalChangeTarget> = new Set<ProposalChangeTarget>([
   "entity",
@@ -44,6 +52,11 @@ const DATA_TARGETS: ReadonlySet<ProposalChangeTarget> = new Set<ProposalChangeTa
 function isImpactableChange(change: ProposalChange): boolean {
   if (!DATA_TARGETS.has(change.target)) return false;
   if (change.target === "entity" && change.operation === "create") return false;
+  // A relation create is additive (no prior rows to probe). Defensive belt — a
+  // relation is not in DATA_TARGETS today, so this is already non-breaking via the
+  // guard above; this keeps the create-is-non-breaking rule locally explicit if a
+  // future maintainer ever adds `relation` to DATA_TARGETS.
+  if (change.target === "relation" && change.operation === "create") return false;
   return true;
 }
 

--- a/packages/core/src/life-system/proposal-preanalysis/impact-analyzer.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/impact-analyzer.ts
@@ -55,7 +55,10 @@ function isImpactableChange(change: ProposalChange): boolean {
   // A relation create is additive (no prior rows to probe). Defensive belt — a
   // relation is not in DATA_TARGETS today, so this is already non-breaking via the
   // guard above; this keeps the create-is-non-breaking rule locally explicit if a
-  // future maintainer ever adds `relation` to DATA_TARGETS.
+  // future maintainer ever adds `relation` to DATA_TARGETS. NOTE: doing so ALSO
+  // requires teaching `resolveEntityName` below to map a `relation` change to an
+  // entity (it returns null for relation today, so a relation UPDATE would probe
+  // no table and be silently treated as zero-impact).
   if (change.target === "relation" && change.operation === "create") return false;
   return true;
 }

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -13,6 +13,7 @@ import type { DryRunOutcome, DryRunStatus } from "./dry-run";
 import type { EntityDefinition } from "./entity";
 import type { EventDefinition } from "./event";
 import type { FieldOverlayDefinition } from "./overlay";
+import type { RelationDefinition } from "./relation";
 import type { RuleDefinition } from "./rule";
 import type { StateDefinition } from "./state";
 import type { ViewDefinition } from "./view";
@@ -44,6 +45,8 @@ export interface ProposalAuthor {
 
 export type ProposalChangeTarget =
   | "entity"
+  /** A first-class semantic relation (`defineRelation()`) — entity-adjacent. */
+  | "relation"
   | "action"
   | "rule"
   | "view"
@@ -67,6 +70,7 @@ export type ProposalChangeOperation = "create" | "update" | "delete";
 
 export type ChangeDefinition =
   | EntityDefinition
+  | RelationDefinition
   | ActionDefinition
   | RuleDefinition
   | ViewDefinition


### PR DESCRIPTION
## Summary

Closes #580 — completes the 说→有 chain for the **entity + relation** case.

When the NL schema-intent resolver drafts an `add_entity` proposal that includes a relation, the relation was **stripped** from the governed proposal and **silently dropped at graduation** (only `defineEntity()` was written, never `defineRelation()`). #578 deliberately pinned that strip under test and deferred the fix here.

This makes `relation` a **first-class graduable `ProposalChange`**:

- **Types** (`packages/core/src/types/proposal.ts`): add `"relation"` to `ProposalChangeTarget` and `RelationDefinition` to the `ChangeDefinition` union.
- **File writer** (`proposal-file-writer.ts`): wire the three `Record<WritableChangeTarget, …>` maps — `relations/` subdir, `.relation` kind suffix, `defineRelation` factory — so a relation change deterministically serializes to `export default defineRelation({...})`.
- **Impact analyzer**: classify a relation-create as additive / non-breaking (mirrors entity-create); intentionally kept OUT of `DATA_TARGETS` (a brand-new relation has no prior rows to probe).
- **Route** (`persistGovernedEntityDraft`): emit a **second** `relation` change (the entity change stays a clean `EntityDefinition`) with a structural guard that **throws** on a present-but-malformed relation rather than silently dropping it.

Net: an `add_entity`-with-relation proposal now graduates to BOTH `defineEntity(...)` and `defineRelation(...)` source.

## Test

- Updated the adapter-server HTTP test: the governed proposal now carries TWO changes — `entity` (definition clean of `relation`) **and** `relation` (definition = the `RelationDefinition`, asserted `from`/`to`/`cardinality`/`fromName`/`toName`). Response round-trip on `body.relation` kept.
- Added a `proposal-file-writer` test: a `relation` create writes to `relations/` as `defineRelation({...})`.
- `bun run typecheck` clean (adding `"relation"` to the union surfaced no exhaustiveness breaks beyond the 3 intended file-writer map entries). Targeted tests: 71 pass / 0 fail across the 3 affected files.

## Notes for review

- `DATA_TARGETS` deliberately excludes `relation` (documented inline) — the explicit relation-create non-breaking rule is a defensive belt that stays correct even if a future maintainer adds `relation` to `DATA_TARGETS`.
- The relation change's `name` is the relation's own name (e.g. `purchase_request_items`), distinct from the entity change's name, so they never collide on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Relations are now independently tracked and managed as proposal changes.

* **Improvements**
  * Graduated proposals now generate separate relation definitions alongside entity definitions.
  * Enhanced error handling for schema proposal persistence with structured error responses.

* **Tests**
  * Added comprehensive test coverage for relation proposal changes and file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->