### PR TITLE
feat(adapter-mcp): resolve_schema_intent MCP tool — NL→governed proposal (#583)

### DIFF
--- a/addons/adapter-mcp/cap-adapter-mcp/__tests__/schema-intent-tools.test.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/__tests__/schema-intent-tools.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Spec 52 "说→有" (issue #583) — `resolve_schema_intent` MCP tool tests.
+ *
+ * The MCP-channel sibling of the HTTP test
+ * `adapter-server/__tests__/ai-resolve-schema-intent.test.ts`. Exercises the
+ * real resolver (`resolveSchemaIntent`) behind the MCP tool, with a
+ * deterministic fake AIService (no real LLM calls). A validated draft is
+ * PERSISTED into the GOVERNED ProposalEngine the MCP server's
+ * `create_proposal` / `list_proposals` tools share, so it surfaces in the
+ * review pipeline (`/api/proposals`).
+ *
+ * Scenarios:
+ *   1. add_entity → entity draft returned + governed proposal persisted (draft).
+ *   2. add_rule → rule draft returned + governed proposal persisted (draft).
+ *   3. AI not configured → structured unavailable error, nothing persisted.
+ *   4. Permission denied via checkToolPolicy → blocked, nothing persisted.
+ *   5. no_match → nothing persisted (not a governed change).
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type {
+  ActionDefinition,
+  Actor,
+  AIService,
+  EntityDefinition,
+  RuleDefinition,
+} from "@linchkit/core";
+import {
+  ActionRegistry,
+  createOntologyRegistry,
+  createProposalEngine,
+  EntityRegistry,
+} from "@linchkit/core/server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerSchemaIntentTools } from "../src/schema-intent-tools";
+
+// ── Test harness (mirrors proposal-tools.test.ts) ───────────
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+type ToolsMap = Record<string, RegisteredTool>;
+
+function getTools(server: unknown): ToolsMap {
+  return (server as { _registeredTools: ToolsMap })._registeredTools;
+}
+
+function parseToolResult(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const purchaseSchema: EntityDefinition = {
+  name: "purchase_request",
+  label: "Purchase Request",
+  description: "A purchase request",
+  fields: {
+    amount: { type: "number", required: true, label: "Amount" },
+    department: { type: "string", required: true, label: "Department" },
+    status: { type: "string", label: "Status" },
+  },
+};
+
+const createPurchaseAction: ActionDefinition = {
+  name: "create_purchase_request",
+  entity: "purchase_request",
+  label: "Create Purchase Request",
+  description: "Create a new purchase request for a department",
+  input: {
+    amount: { type: "number", required: true, label: "Amount" },
+    department: { type: "string", required: true, label: "Department" },
+  },
+  policy: "unrestricted",
+};
+
+function buildOntology(rules: RuleDefinition[] = []): ReturnType<typeof createOntologyRegistry> {
+  const entityRegistry = new EntityRegistry();
+  entityRegistry.register(purchaseSchema);
+  const actionRegistry = new ActionRegistry();
+  actionRegistry.register(createPurchaseAction);
+  return createOntologyRegistry({
+    schemas: entityRegistry,
+    actions: actionRegistry,
+    rules,
+    states: [],
+    views: [],
+  });
+}
+
+interface FakeAiServiceOptions {
+  responseContent?: string;
+}
+
+function fakeAiService(opts: FakeAiServiceOptions): AIService {
+  return {
+    configured: true,
+    defaultProvider: "fake",
+    providerNames: ["fake"],
+    complete: async () => ({
+      content: opts.responseContent ?? "",
+      usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      model: "fake-model",
+      provider: "fake",
+      duration: 5,
+    }),
+  } as unknown as AIService;
+}
+
+const unconfiguredAi: AIService = {
+  configured: false,
+  defaultProvider: null,
+  providerNames: [],
+  complete: async () => {
+    throw new Error("AI not configured");
+  },
+} as unknown as AIService;
+
+/** Build a server with the resolve_schema_intent tool registered. */
+function setup(opts: {
+  aiService: AIService;
+  rules?: RuleDefinition[];
+  permissionRegistry?: import("@linchkit/core").PermissionRegistry;
+  actor?: Actor;
+  checkToolPolicy?: (
+    toolName: string,
+    category: string,
+  ) => { content: Array<{ type: "text"; text: string }>; isError: true } | undefined;
+}): {
+  tools: ToolsMap;
+  proposalEngine: ReturnType<typeof createProposalEngine>;
+} {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const proposalEngine = createProposalEngine();
+  registerSchemaIntentTools(server, {
+    aiService: opts.aiService,
+    ontologyRegistry: buildOntology(opts.rules),
+    proposalEngine,
+    permissionRegistry: opts.permissionRegistry,
+    getSessionActor: () => opts.actor,
+    checkToolPolicy: opts.checkToolPolicy,
+  });
+  return { tools: getTools(server), proposalEngine };
+}
+
+// ── Scenario 1: add_entity ──────────────────────────────────
+
+describe("resolve_schema_intent — add_entity", () => {
+  let tools: ToolsMap;
+  let proposalEngine: ReturnType<typeof createProposalEngine>;
+
+  beforeEach(() => {
+    const ai = fakeAiService({
+      responseContent: JSON.stringify({
+        kind: "add_entity",
+        entity: {
+          name: "product",
+          label: "Product",
+          fields: [
+            { name: "barcode", type: "string", required: false, unique: true },
+            { name: "case_pack_quantity", type: "number", required: false, min: 1 },
+          ],
+        },
+        confidence: 0.9,
+        explanation: "Add a product catalog entity.",
+      }),
+    });
+    ({ tools, proposalEngine } = setup({ aiService: ai }));
+  });
+
+  test("registers the resolve_schema_intent tool", () => {
+    expect(tools.resolve_schema_intent).toBeDefined();
+  });
+
+  test("returns the entity draft and persists a governed proposal (draft)", async () => {
+    const result = await tools.resolve_schema_intent?.handler(
+      { prompt: "增加一个商品管理，支持条码和箱规" },
+      {},
+    );
+    expect(result?.isError).toBeUndefined();
+    const body = parseToolResult(result) as {
+      outcome: string;
+      entityName?: string;
+      fields?: Array<{ name: string }>;
+      proposalId?: string;
+      proposalStatus?: string;
+    };
+    expect(body.outcome).toBe("entity_proposal_draft");
+    expect(body.entityName).toBe("product");
+    expect((body.fields ?? []).map((f) => f.name).sort()).toEqual(
+      ["barcode", "case_pack_quantity"].sort(),
+    );
+    expect(typeof body.proposalId).toBe("string");
+    expect(body.proposalStatus).toBe("draft");
+
+    // Persisted into the SAME engine list_proposals serves, scoped to the entity.
+    const persisted = proposalEngine.listProposals({ capability: "product" });
+    expect(persisted).toHaveLength(1);
+    const found = persisted.find((p) => p.id === body.proposalId);
+    expect(found).toBeDefined();
+    if (!found) throw new Error("expected the governed entity draft");
+    expect(found.status).toBe("draft");
+    const changes = found.changes as Array<{ target: string; operation: string; name: string }>;
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.target).toBe("entity");
+    expect(changes[0]?.operation).toBe("create");
+    expect(changes[0]?.name).toBe("product");
+    // Audit trail — records WHO requested the resolution.
+    expect(String(found.description ?? "")).toContain("Requested by");
+  });
+});
+
+// ── Scenario 2: add_rule ────────────────────────────────────
+
+describe("resolve_schema_intent — add_rule", () => {
+  let tools: ToolsMap;
+  let proposalEngine: ReturnType<typeof createProposalEngine>;
+
+  beforeEach(() => {
+    const ai = fakeAiService({
+      responseContent: JSON.stringify({
+        kind: "add_rule",
+        targetEntity: "purchase_request",
+        rule: {
+          name: "block_overlimit_amount",
+          label: "Block over-limit amount",
+          description: "Block purchase requests over 10000",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 10000 },
+          effect: { type: "block", message: "Amount exceeds the 10000 limit" },
+        },
+        confidence: 0.9,
+        explanation: "Block purchase requests whose amount exceeds 10000.",
+      }),
+    });
+    ({ tools, proposalEngine } = setup({ aiService: ai }));
+  });
+
+  test("returns the rule draft and persists a governed proposal (draft)", async () => {
+    const result = await tools.resolve_schema_intent?.handler(
+      { prompt: "Block purchase requests over 10000" },
+      {},
+    );
+    expect(result?.isError).toBeUndefined();
+    const body = parseToolResult(result) as {
+      outcome: string;
+      ruleName?: string;
+      targetEntity?: string;
+      operation?: string;
+      proposalId?: string;
+      proposalStatus?: string;
+    };
+    expect(body.outcome).toBe("proposal_draft");
+    expect(body.ruleName).toBe("block_overlimit_amount");
+    expect(body.targetEntity).toBe("purchase_request");
+    expect(body.operation).toBe("create");
+    expect(typeof body.proposalId).toBe("string");
+    expect(body.proposalStatus).toBe("draft");
+
+    const persisted = proposalEngine.listProposals({ capability: "purchase_request" });
+    const found = persisted.find((p) => p.id === body.proposalId);
+    expect(found).toBeDefined();
+    if (!found) throw new Error("expected the governed rule draft");
+    expect(found.status).toBe("draft");
+    const changes = found.changes as Array<{
+      target: string;
+      operation: string;
+      name: string;
+      definition?: Record<string, unknown>;
+    }>;
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.target).toBe("rule");
+    expect(changes[0]?.operation).toBe("create");
+    expect(changes[0]?.name).toBe("block_overlimit_amount");
+    expect(changes[0]?.definition?.condition).toEqual({
+      field: "amount",
+      operator: "gt",
+      value: 10000,
+    });
+  });
+});
+
+// ── Scenario 3: AI not configured ───────────────────────────
+
+describe("resolve_schema_intent — AI not configured", () => {
+  test("returns a structured unavailable error and persists nothing", async () => {
+    const { tools, proposalEngine } = setup({ aiService: unconfiguredAi });
+    const result = await tools.resolve_schema_intent?.handler(
+      { prompt: "Block purchase requests over 10000" },
+      {},
+    );
+    expect(result?.isError).toBe(true);
+    const body = parseToolResult(result) as { error: string; message: string };
+    expect(body.error).toBe("unavailable");
+    expect(body.message.length).toBeGreaterThan(0);
+    // Nothing reaches the governed engine.
+    expect(proposalEngine.listProposals({})).toHaveLength(0);
+  });
+});
+
+// ── Scenario 4: permission denied via checkToolPolicy ───────
+
+describe("resolve_schema_intent — blocked by tool policy", () => {
+  test("checkToolPolicy short-circuits → blocked, nothing persisted", async () => {
+    const ai = fakeAiService({
+      responseContent: JSON.stringify({
+        kind: "add_rule",
+        targetEntity: "purchase_request",
+        rule: {
+          name: "block_overlimit_amount",
+          label: "Block over-limit amount",
+          trigger: { action: "create_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 10000 },
+          effect: { type: "block", message: "too big" },
+        },
+        confidence: 0.9,
+        explanation: "x",
+      }),
+    });
+    const { tools, proposalEngine } = setup({
+      aiService: ai,
+      checkToolPolicy: (toolName, category) => {
+        // Deny the resolve_schema_intent tool for this session.
+        if (toolName === "resolve_schema_intent" && category === "proposals") {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ error: "Tool not allowed by client policy" }),
+              },
+            ],
+            isError: true as const,
+          };
+        }
+        return undefined;
+      },
+    });
+
+    const result = await tools.resolve_schema_intent?.handler(
+      { prompt: "Block purchase requests over 10000" },
+      {},
+    );
+    expect(result?.isError).toBe(true);
+    const body = parseToolResult(result) as { error: string };
+    expect(body.error).toBe("Tool not allowed by client policy");
+    // Policy short-circuits BEFORE the AI is called — nothing governed.
+    expect(proposalEngine.listProposals({})).toHaveLength(0);
+  });
+});
+
+// ── Scenario 5: no_match persists nothing ───────────────────
+
+describe("resolve_schema_intent — no_match", () => {
+  test("returns no_match and persists nothing", async () => {
+    const ai = fakeAiService({
+      responseContent: JSON.stringify({
+        kind: "no_match",
+        explanation: "This is about creating an entity, not a rule.",
+      }),
+    });
+    const { tools, proposalEngine } = setup({ aiService: ai });
+    const result = await tools.resolve_schema_intent?.handler(
+      { prompt: "Create a brand new vendor entity" },
+      {},
+    );
+    expect(result?.isError).toBeUndefined();
+    const body = parseToolResult(result) as { outcome: string; proposalId?: unknown };
+    expect(body.outcome).toBe("no_match");
+    expect(body.proposalId).toBeUndefined();
+    expect(proposalEngine.listProposals({})).toHaveLength(0);
+  });
+});

--- a/addons/adapter-mcp/cap-adapter-mcp/src/factory.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/factory.ts
@@ -88,6 +88,15 @@ export function createCapAdapterMcp(options?: CapAdapterMcpOptions): CapabilityD
         // Spec 60 §6 — when the runtime exposes overlay fields, surface them
         // via list_entities / get_entity so AI agents see admin-added fields.
         overlayRegistry: ctx.overlayRegistry,
+        // Spec 52 "说→有" (issue #583) — when the runtime exposes an AI service
+        // + ontology, register the resolve_schema_intent tool. `permissionRegistry`
+        // scopes the ontology catalog to the calling actor (least-privilege).
+        aiService: ctx.aiService,
+        permissionRegistry: ctx.permissionRegistry,
+        // The shared governed engine — gates create_proposal AND
+        // resolve_schema_intent, and lets MCP-drafted proposals surface in
+        // /api/proposals (issue #583).
+        proposalEngine: ctx.proposalEngine,
       });
 
       if (transportMode === "stdio") {
@@ -136,6 +145,14 @@ export function createCapAdapterMcp(options?: CapAdapterMcpOptions): CapabilityD
         insightEngine: ctx.evolutionRuntime?.insightEngine,
         // Spec 60 §6 — propagate overlay registry to per-session McpServers.
         overlayRegistry: ctx.overlayRegistry,
+        // Spec 52 "说→有" (issue #583) — propagate AI service + permission
+        // registry so each per-session McpServer can register resolve_schema_intent.
+        aiService: ctx.aiService,
+        permissionRegistry: ctx.permissionRegistry,
+        // The shared governed engine — gates create_proposal AND
+        // resolve_schema_intent, and lets MCP-drafted proposals surface in
+        // /api/proposals (issue #583).
+        proposalEngine: ctx.proposalEngine,
       };
 
       const {

--- a/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
@@ -17,10 +17,12 @@
 import type {
   ActionRegistry,
   Actor,
+  AIService,
   CommandLayer,
   EntityRegistry,
   FieldOverlayRecord,
   OntologyRegistry,
+  PermissionRegistry,
   RuleDefinition,
   StateDefinition,
 } from "@linchkit/core";
@@ -35,6 +37,7 @@ import { registerInsightTools } from "./insight-tools";
 import { registerManagementTools } from "./management-tools";
 import { registerProposalTools } from "./proposal-tools";
 import { registerScaffoldTools } from "./scaffold-tools";
+import { registerSchemaIntentTools } from "./schema-intent-tools";
 import { generateActionTools, isMcpExposed } from "./tool-registry";
 import type { McpClient, ToolPolicy } from "./types";
 
@@ -97,6 +100,20 @@ export interface McpAdapterOptions {
    * fall back to an empty `overlayFields: []` array — never throw.
    */
   overlayRegistry?: OverlayRegistry;
+  /**
+   * AI service — provides LLM completion (Spec 52 "说→有", issue #583).
+   * When configured AND `ontologyRegistry` + `proposalEngine` are present,
+   * registers the `resolve_schema_intent` tool so MCP clients can turn a
+   * natural-language utterance into a GOVERNED proposal draft. When omitted /
+   * not configured, the tool is simply not registered (graceful degradation).
+   */
+  aiService?: AIService;
+  /**
+   * Permission registry — when provided, `resolve_schema_intent` scopes its
+   * ontology catalog to entities the calling actor can act on (least-privilege,
+   * Spec 52 §1.1). Optional: dev runs without RBAC pass everything through.
+   */
+  permissionRegistry?: PermissionRegistry;
 }
 
 /**
@@ -149,6 +166,9 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
     executionLogger,
     insightEngine,
     overlayRegistry,
+    aiService,
+    permissionRegistry,
+    ontologyRegistry,
   } = options;
 
   const server = new McpServer({ name, version });
@@ -360,6 +380,23 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
       { name: "list_proposals", category: "proposals" },
       { name: "approve_proposal", category: "proposals" },
     );
+
+    // Register the schema-intent tool only when AI + ontology are ALSO wired
+    // (issue #583). It persists its governed draft into the SAME proposalEngine
+    // used above, so it must live inside this `if (proposalEngine)` block. The
+    // ontology + AI presence guard mirrors how the HTTP route 503s without
+    // them; here we simply don't register the tool when they're absent.
+    if (aiService?.configured && ontologyRegistry) {
+      registerSchemaIntentTools(server, {
+        aiService,
+        ontologyRegistry,
+        proposalEngine,
+        permissionRegistry,
+        getSessionActor: () => sessionActor,
+        checkToolPolicy,
+      });
+      allToolNames.push({ name: "resolve_schema_intent", category: "proposals" });
+    }
   }
 
   // Register execution log tools if execution logger is available

--- a/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-ontology.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-ontology.ts
@@ -1,0 +1,195 @@
+/**
+ * Spec 52 "说→有" — permission-scoped Ontology snapshot for the schema-intent
+ * resolver, MCP channel (issue #583).
+ *
+ * This is a FAITHFUL LOCAL COPY of adapter-server's
+ * `routes/ai-schema-intent-ontology.ts` (`buildSchemaIntentOntology`). The
+ * MCP `resolve_schema_intent` tool needs the SAME permission-scoped projection
+ * the HTTP route uses, but `adapter-mcp` must NOT import from `adapter-server`
+ * (module boundary: each adapter is independent; only `@linchkit/core` is
+ * shared). The helper depends ONLY on core types + `checkActionPermission`
+ * (from `@linchkit/core/server`), so copying it here keeps both channels in
+ * lock-step without crossing the boundary.
+ *
+ * If this projection logic ever moves into `@linchkit/core/ai`, BOTH this file
+ * and the adapter-server route should delegate to the core export instead.
+ *
+ * It owns the projection from the full `OntologyRegistry` into the structural
+ * `SchemaIntentOntology` the resolver consumes — including the EXISTING-rules
+ * snapshot (`update_rule` target list) and its permission gates.
+ */
+
+import type {
+  ActionDefinition,
+  Actor,
+  FieldDefinition,
+  OntologyRegistry,
+  PermissionRegistry,
+  RuleDefinition,
+} from "@linchkit/core";
+import type {
+  SchemaIntentEntity,
+  SchemaIntentOntology,
+  SchemaIntentRule,
+  SchemaIntentRuleEffect,
+} from "@linchkit/core/ai";
+import { checkActionPermission } from "@linchkit/core/server";
+
+/**
+ * Build the structural `SchemaIntentOntology` the resolver consumes from the
+ * full `OntologyRegistry`, scoped to entities the calling actor can act on.
+ *
+ * An entity is exposed only when the actor can execute at least one of its
+ * actions (matching the permission convention in `permission-middleware.ts`:
+ * the action's `entity` is the capability name). When no `permissionRegistry`
+ * is wired in (typical dev runs) we pass everything through — same permissive
+ * default as `ai-resolve-intent.ts`.
+ *
+ * Exported for unit testing the permission gate in isolation (both
+ * `listEntities` and `describeEntity` must enforce it).
+ */
+export function buildSchemaIntentOntology(opts: {
+  base: OntologyRegistry;
+  permissionRegistry?: PermissionRegistry;
+  actor: Actor;
+}): SchemaIntentOntology {
+  const { base, permissionRegistry, actor } = opts;
+
+  const allowedActions = (entityName: string): ActionDefinition[] => {
+    const all = base.actionsFor(entityName);
+    if (!permissionRegistry) return all;
+    const allowed: ActionDefinition[] = [];
+    for (const action of all) {
+      const result = checkActionPermission(permissionRegistry, actor, action.entity, action.name);
+      if (result.allowed) allowed.push(action);
+    }
+    return allowed;
+  };
+
+  const visibleEntities = (): string[] => {
+    const out: string[] = [];
+    for (const name of base.listEntities()) {
+      // With no permission registry, every entity is visible. Otherwise an
+      // entity is visible only if the actor can run at least one of its
+      // actions — there is nothing to attach a rule trigger to otherwise.
+      if (!permissionRegistry || allowedActions(name).length > 0) out.push(name);
+    }
+    return out;
+  };
+
+  // Project a registered RuleDefinition into the resolver's rule snapshot.
+  // A CODE condition (a TypeScript function) is NEVER serialized — only its
+  // kind + the rule's description are exposed, so the AI cannot pretend to
+  // edit source it cannot see. Declarative conditions are structured data
+  // and travel whole. `priority` + the declarative effect payload travel too
+  // so an update round-trip never silently resets / fabricates them, and
+  // `roundTrippable` marks whether the FULL rule can be rebuilt declaratively
+  // (the resolver takes the honest diff-only path otherwise).
+  const toSchemaIntentRule = (rule: RuleDefinition): SchemaIntentRule => {
+    const isCode = typeof rule.condition === "function";
+    // `rule.trigger` is guarded everywhere it is narrowed with `in`: a
+    // malformed rule can carry an undefined/null trigger at runtime despite
+    // the static type, and `"action" in undefined` throws.
+    const triggerActions =
+      rule.trigger && "action" in rule.trigger
+        ? Array.isArray(rule.trigger.action)
+          ? rule.trigger.action
+          : [rule.trigger.action]
+        : undefined;
+    // Only the declarative payload fields the resolver's buildEffect consumes
+    // (message / level / setFields) — never execute_action / trigger_flow
+    // params, which are not declaratively rebuildable anyway.
+    const effect: SchemaIntentRuleEffect = { type: rule.effect.type };
+    if ("message" in rule.effect && rule.effect.message !== undefined) {
+      effect.message = rule.effect.message;
+    }
+    if ("level" in rule.effect) effect.level = rule.effect.level;
+    if ("setFields" in rule.effect) effect.setFields = rule.effect.setFields;
+    // The declarative rebuild path (buildRuleDefinition) can only express:
+    // a SINGLE-action trigger, a SIMPLE (non-composite/not) condition, and a
+    // block/warn/require_approval/enrich effect. Anything else must take the
+    // diff-only path or the rebuild would silently flatten/replace parts the
+    // user never asked to change.
+    const hasSingleActionTrigger = Boolean(
+      rule.trigger && "action" in rule.trigger && typeof rule.trigger.action === "string",
+    );
+    const hasSimpleCondition =
+      !isCode &&
+      typeof rule.condition === "object" &&
+      rule.condition !== null &&
+      "field" in rule.condition;
+    const hasDeclarativeEffect =
+      rule.effect.type === "block" ||
+      rule.effect.type === "warn" ||
+      rule.effect.type === "require_approval" ||
+      rule.effect.type === "enrich";
+    const roundTrippable = hasSingleActionTrigger && hasSimpleCondition && hasDeclarativeEffect;
+    return {
+      name: rule.name,
+      label: rule.label,
+      description: rule.description,
+      ...(triggerActions ? { triggerActions } : {}),
+      effectType: rule.effect.type,
+      effect,
+      ...(rule.priority !== undefined ? { priority: rule.priority } : {}),
+      conditionKind: isCode ? "code" : "declarative",
+      ...(isCode ? {} : { condition: rule.condition as SchemaIntentRule["condition"] }),
+      roundTrippable,
+    };
+  };
+
+  // Permission gate for rules, mirroring `actionNames`: an action-triggered
+  // rule is visible only when the actor can run at least one of its trigger
+  // actions. Rules with non-action triggers (state/event/schedule) ride on
+  // the entity-level gate, which already passed by the time this runs.
+  const visibleRules = (entityName: string, rules: RuleDefinition[]): SchemaIntentRule[] => {
+    if (!permissionRegistry) return rules.map(toSchemaIntentRule);
+    const allowedNames = new Set(allowedActions(entityName).map((a) => a.name));
+    return rules
+      .filter((rule) => {
+        // A malformed (trigger-less) rule rides the entity-level gate, same
+        // as non-action triggers — `in` on undefined/null would throw.
+        if (!rule.trigger || !("action" in rule.trigger)) return true;
+        const actions = Array.isArray(rule.trigger.action)
+          ? rule.trigger.action
+          : [rule.trigger.action];
+        return actions.some((name) => allowedNames.has(name));
+      })
+      .map(toSchemaIntentRule);
+  };
+
+  return {
+    listEntities: () => visibleEntities(),
+    describeEntity: (entityName: string): SchemaIntentEntity | undefined => {
+      // Enforce the SAME permission gate the visible-entity list uses. Without
+      // this, calling describeEntity() directly with an entity the actor cannot
+      // act on would leak its full description (least-privilege violation) —
+      // listEntities() filters, but describeEntity() must too.
+      if (permissionRegistry && allowedActions(entityName).length === 0) {
+        return undefined;
+      }
+      const descriptor = base.describe(entityName);
+      if (!descriptor) return undefined;
+      const fields: SchemaIntentEntity["fields"] = [];
+      for (const [name, raw] of Object.entries(descriptor.fields)) {
+        const field = raw as FieldDefinition;
+        fields.push({
+          name,
+          type: field.type,
+          required: field.required === true,
+          label: field.label,
+          description: field.description,
+        });
+      }
+      return {
+        name: descriptor.name,
+        label: descriptor.label,
+        description: descriptor.description,
+        fields,
+        actionNames: allowedActions(entityName).map((a) => a.name),
+        // EXISTING rules (includes inherited) — the `update_rule` target list.
+        rules: visibleRules(entityName, descriptor.rules),
+      };
+    },
+  };
+}

--- a/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-ontology.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-ontology.ts
@@ -91,7 +91,7 @@ export function buildSchemaIntentOntology(opts: {
     // malformed rule can carry an undefined/null trigger at runtime despite
     // the static type, and `"action" in undefined` throws.
     const triggerActions =
-      rule.trigger && "action" in rule.trigger
+      rule.trigger && typeof rule.trigger === "object" && "action" in rule.trigger
         ? Array.isArray(rule.trigger.action)
           ? rule.trigger.action
           : [rule.trigger.action]
@@ -111,7 +111,10 @@ export function buildSchemaIntentOntology(opts: {
     // diff-only path or the rebuild would silently flatten/replace parts the
     // user never asked to change.
     const hasSingleActionTrigger = Boolean(
-      rule.trigger && "action" in rule.trigger && typeof rule.trigger.action === "string",
+      rule.trigger &&
+        typeof rule.trigger === "object" &&
+        "action" in rule.trigger &&
+        typeof rule.trigger.action === "string",
     );
     const hasSimpleCondition =
       !isCode &&
@@ -149,7 +152,8 @@ export function buildSchemaIntentOntology(opts: {
       .filter((rule) => {
         // A malformed (trigger-less) rule rides the entity-level gate, same
         // as non-action triggers — `in` on undefined/null would throw.
-        if (!rule.trigger || !("action" in rule.trigger)) return true;
+        if (!rule.trigger || typeof rule.trigger !== "object" || !("action" in rule.trigger))
+          return true;
         const actions = Array.isArray(rule.trigger.action)
           ? rule.trigger.action
           : [rule.trigger.action];

--- a/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-tools.ts
@@ -1,0 +1,437 @@
+/**
+ * Spec 52 "说→有" — MCP `resolve_schema_intent` tool (issue #583).
+ *
+ * The MCP-channel sibling of the HTTP route
+ * `POST /api/ai/resolve-schema-intent` (issue #578). It lets an MCP-connected
+ * agent send a natural-language utterance (e.g. "增加一个商品管理") and get a
+ * GOVERNED proposal draft — closing the "every channel" gap for 说→有 on the
+ * MCP channel.
+ *
+ * It is a faithful port of the route's wiring + security posture:
+ *  - Validates/sanitizes the prompt (Zod min-length; the resolver's
+ *    `sanitizePrompt` runs the prompt-injection defense internally).
+ *  - Builds a PERMISSION-SCOPED ontology via `buildSchemaIntentOntology`
+ *    (LOCAL copy in `./schema-intent-ontology` — adapter-mcp must not import
+ *    from adapter-server; see that file's header for the boundary rationale).
+ *  - Guards on `aiService?.configured` / `ontologyRegistry` / `proposalEngine`
+ *    — degrades gracefully with a structured "unavailable" error (mirrors the
+ *    route's 503 semantics) instead of throwing.
+ *  - Runs the canonical `resolveSchemaIntent()` engine, drafting into a
+ *    THROWAWAY draft engine (Engine A) exactly like the route.
+ *  - Persists the validated draft into the SAME governed `proposalEngine`
+ *    (Engine B) the MCP server already uses for `create_proposal` — so it
+ *    surfaces in `list_proposals` / `/api/proposals`.
+ *
+ * Hard rules (repo principle "AI Never Modifies Production Directly"):
+ *  - The tool NEVER submits, approves, or applies the proposal. The persisted
+ *    governed Proposal is ALWAYS `draft`. Graduating it is a separate,
+ *    human-gated path.
+ */
+
+import type {
+  Actor,
+  AIService,
+  EntityDefinition,
+  OntologyRegistry,
+  PermissionRegistry,
+  ProposalChange,
+  ProposalDefinition,
+  RuleDefinition,
+} from "@linchkit/core";
+import type {
+  SchemaIntentEntityProposalDraft,
+  SchemaIntentOutcome,
+  SchemaIntentProposalDraft,
+} from "@linchkit/core/ai";
+import {
+  ProposalEngine,
+  REQUIRES_CODE_CHANGE_MARKER,
+  resolveSchemaIntent,
+} from "@linchkit/core/ai";
+import type { ProposalEngine as GovernedProposalEngine } from "@linchkit/core/server";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { buildSchemaIntentOntology } from "./schema-intent-ontology";
+import { toMcpShape } from "./zod-compat";
+
+/** Error result returned when a tool is blocked by policy or unavailable. */
+interface ToolBlockedResult {
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+}
+
+export interface SchemaIntentToolsOptions {
+  /** AI service — provides LLM completion. The tool degrades when not configured. */
+  aiService?: AIService;
+  /** Unified ontology registry — projected into a permission-scoped catalog. */
+  ontologyRegistry?: OntologyRegistry;
+  /**
+   * GOVERNED proposal engine — the SAME instance `create_proposal` /
+   * `list_proposals` use, so the NL draft surfaces in the review pipeline.
+   */
+  proposalEngine?: GovernedProposalEngine;
+  /**
+   * Permission registry — when present, the ontology catalog is scoped to
+   * entities the resolved actor can act on (least-privilege). Optional: dev
+   * runs without RBAC pass everything through.
+   */
+  permissionRegistry?: PermissionRegistry;
+  /** Session actor getter — called at invocation time to reflect auth changes. */
+  getSessionActor?: () => Actor | undefined;
+  /**
+   * Tool policy checker. Returns an error result if the tool is not allowed,
+   * or undefined if the tool is permitted.
+   */
+  checkToolPolicy?: (toolName: string, category: string) => ToolBlockedResult | undefined;
+}
+
+/** Default actor when no session actor is wired (open access / stdio). */
+const DEFAULT_ACTOR: Actor = {
+  type: "ai",
+  id: "mcp-client",
+  name: "MCP Client",
+  groups: ["ai_agent"],
+};
+
+/** Wrap a payload object as a successful MCP text tool result. */
+function textResult(payload: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+/** Wrap a structured error as an MCP error tool result (mirrors route 503/500). */
+function errorResult(payload: Record<string, unknown>): ToolBlockedResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    isError: true,
+  };
+}
+
+// ── Translate the resolver draft → governed Proposal ─────────
+// Ports `persistGovernedRuleDraft` / `persistGovernedEntityDraft` from
+// adapter-server's `ai-resolve-schema-intent.ts`. The functions depend ONLY
+// on core types + the governed engine's `createProposal`, so the port carries
+// no adapter-server dependency.
+
+/**
+ * Persist a resolver-produced `add_rule` / `update_rule` draft into the shared
+ * GOVERNED engine — the same instance `list_proposals` reads from — so the NL
+ * draft surfaces in the review pipeline.
+ *
+ * The resolver runs ALL of its security validation first; by the time we reach
+ * here the draft carries only validated, typed values. The proposal lands in
+ * `draft` status. It is NEVER submitted, approved, or applied here.
+ *
+ * Returns `undefined` when the draft does not carry a usable rule definition
+ * for a definition-bearing path (defensive — the resolver only emits
+ * `proposal_draft` with a built rule).
+ */
+function persistGovernedRuleDraft(opts: {
+  engine: GovernedProposalEngine;
+  outcome: SchemaIntentProposalDraft;
+  reasoning: string;
+  /** The actor who requested the resolution — recorded for the audit trail. */
+  actor: Actor;
+}): ProposalDefinition | undefined {
+  const { engine, outcome, reasoning, actor } = opts;
+  const { proposal: draft, ruleName, targetEntity, explanation, operation } = outcome;
+  const diffOnly = outcome.requiresCodeChange === true;
+
+  const rawDefinition = draft.diff?.definition;
+  const definition =
+    rawDefinition && typeof rawDefinition === "object"
+      ? (rawDefinition as RuleDefinition)
+      : undefined;
+  if (!definition && !diffOnly) return undefined;
+
+  // A diff-only draft is an HONEST developer change-request: it has no
+  // definition BY DESIGN (the rule cannot be rebuilt declaratively). The
+  // PERSISTED proposal carries a stable text marker on the change's diff and
+  // the description — the fields the review UI renders.
+  const diffText = outcome.diffSummary ?? explanation;
+  const change: ProposalChange = {
+    target: "rule",
+    operation,
+    name: ruleName,
+    ...(definition ? { definition } : {}),
+    diff: diffOnly ? `${REQUIRES_CODE_CHANGE_MARKER} ${diffText}` : diffText,
+  };
+
+  const codeChangeNote = diffOnly
+    ? `\n\n${REQUIRES_CODE_CHANGE_MARKER} This update targets a rule that cannot be rebuilt declaratively; it intentionally carries no definition — a developer must apply the described change in source.`
+    : "";
+
+  return engine.createProposal({
+    title: explanation,
+    // Preserve the original utterance + the requesting actor for the audit
+    // trail. The utterance is never interpolated into a privileged context —
+    // this string is display/audit metadata only.
+    description: `${reasoning}\n\n(Requested by ${actor.type}:${actor.id})${codeChangeNote}`,
+    author: { type: "ai", id: "schema-intent-resolver", name: "Schema Intent Resolver" },
+    // The rule attaches to its target entity — the governed capability key.
+    capability: targetEntity,
+    changeType: "minor",
+    changes: [change],
+  });
+}
+
+/**
+ * Persist a resolver-produced `add_entity` draft into the shared GOVERNED
+ * engine. The resolver runs ALL of its structural validation first; we
+ * translate the validated `EntityDefinition` into a single governed
+ * `ProposalChange` (`{ target: "entity", operation: "create", ... }`) in
+ * `draft` status. It is NEVER submitted, approved, or applied here.
+ *
+ * A drafted relation rides along inside the resolver draft's definition, but it
+ * is NOT carried into the governed change (the relation is stripped below) —
+ * mirroring the route's #580 deferral. The relation still surfaces in the tool
+ * response for the review UI.
+ *
+ * Throws (rather than returning undefined) on a malformed/missing definition —
+ * a silent undefined would let the tool report success while nothing governed.
+ */
+function persistGovernedEntityDraft(opts: {
+  engine: GovernedProposalEngine;
+  outcome: SchemaIntentEntityProposalDraft;
+  reasoning: string;
+  actor: Actor;
+}): ProposalDefinition {
+  const { engine, outcome, reasoning, actor } = opts;
+  const { proposal: draft, entityName, explanation } = outcome;
+
+  const definition = draft.diff?.definition;
+  if (!definition || typeof definition !== "object") {
+    throw new Error(
+      `persistGovernedEntityDraft: missing or non-object entity definition (entityName=${entityName})`,
+    );
+  }
+  // Strip the drafted relation extra — the governed `entity` change's
+  // definition must be a clean `EntityDefinition`. The relation surfaces
+  // separately in the response (#580 deferral).
+  const { relation: _relation, ...entityRest } = definition as Record<string, unknown>;
+  if (
+    typeof entityRest.name !== "string" ||
+    typeof entityRest.fields !== "object" ||
+    entityRest.fields === null
+  ) {
+    throw new Error(
+      `persistGovernedEntityDraft: entity definition missing a string name or fields object (entityName=${entityName})`,
+    );
+  }
+  const entityDefinition = entityRest as unknown as EntityDefinition;
+
+  const change: ProposalChange = {
+    target: "entity",
+    operation: "create",
+    name: entityName,
+    definition: entityDefinition,
+    diff: explanation,
+  };
+
+  return engine.createProposal({
+    title: explanation,
+    description: `${reasoning}\n\n(Requested by ${actor.type}:${actor.id})`,
+    author: { type: "ai", id: "schema-intent-resolver", name: "Schema Intent Resolver" },
+    capability: entityName,
+    changeType: "minor",
+    changes: [change],
+  });
+}
+
+// ── Response shaping ─────────────────────────────────────────
+
+/**
+ * Shape the structured tool response from the resolver outcome + the persisted
+ * governed proposal. Mirrors the HTTP route's `toResponse`: surfaces the
+ * outcome kind, the governed proposalId + status, and the key fields per kind.
+ */
+function shapeResponse(
+  outcome: SchemaIntentOutcome,
+  governed?: ProposalDefinition,
+): Record<string, unknown> {
+  switch (outcome.kind) {
+    case "proposal_draft":
+      return {
+        outcome: "proposal_draft",
+        proposalId: governed?.id,
+        proposalStatus: governed?.status,
+        operation: outcome.operation,
+        ruleName: outcome.ruleName,
+        targetEntity: outcome.targetEntity,
+        confidence: outcome.confidence,
+        explanation: outcome.explanation,
+        ...(outcome.diffSummary !== undefined ? { diffSummary: outcome.diffSummary } : {}),
+        ...(outcome.requiresCodeChange ? { requiresCodeChange: true } : {}),
+      };
+    case "entity_proposal_draft":
+      return {
+        outcome: "entity_proposal_draft",
+        proposalId: governed?.id,
+        proposalStatus: governed?.status,
+        entityName: outcome.entityName,
+        fields: outcome.fields,
+        ...(outcome.relation ? { relation: outcome.relation } : {}),
+        confidence: outcome.confidence,
+        explanation: outcome.explanation,
+      };
+    case "clarification":
+      return {
+        outcome: "clarification",
+        question: outcome.question,
+        bestConfidence: outcome.bestConfidence,
+        ...(outcome.detectedIntents ? { detectedIntents: outcome.detectedIntents } : {}),
+      };
+    case "no_match":
+      return {
+        outcome: "no_match",
+        reason: outcome.reason,
+        message: outcome.message,
+      };
+  }
+}
+
+// ── Tool registration ────────────────────────────────────────
+
+const resolveSchemaIntentShape = {
+  prompt: z
+    .string()
+    .min(1, "prompt must be a non-empty string")
+    .describe(
+      "Natural-language utterance describing a desired metamodel change " +
+        "(e.g. '增加一个商品管理' or 'block purchase requests over 10000'). " +
+        "Resolves into a GOVERNED proposal draft — never auto-applied.",
+    ),
+};
+
+/**
+ * Register the `resolve_schema_intent` tool on the MCP server.
+ *
+ * The caller must only register this when `aiService.configured`,
+ * `ontologyRegistry`, and `proposalEngine` are all present (mirroring how
+ * `registerProposalTools` is conditionally registered). The tool still
+ * re-guards at invocation time and returns a structured unavailable error if
+ * any dependency is missing — defense-in-depth.
+ */
+export function registerSchemaIntentTools(
+  server: McpServer,
+  options: SchemaIntentToolsOptions,
+): void {
+  server.tool(
+    "resolve_schema_intent",
+    "说→有 (Spec 52): turn a natural-language utterance into a GOVERNED metamodel " +
+      "change proposal (new entity, new/updated business rule). The proposal is " +
+      "always created in DRAFT status and surfaces in list_proposals / the review " +
+      "pipeline — AI never auto-applies. Human approval is required before any " +
+      "structural change is applied.",
+    toMcpShape(resolveSchemaIntentShape),
+    async (args: { prompt: string }) => {
+      // Defense-in-depth: verify tool is allowed for current session. Reuses
+      // the "proposals" category — a schema-intent resolution produces a
+      // governed proposal, same as create_proposal.
+      const blocked = options.checkToolPolicy?.("resolve_schema_intent", "proposals");
+      if (blocked) return blocked;
+
+      const { aiService, ontologyRegistry, proposalEngine, permissionRegistry } = options;
+
+      // Graceful degradation — structured unavailable error, never throw.
+      // Mirrors the route's 503 semantics.
+      if (!aiService?.configured) {
+        return errorResult({
+          error: "unavailable",
+          message:
+            "AI service is not configured. Configure an AI provider in linchkit.config.ts to enable schema intent resolution.",
+        });
+      }
+      if (!ontologyRegistry) {
+        return errorResult({
+          error: "unavailable",
+          message:
+            "Ontology registry is not available — schema intent resolution requires the unified Ontology layer.",
+        });
+      }
+      if (!proposalEngine) {
+        return errorResult({
+          error: "unavailable",
+          message:
+            "Proposal engine is not available — schema intent resolution requires the governed proposal pipeline.",
+        });
+      }
+
+      // Resolve the actor from the trusted session context (NEVER from input).
+      const actor = options.getSessionActor?.() ?? DEFAULT_ACTOR;
+
+      // Permission-scoped ontology — the AI sees only what the actor can act on.
+      const ontology = buildSchemaIntentOntology({
+        base: ontologyRegistry,
+        permissionRegistry,
+        actor,
+      });
+
+      // Engine A — the resolver's throwaway draft sink. Every successful
+      // resolution is TRANSLATED into the governed engine (Engine B) below,
+      // then this engine is cleared so its in-memory map never grows unbounded.
+      const draftEngine = new ProposalEngine();
+
+      let outcome: SchemaIntentOutcome;
+      try {
+        outcome = await resolveSchemaIntent(
+          {
+            utterance: args.prompt,
+            userId: actor.id,
+          },
+          {
+            provider: aiService,
+            ontology,
+            // The resolver mints its draft + runs ALL security validation here.
+            proposalEngine: draftEngine,
+          },
+        );
+      } catch (err) {
+        // The resolver swallows AI errors into no_match, so reaching here means
+        // an unexpected programmer error. Surface a structured error; nothing
+        // is applied.
+        const message = err instanceof Error ? err.message : "Schema intent resolution failed";
+        return errorResult({ error: "resolution_failed", message });
+      } finally {
+        // Engine A is throwaway — its entry was already translated into the
+        // governed engine (or nothing was minted). Clearing keeps its in-memory
+        // map bounded. The resolver's returned proposal object survives the
+        // clear (we only drop the map entry); translation reads it by reference.
+        draftEngine.clear();
+      }
+
+      // ── Persist the GOVERNED draft (only for a real proposed rule/entity) ──
+      // `clarification` / `no_match` are NOT governed changes — nothing persists.
+      let governed: ProposalDefinition | undefined;
+      try {
+        if (outcome.kind === "proposal_draft") {
+          governed = persistGovernedRuleDraft({
+            engine: proposalEngine,
+            outcome,
+            reasoning: args.prompt,
+            actor,
+          });
+        } else if (outcome.kind === "entity_proposal_draft") {
+          governed = persistGovernedEntityDraft({
+            engine: proposalEngine,
+            outcome,
+            reasoning: args.prompt,
+            actor,
+          });
+        }
+      } catch (err) {
+        // persistGovernedEntityDraft throws on a malformed/missing definition
+        // (defensive guards that should never fire in normal flow). Keep the
+        // structured-error envelope instead of leaking an unhandled throw.
+        const message = err instanceof Error ? err.message : "Failed to persist governed proposal";
+        return errorResult({ error: "persist_failed", message });
+      }
+
+      return textResult(shapeResponse(outcome, governed));
+    },
+  );
+}

--- a/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-tools.ts
@@ -141,7 +141,7 @@ function persistGovernedRuleDraft(opts: {
   const { proposal: draft, ruleName, targetEntity, explanation, operation } = outcome;
   const diffOnly = outcome.requiresCodeChange === true;
 
-  const rawDefinition = draft.diff?.definition;
+  const rawDefinition = draft?.diff?.definition;
   const definition =
     rawDefinition && typeof rawDefinition === "object"
       ? (rawDefinition as RuleDefinition)
@@ -203,7 +203,7 @@ function persistGovernedEntityDraft(opts: {
   const { engine, outcome, reasoning, actor } = opts;
   const { proposal: draft, entityName, explanation } = outcome;
 
-  const definition = draft.diff?.definition;
+  const definition = draft?.diff?.definition;
   if (!definition || typeof definition !== "object") {
     throw new Error(
       `persistGovernedEntityDraft: missing or non-object entity definition (entityName=${entityName})`,

--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-mcp-transport.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-mcp-transport.test.ts
@@ -168,6 +168,12 @@ beforeAll(async () => {
     evolutionRuntime,
   });
 
+  // The bridged context MUST carry the shared governed proposal engine: the MCP
+  // transport factory gates create_proposal / resolve_schema_intent on it, so a
+  // missing proposalEngine silently de-activates those tools in the dev MCP path
+  // (issue #583). Pin it here so a regression fails loudly rather than going dark.
+  expect(transportCtx.proposalEngine).toBeDefined();
+
   // Build the MCP server from the bridged context — same args the MCP transport
   // factory passes — and drive it over an in-process JSON-RPC pipe (no socket).
   const { server } = await createMcpAdapter({

--- a/addons/adapter-server/cap-adapter-server/src/start-dev-transports.ts
+++ b/addons/adapter-server/cap-adapter-server/src/start-dev-transports.ts
@@ -42,6 +42,7 @@ import {
   InMemoryOverlayStore,
 } from "@linchkit/core/server";
 import type { AssembledDevSchema } from "./assemble-schema";
+import { getSharedProposalEngine } from "./proposal-api";
 
 /** Transport name owned by cap-adapter-server — its HTTP server is started directly by dev.ts. */
 const HTTP_TRANSPORT_NAME = "http";
@@ -172,6 +173,10 @@ export async function buildDevTransportContext(
     aiService: runtime.ai,
     aiConfig: config.ai,
     evolutionRuntime,
+    // The SAME governed engine `/api/proposals` reads from — so AI drafts
+    // created over the MCP channel (create_proposal / resolve_schema_intent)
+    // surface in the review pipeline, not a throwaway instance (issue #583).
+    proposalEngine: getSharedProposalEngine(),
   };
 }
 

--- a/packages/core/src/types/transport.ts
+++ b/packages/core/src/types/transport.ts
@@ -16,6 +16,7 @@ import type { ActionExecutor, DataProvider } from "../engine/action-engine";
 import type { ApprovalEngine } from "../engine/approval-engine";
 import type { CommandLayer, MiddlewareRegistration } from "../engine/command-layer";
 import type { PermissionRegistry } from "../engine/permission-engine";
+import type { ProposalEngine } from "../engine/proposal-engine";
 import type { DerivedPropertyEngine } from "../entity/derived-property";
 import type { EntityRegistry } from "../entity/entity-registry";
 import type { RelationRegistry } from "../entity/relation-registry";
@@ -97,6 +98,14 @@ export interface TransportContext {
    * to the right backend (Drizzle or in-memory).
    */
   evolutionRuntime?: EvolutionRuntime;
+  /**
+   * Governed proposal engine — the shared instance `/api/proposals` reads from.
+   * Transports (MCP, HTTP) use it to persist AI-drafted structural changes so
+   * they surface in the review pipeline. When present (alongside `aiService` +
+   * `ontologyRegistry`), the MCP transport registers `create_proposal` and
+   * `resolve_schema_intent` (Spec 52 "说→有", issue #583).
+   */
+  proposalEngine?: ProposalEngine;
 }
 
 /** Lifecycle handle returned by transport factory */


### PR DESCRIPTION
## Summary

Closes #583 — brings the 说→有 NL drafting flow to the **MCP channel**, closing the "every channel" gap (THE acceptance bar: the full chain must work from UI / REST / MCP / AI agent).

Today an MCP-connected agent can only call the STRUCTURED `create_proposal` tool (it must construct the changes itself). It cannot say a natural-language sentence (e.g. "增加一个商品管理") and get a governed proposal draft the way the HTTP route `POST /api/ai/resolve-schema-intent` (#578) does.

This adds an MCP tool **`resolve_schema_intent`** that wraps the canonical `resolveSchemaIntent()` engine — same security posture, same governed persistence, same outcomes (add_entity / add_rule / update_rule / clarification / no_match).

## What's in it

- **New tool** (`schema-intent-tools.ts`): zod-validated prompt → permission-scoped ontology → `resolveSchemaIntent()` into a throwaway draft engine → persist the governed draft into the shared engine. Permission-gated via `checkToolPolicy`; graceful "unavailable" (not throw) when AI/ontology/engine absent.
- **Boundary-safe** (`schema-intent-ontology.ts` + inlined persistence helpers): `adapter-mcp` must not import `adapter-server`, so the ontology helper is a faithful local copy and the two governed-persistence helpers are ported inline — all depend ONLY on `@linchkit/core`. Verified zero `adapter-server` imports.
- **LIVE, not just present**: the gap was that `proposalEngine` never reached the MCP adapter (so even `create_proposal` was dormant in the dev MCP path). Added `proposalEngine` to `TransportContext`, set it from `getSharedProposalEngine()` in `start-dev-transports`, and forwarded it through the MCP factory (stdio + SSE). This activates BOTH `create_proposal` and `resolve_schema_intent`, and MCP-drafted proposals now surface in `/api/proposals`.

## Test

- `schema-intent-tools.test.ts` (6 pass): add_entity (draft + governed persist), add_rule (draft + persist with condition), AI-not-configured (structured unavailable, nothing persisted), policy-denied (blocked, nothing persisted), no_match (nothing persisted).
- `dev-mcp-transport.test.ts`: added `expect(transportCtx.proposalEngine).toBeDefined()` — pins the live wiring so a regression that re-dormants the tools fails loudly.
- `bun run typecheck` clean (0 errors). Regression: factory/mcp-server/dev-transport suites green.

## Notes for review

- The duplicated ontology/persistence logic is a deliberate copy to respect the module boundary (`adapter-mcp` ↛ `adapter-server`). If the project later hoists `buildSchemaIntentOntology` into core, both copies should delegate.
- Draft-engine-vs-governed-engine split mirrors the HTTP route: the resolver drafts into a throwaway `@linchkit/core/ai` engine; the governed `@linchkit/core/server` engine is the persisted one.

Related: #578, #565 (multi-channel walkthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
