### PR TITLE
chore(capabilities): sync coreVersion to ^0.3.0 after the 0.3.0 release (#174)

### DIFF
--- a/addons/adapter-a2a/cap-adapter-a2a/package.json
+++ b/addons/adapter-a2a/cap-adapter-a2a/package.json
@@ -21,7 +21,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-mcp/cap-adapter-mcp/package.json
+++ b/addons/adapter-mcp/cap-adapter-mcp/package.json
@@ -24,7 +24,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-mcp/cap-mcp-ui/package.json
+++ b/addons/adapter-mcp/cap-mcp-ui/package.json
@@ -26,7 +26,7 @@
     "@linchkit/cap-adapter-mcp": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -48,7 +48,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-ui/cap-adapter-ui/package.json
+++ b/addons/adapter-ui/cap-adapter-ui/package.json
@@ -84,7 +84,7 @@
     "autoprefixer": "^10.4.27"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/ai-provider/cap-ai-provider/package.json
+++ b/addons/ai-provider/cap-ai-provider/package.json
@@ -28,7 +28,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/audit/cap-audit-ui/package.json
+++ b/addons/audit/cap-audit-ui/package.json
@@ -24,7 +24,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/auth/cap-auth-better-auth/package.json
+++ b/addons/auth/cap-auth-better-auth/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "system"
   }

--- a/addons/auth/cap-auth/package.json
+++ b/addons/auth/cap-auth/package.json
@@ -37,7 +37,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/cache-redis/cap-cache-redis/package.json
+++ b/addons/cache-redis/cap-cache-redis/package.json
@@ -28,7 +28,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/chatter/cap-chatter-ui/package.json
+++ b/addons/chatter/cap-chatter-ui/package.json
@@ -25,7 +25,7 @@
     "@linchkit/ui-kit": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/chatter/cap-chatter/package.json
+++ b/addons/chatter/cap-chatter/package.json
@@ -27,7 +27,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/demo/cap-life-demo/package.json
+++ b/addons/demo/cap-life-demo/package.json
@@ -12,7 +12,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/demo/cap-purchase-demo/package.json
+++ b/addons/demo/cap-purchase-demo/package.json
@@ -9,7 +9,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "business"
   }

--- a/addons/dry-run/cap-dry-run/package.json
+++ b/addons/dry-run/cap-dry-run/package.json
@@ -21,7 +21,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/file-storage/cap-file-storage/package.json
+++ b/addons/file-storage/cap-file-storage/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/flow-restate/cap-flow-restate/package.json
+++ b/addons/flow-restate/cap-flow-restate/package.json
@@ -23,7 +23,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "infrastructure"
   }

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/package.json
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/package.json
@@ -25,7 +25,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/lock/cap-lock/__tests__/capability.test.ts
+++ b/addons/lock/cap-lock/__tests__/capability.test.ts
@@ -31,7 +31,7 @@ describe("cap-lock capability metadata", () => {
     expect(capLock.type).toBe("standard");
     expect(capLock.category).toBe("system");
     expect(capLock.version).toBe("1.0.0");
-    expect(capLock.coreVersion).toBe("^0.2.0");
+    expect(capLock.coreVersion).toBe("^0.3.0");
   });
 
   it("declares only the database.read system permission", () => {

--- a/addons/lock/cap-lock/capability.json
+++ b/addons/lock/cap-lock/capability.json
@@ -10,6 +10,6 @@
     "graphqlExtensions": ["fieldLockBypass"]
   },
   "linchkit": {
-    "coreVersion": "^0.2.0"
+    "coreVersion": "^0.3.0"
   }
 }

--- a/addons/lock/cap-lock/package.json
+++ b/addons/lock/cap-lock/package.json
@@ -24,7 +24,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/lock/cap-lock/src/factory.ts
+++ b/addons/lock/cap-lock/src/factory.ts
@@ -69,7 +69,7 @@ export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
     type: "standard",
     category: "system",
     version: "1.0.0",
-    coreVersion: "^0.2.0",
+    coreVersion: "^0.3.0",
 
     configSchema: capLockConfig.schema,
     config: policy,

--- a/addons/migration/cap-migration/package.json
+++ b/addons/migration/cap-migration/package.json
@@ -17,7 +17,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/notification/cap-notification/package.json
+++ b/addons/notification/cap-notification/package.json
@@ -25,7 +25,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/observability/cap-observability-otel/package.json
+++ b/addons/observability/cap-observability-otel/package.json
@@ -37,7 +37,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/permission/cap-permission/package.json
+++ b/addons/permission/cap-permission/package.json
@@ -20,7 +20,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/search/cap-search-ui/package.json
+++ b/addons/search/cap-search-ui/package.json
@@ -27,7 +27,7 @@
     "@linchkit/cap-search": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/search/cap-search/package.json
+++ b/addons/search/cap-search/package.json
@@ -28,7 +28,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/theme/cap-theme/package.json
+++ b/addons/theme/cap-theme/package.json
@@ -27,7 +27,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/vector/cap-vector-pgvector/package.json
+++ b/addons/vector/cap-vector-pgvector/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/view-calendar/cap-view-calendar/package.json
+++ b/addons/view-calendar/cap-view-calendar/package.json
@@ -31,7 +31,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "view",
     "autoInstall": false

--- a/addons/view-kanban/cap-view-kanban/package.json
+++ b/addons/view-kanban/cap-view-kanban/package.json
@@ -32,7 +32,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "view",
     "autoInstall": false

--- a/addons/view-timeline/cap-view-timeline/package.json
+++ b/addons/view-timeline/cap-view-timeline/package.json
@@ -28,7 +28,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "coreVersion": "^0.2.0",
+    "coreVersion": "^0.3.0",
     "type": "standard",
     "category": "view",
     "autoInstall": false


### PR DESCRIPTION
## What

Bump `linchkit.coreVersion` `^0.2.0` → `^0.3.0` across all 31 capability `package.json` files (plus cap-lock's `defineCapability` source + its unit test), so the declared core-compatibility range matches the 0.3.0 release.

## Why — Capability Lint is failing on EVERY PR

The 0.3.0 version-packages release (#174) bumped `@linchkit/core` to `0.3.0` and every capability's `peerDependencies["@linchkit/core"]` to `^0.3.0`, but **left `coreVersion` at `^0.2.0`**. Capability Lint (Spec 21 §10.1) now fails for every capability on any PR (the merge-with-main check sees core `0.3.0` against a `^0.2.0` range):

```
[core-version] peerDependencies["@linchkit/core"] is "^0.3.0" but the declared coreVersion is "^0.2.0". They must be equal.
[core-version] Declared coreVersion range "^0.2.0" does not satisfy the current @linchkit/core version "0.3.0".
```

This blocks #587 (and all open PRs). This PR unblocks them.

## Scope

- 31 `package.json` files: `coreVersion` `^0.2.0` → `^0.3.0` (now equals the release's `^0.3.0` peerDeps; the two `workspace:*` demo packages are exempt from the equality rule and now satisfy installed core `0.3.0`).
- `addons/lock/cap-lock/src/factory.ts` + `__tests__/capability.test.ts`: cap-lock is the only capability that also declares `coreVersion` in its `defineCapability` source and pins it in a test — both bumped for consistency.

Verified locally: `bun run check` ✅, `bun run typecheck` ✅, cap-lock capability test ✅, `linch lint-capability` ✅ on a sampled capability.

## Follow-up (root cause)

The release pipeline bumps version + peerDeps but **not** `coreVersion`. A follow-up should teach `scripts/release.ts` / the changeset flow to keep `coreVersion` in sync with the core version bump, so this does not recur on the next core release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
