### PR TITLE
chore: add changesets for this session's published-package changes

### DIFF
--- a/.changeset/a2a-agent-card.md
+++ b/.changeset/a2a-agent-card.md
@@ -1,0 +1,7 @@
+---
+"@linchkit/cap-adapter-a2a": minor
+---
+
+feat(a2a): A2A v1.0 AgentCard generator + a2a exposure flag (phase-1 spike, #89)
+
+Maps the OntologyRegistry's exposed actions to an A2A v1.0 AgentCard at boot. Exposure follows the MCP pattern (`exposure.a2a === false` / `exposure.internal === true` exclude; `exposure === "all"` includes; unknown values fail closed).

--- a/.changeset/adapter-ui-api-split.md
+++ b/.changeset/adapter-ui-api-split.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cap-adapter-ui": patch
+---
+
+refactor(adapter-ui): split `lib/api.ts` into focused modules under the 500-line cap. Internal restructuring only — the public API client surface is unchanged.

--- a/.changeset/mcp-resolve-schema-intent.md
+++ b/.changeset/mcp-resolve-schema-intent.md
@@ -1,0 +1,9 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-mcp": minor
+"@linchkit/cap-adapter-server": minor
+---
+
+feat(adapter-mcp): `resolve_schema_intent` MCP tool — NL→governed proposal (#583)
+
+MCP agents can now send a natural-language utterance and get a governed proposal draft, the same capability the HTTP route provides — closing the "every channel" gap for 说→有. Adds `proposalEngine` to `TransportContext` and forwards it through the MCP factory, which also activates `create_proposal` (previously dormant in the dev MCP path because the engine never reached the adapter).

--- a/.changeset/nl-add-entity-proposal.md
+++ b/.changeset/nl-add-entity-proposal.md
@@ -1,0 +1,8 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+---
+
+feat(说→有): NL schema-intent drafts a governed `add_entity` proposal (#575)
+
+The schema-intent resolver now turns an utterance like "增加一个商品管理" into a governed `add_entity` ProposalDraft (instead of `no_match`). A new `schema-intent-entity-builder` validates the entity shape (snake_case name, no system-field collisions, valid field types/constraints, optional relation endpoints) and mints the draft; `POST /api/ai/resolve-schema-intent` persists it into the shared governed engine so it surfaces in the human-gated review pipeline. Works on an empty catalog (first entity), and surfaces requested-but-malformed relations as errors rather than silently dropping them.

--- a/.changeset/relation-graduation.md
+++ b/.changeset/relation-graduation.md
@@ -1,0 +1,8 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+---
+
+feat: graduate an NL-drafted relation as a first-class change (#580)
+
+`relation` is now a first-class graduable `ProposalChange`: added to `ProposalChangeTarget` and the `ChangeDefinition` union, wired into `ProposalFileWriter` (relations/ subdir, `defineRelation` factory), and classified additive/non-breaking by the impact analyzer. An `add_entity`-with-relation proposal now persists a SECOND `relation` change (the entity change stays a clean `EntityDefinition`) and graduates to BOTH `defineEntity()` and `defineRelation()` source.


### PR DESCRIPTION
## Summary

This session's PRs touched published packages but landed **without changesets**, so they would be excluded from the release (`/linch-workflow` requires a changeset for npm-published code). Add them so the version-packages PR (#174) reflects current main:

- `nl-add-entity-proposal` — @linchkit/core + cap-adapter-server (minor) — #578
- `relation-graduation` — @linchkit/core + cap-adapter-server (minor) — #582 / #580
- `mcp-resolve-schema-intent` — @linchkit/core + cap-adapter-mcp + cap-adapter-server (minor) — #584 / #583
- `a2a-agent-card` — cap-adapter-a2a (minor) — #561 / #89
- `adapter-ui-api-split` — cap-adapter-ui (patch, internal refactor) — #579

Docs-only (markdown changeset files); no code change. Once merged, the changesets bot regenerates #174 to include these, and merging #174 publishes a release that reflects current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A2A v1.0 AgentCard generator with exposure control now available
  * MCP agents can use natural language to resolve schema intents and generate governed proposals
  * Natural language support for drafting entity and relation proposals with validation
  * Relations promoted to first-class proposal changes with full workflow support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->