### PR TITLE
feat(core): SourcePatcher seam — in-place named-constant graduation (#566)

### DIFF
--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createProposalEngine, ProposalFileWriter } from "../src/server-entry";
@@ -1005,6 +1005,38 @@ describe("ProposalFileWriter source patch (#566)", () => {
 
     // Patcher never invoked — nothing was read or written outside the repo.
     expect(calls).toHaveLength(0);
+  });
+
+  it("rejects a symlink INSIDE repoRoot that resolves OUTSIDE it (coderabbit #590)", async () => {
+    // A symlink whose own path is inside repoRoot but whose target is outside
+    // must not be patchable — the string-level check passes, so only the realpath
+    // containment catches it. Proves the symlink-escape defense.
+    const outsideDir = await mkdtemp(join(tmpdir(), "sp-outside-"));
+    const outsideFile = join(outsideDir, "secret.ts");
+    const ORIGINAL = "export const MANAGER_APPROVAL_THRESHOLD = 10000;\n";
+    await writeFile(outsideFile, ORIGINAL, "utf8");
+    await mkdir(join(tmpDir, "rules"), { recursive: true });
+    const linkRel = join("rules", "link.ts");
+    await symlink(outsideFile, join(tmpDir, linkRel));
+
+    try {
+      const { calls, patcher } = makeFakePatcher();
+      const writer = new ProposalFileWriter({
+        rootDir: tmpDir,
+        repoRoot: tmpDir,
+        sourcePatcher: patcher,
+      });
+
+      await expect(writer.writeApprovedProposal(sourcePatchProposal(linkRel))).rejects.toThrow(
+        /symlink|outside repoRoot/i,
+      );
+
+      // The outside target was neither patched nor even read.
+      expect(calls).toHaveLength(0);
+      expect(await readFile(outsideFile, "utf8")).toBe(ORIGINAL);
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
   });
 
   it("THROWS when the sourcePatch target file is missing", async () => {

--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createProposalEngine, ProposalFileWriter } from "../src/server-entry";
 import type { ProposalChange, ProposalDefinition } from "../src/types/proposal";
+import type { SourcePatchRequest, SourcePatchResult } from "../src/types/source-patch";
 
 // ── Fixtures ────────────────────────────────────────────────
 
@@ -860,6 +861,147 @@ function selfContainedEntityChange(name = "widget"): ProposalChange {
     } as never,
   };
 }
+
+// ── In-place source patch (#566 — Option A capability-seam) ──────────────────
+//
+// A `sourcePatch` change graduates by patching a NAMED CONSTANT in an EXISTING
+// source file IN PLACE — a THIRD path alongside declarative codegen and
+// AI-materialized generatedSource. The concrete TS-AST patcher lives OUTSIDE
+// core and is INJECTED via `sourcePatcher`; these tests use a tiny fake.
+
+describe("ProposalFileWriter source patch (#566)", () => {
+  /**
+   * A tiny fake patcher: records the request it received and replaces
+   * `<constantName> = 10000` with `<constantName> = <newValueLiteral>`. Stands
+   * in for the real injected TS-AST `patchNamedConstant` (which lives outside
+   * core).
+   */
+  function makeFakePatcher() {
+    const calls: SourcePatchRequest[] = [];
+    const patcher = (request: SourcePatchRequest): SourcePatchResult => {
+      calls.push(request);
+      const needle = `${request.constantName} = 10000`;
+      const replacement = `${request.constantName} = ${request.newValueLiteral}`;
+      return {
+        source: request.source.replace(needle, replacement),
+        oldValueLiteral: "10000",
+        changed: request.source.includes(needle),
+      };
+    };
+    return { calls, patcher };
+  }
+
+  function sourcePatchProposal(
+    filePath: string,
+    overrides: Partial<NonNullable<ProposalChange["sourcePatch"]>> = {},
+  ): ProposalDefinition {
+    const change: ProposalChange = {
+      target: "rule",
+      operation: "update",
+      name: "manager_approval_threshold",
+      diff: "把经理审批阈值改成 2 万",
+      sourcePatch: {
+        filePath,
+        constantName: "MANAGER_APPROVAL_THRESHOLD",
+        newValueLiteral: "20000",
+        ...overrides,
+      },
+    };
+    return makeApprovedProposal({ changes: [change] });
+  }
+
+  it("patches the existing file IN PLACE via the injected patcher", async () => {
+    // Existing source file with a named constant to patch.
+    const relPath = join("rules", "x.ts");
+    const absPath = join(tmpDir, relPath);
+    await mkdir(join(tmpDir, "rules"), { recursive: true });
+    await writeFile(absPath, "export const MANAGER_APPROVAL_THRESHOLD = 10000;\n", "utf8");
+
+    const { calls, patcher } = makeFakePatcher();
+    const writer = new ProposalFileWriter({
+      rootDir: tmpDir,
+      repoRoot: tmpDir,
+      sourcePatcher: patcher,
+    });
+
+    const written = await writer.writeApprovedProposal(sourcePatchProposal(relPath));
+
+    // The returned written[] carries the absolute path of the patched file.
+    expect(written).toEqual([absPath]);
+
+    // File content was replaced in place with the patcher's output.
+    const contents = await readFile(absPath, "utf8");
+    expect(contents).toBe("export const MANAGER_APPROVAL_THRESHOLD = 20000;\n");
+
+    // The patcher received the right request.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].constantName).toBe("MANAGER_APPROVAL_THRESHOLD");
+    expect(calls[0].newValueLiteral).toBe("20000");
+    expect(calls[0].source).toContain("= 10000");
+  });
+
+  it("THROWS when a sourcePatch change has no injected sourcePatcher (names proposal/change)", async () => {
+    const relPath = join("rules", "x.ts");
+    const absPath = join(tmpDir, relPath);
+    await mkdir(join(tmpDir, "rules"), { recursive: true });
+    await writeFile(absPath, "export const MANAGER_APPROVAL_THRESHOLD = 10000;\n", "utf8");
+
+    // No sourcePatcher injected.
+    const writer = new ProposalFileWriter({ rootDir: tmpDir, repoRoot: tmpDir });
+    const proposal = sourcePatchProposal(relPath);
+
+    await expect(writer.writeApprovedProposal(proposal)).rejects.toThrow(
+      /manager_approval_threshold/,
+    );
+    await expect(writer.writeApprovedProposal(proposal)).rejects.toThrow(/sourcePatcher|injected/i);
+
+    // The file was left untouched (no patch applied).
+    const contents = await readFile(absPath, "utf8");
+    expect(contents).toBe("export const MANAGER_APPROVAL_THRESHOLD = 10000;\n");
+  });
+
+  it("THROWS on path traversal that escapes repoRoot, reading/writing nothing outside", async () => {
+    const { calls, patcher } = makeFakePatcher();
+    const writer = new ProposalFileWriter({
+      rootDir: tmpDir,
+      repoRoot: tmpDir,
+      sourcePatcher: patcher,
+    });
+    // An attempt to escape the repoRoot.
+    const proposal = sourcePatchProposal("../../etc/evil.ts");
+
+    await expect(writer.writeApprovedProposal(proposal)).rejects.toThrow(/escapes repoRoot/);
+
+    // Patcher never invoked — nothing was read or written outside the repo.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("THROWS when the sourcePatch target file is missing", async () => {
+    const { calls, patcher } = makeFakePatcher();
+    const writer = new ProposalFileWriter({
+      rootDir: tmpDir,
+      repoRoot: tmpDir,
+      sourcePatcher: patcher,
+    });
+    // Points at a file that does not exist (inside the repo, so traversal passes).
+    const proposal = sourcePatchProposal(join("rules", "does-not-exist.ts"));
+
+    await expect(writer.writeApprovedProposal(proposal)).rejects.toThrow(/does not exist|missing/i);
+
+    // Patcher never invoked — the missing file is caught before patching.
+    expect(calls).toHaveLength(0);
+  });
+
+  it("defaults repoRoot to process.cwd() when not supplied", async () => {
+    // Resolve a path relative to cwd that escapes into an unrelated dir — the
+    // default repoRoot (process.cwd()) is used, and a traversal still throws.
+    const { patcher } = makeFakePatcher();
+    const writer = new ProposalFileWriter({ rootDir: tmpDir, sourcePatcher: patcher });
+    const proposal = sourcePatchProposal("../../../../etc/passwd.ts");
+
+    await expect(writer.writeApprovedProposal(proposal)).rejects.toThrow(/escapes repoRoot/);
+  });
+});
 
 describe("ProposalEngine.onApproved hook", () => {
   it("fires on approveProposal and persists the file", async () => {

--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -940,6 +940,37 @@ describe("ProposalFileWriter source patch (#566)", () => {
     expect(calls[0].source).toContain("= 10000");
   });
 
+  it("does NOT rewrite the file when the patch is a no-op (changed: false) (gemini #590)", async () => {
+    // The value is already at target → the patcher reports changed: false.
+    // Rewriting identical bytes would bump mtime and trip watchers/HMR, so the
+    // writer must SKIP the write. To prove it, the fake patcher reports no change
+    // but returns DIFFERENT bytes: if the writer wrote unconditionally the file
+    // would become the marker; skipping on changed:false keeps the original.
+    const relPath = join("rules", "noop.ts");
+    const absPath = join(tmpDir, relPath);
+    await mkdir(join(tmpDir, "rules"), { recursive: true });
+    const ORIGINAL = "export const MANAGER_APPROVAL_THRESHOLD = 20000;\n";
+    await writeFile(absPath, ORIGINAL, "utf8");
+
+    const patcher = (): SourcePatchResult => ({
+      source: "// MARKER — must never be written on a no-op\n",
+      oldValueLiteral: "20000",
+      changed: false,
+    });
+    const writer = new ProposalFileWriter({
+      rootDir: tmpDir,
+      repoRoot: tmpDir,
+      sourcePatcher: patcher,
+    });
+
+    const written = await writer.writeApprovedProposal(sourcePatchProposal(relPath));
+
+    // The change still resolves to that file (reported in written[])...
+    expect(written).toEqual([absPath]);
+    // ...but the file was NOT rewritten — content is the original, not the marker.
+    expect(await readFile(absPath, "utf8")).toBe(ORIGINAL);
+  });
+
   it("THROWS when a sourcePatch change has no injected sourcePatcher (names proposal/change)", async () => {
     const relPath = join("rules", "x.ts");
     const absPath = join(tmpDir, relPath);

--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -965,9 +965,9 @@ describe("ProposalFileWriter source patch (#566)", () => {
 
     const written = await writer.writeApprovedProposal(sourcePatchProposal(relPath));
 
-    // The change still resolves to that file (reported in written[])...
-    expect(written).toEqual([absPath]);
-    // ...but the file was NOT rewritten — content is the original, not the marker.
+    // A no-op is NOT reported as written (claude #590)...
+    expect(written).toEqual([]);
+    // ...and the file was NOT rewritten — content is the original, not the marker.
     expect(await readFile(absPath, "utf8")).toBe(ORIGINAL);
   });
 

--- a/packages/core/src/engine/proposal-file-writer.ts
+++ b/packages/core/src/engine/proposal-file-writer.ts
@@ -467,8 +467,10 @@ export class ProposalFileWriter {
       // `sourcePatch` fall through to the unchanged materialized-source / codegen
       // path below.
       if (change.sourcePatch) {
+        // null on a no-op (value already at target) — do not report an unchanged
+        // file as written (#590).
         const patched = await this.applySourcePatch(proposal, change);
-        written.push(patched);
+        if (patched) written.push(patched);
         continue;
       }
 
@@ -547,7 +549,7 @@ export class ProposalFileWriter {
   private async applySourcePatch(
     proposal: ProposalDefinition,
     change: ProposalChange,
-  ): Promise<string> {
+  ): Promise<string | null> {
     // `change.sourcePatch` is guaranteed present by the caller, but narrow it
     // locally so this helper is self-contained.
     const patch = change.sourcePatch;
@@ -615,19 +617,26 @@ export class ProposalFileWriter {
       constantName: patch.constantName,
       newValueLiteral: patch.newValueLiteral,
     });
-    // Skip the write when the value is already at target (changed === false):
-    // rewriting identical bytes is wasteful I/O and bumps the file's mtime,
-    // needlessly tripping file watchers / HMR / build tools (gemini #590).
-    if (result.changed) {
-      await writeFile(abs, result.source, { encoding: "utf8", flag: "w" });
+    // No-op when the value is already at target (changed === false): skip the
+    // write (rewriting identical bytes is wasteful I/O and bumps mtime, tripping
+    // watchers / HMR — gemini #590) AND return null so the caller does NOT report
+    // an unchanged file as "written" (claude #590).
+    if (!result.changed) {
+      this.logger?.info?.(`ProposalFileWriter: sourcePatch no-op for ${abs} (already at target)`, {
+        proposalId: proposal.id,
+        target: change.target,
+        name: change.name,
+        constantName: patch.constantName,
+      });
+      return null;
     }
 
+    await writeFile(abs, result.source, { encoding: "utf8", flag: "w" });
     this.logger?.info?.(`ProposalFileWriter: patched ${abs}`, {
       proposalId: proposal.id,
       target: change.target,
       name: change.name,
       constantName: patch.constantName,
-      changed: result.changed,
     });
 
     return abs;

--- a/packages/core/src/engine/proposal-file-writer.ts
+++ b/packages/core/src/engine/proposal-file-writer.ts
@@ -590,7 +590,12 @@ export class ProposalFileWriter {
       constantName: patch.constantName,
       newValueLiteral: patch.newValueLiteral,
     });
-    await writeFile(abs, result.source, { encoding: "utf8", flag: "w" });
+    // Skip the write when the value is already at target (changed === false):
+    // rewriting identical bytes is wasteful I/O and bumps the file's mtime,
+    // needlessly tripping file watchers / HMR / build tools (gemini #590).
+    if (result.changed) {
+      await writeFile(abs, result.source, { encoding: "utf8", flag: "w" });
+    }
 
     this.logger?.info?.(`ProposalFileWriter: patched ${abs}`, {
       proposalId: proposal.id,

--- a/packages/core/src/engine/proposal-file-writer.ts
+++ b/packages/core/src/engine/proposal-file-writer.ts
@@ -21,7 +21,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, realpath, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { dirname, join } from "node:path";
 import type { Logger } from "../types/logger";
@@ -566,7 +566,8 @@ export class ProposalFileWriter {
       );
     }
 
-    // Path safety: resolve under repoRoot and reject anything that escapes it.
+    // Path safety, step 1 — cheap string-level containment: reject an obvious
+    // traversal before touching the filesystem.
     const abs = path.resolve(this.repoRoot, patch.filePath);
     const rel = path.relative(this.repoRoot, abs);
     if (rel.startsWith("..") || path.isAbsolute(rel)) {
@@ -577,13 +578,37 @@ export class ProposalFileWriter {
       );
     }
 
-    if (!existsSync(abs)) {
+    // Path safety, step 2 — resolve symlinks and re-check containment against the
+    // REAL paths: a symlink INSIDE repoRoot could otherwise point outside it
+    // (coderabbit #590). `realpath(abs)` doubles as the existence check — its
+    // ENOENT becomes the descriptive "missing" error with no `existsSync`→read
+    // TOCTOU gap (claude #590).
+    const realRoot = await realpath(this.repoRoot);
+    let realAbs: string;
+    try {
+      realAbs = await realpath(abs);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(
+          `ProposalFileWriter: sourcePatch target file "${abs}" does not exist ` +
+            `(proposal "${proposal.id}" change "${change.name}") — the file to patch is missing.`,
+        );
+      }
+      throw err;
+    }
+    const realRel = path.relative(realRoot, realAbs);
+    if (realRel.startsWith("..") || path.isAbsolute(realRel)) {
       throw new Error(
-        `ProposalFileWriter: sourcePatch target file "${abs}" does not exist ` +
-          `(proposal "${proposal.id}" change "${change.name}") — the file to patch is missing.`,
+        `ProposalFileWriter: sourcePatch.filePath "${patch.filePath}" resolves (via a symlink) to ` +
+          `"${realAbs}" outside repoRoot "${realRoot}" (proposal "${proposal.id}" change ` +
+          `"${change.name}") — refusing to patch a file outside the repository.`,
       );
     }
 
+    // Read / write / report via `abs` (the logical path under repoRoot, which is
+    // what git tracks); `realAbs` was only needed to make the symlink-containment
+    // and existence checks above honest. `writeFile` follows the symlink to the
+    // same bytes anyway, and `abs === realAbs` for the real no-symlink case.
     const source = await readFile(abs, "utf8");
     const result = this.sourcePatcher({
       source,

--- a/packages/core/src/engine/proposal-file-writer.ts
+++ b/packages/core/src/engine/proposal-file-writer.ts
@@ -21,10 +21,12 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import * as path from "node:path";
 import { dirname, join } from "node:path";
 import type { Logger } from "../types/logger";
 import type { ProposalChange, ProposalChangeTarget, ProposalDefinition } from "../types/proposal";
+import type { SourcePatcher } from "../types/source-patch";
 
 // ── Formatter ───────────────────────────────────────────────
 
@@ -58,6 +60,21 @@ export interface ProposalFileWriterOptions {
    * must never block code generation).
    */
   formatter?: ProposalFormatterOption;
+  /**
+   * Injected source patcher for in-place named-constant edits (#566).
+   *
+   * Required to graduate a change carrying `change.sourcePatch`. The concrete
+   * TypeScript-AST patcher lives OUTSIDE `@linchkit/core` (it imports
+   * `typescript`); core only calls this seam. When absent, a `sourcePatch`
+   * change FAILS LOUD (it cannot be graduated by deterministic codegen).
+   */
+  sourcePatcher?: SourcePatcher;
+  /**
+   * Base directory for resolving `change.sourcePatch.filePath` (#566). The
+   * resolved absolute path is rejected if it escapes this root. Defaults to
+   * `process.cwd()`.
+   */
+  repoRoot?: string;
 }
 
 // ── Defaults ────────────────────────────────────────────────
@@ -376,6 +393,10 @@ export class ProposalFileWriter {
    * handle exactly those cases — so the guard must NOT pre-empt it.
    */
   private readonly usesDefaultCodegen: boolean;
+  /** Injected in-place source patcher for `sourcePatch` changes (#566). */
+  private readonly sourcePatcher?: SourcePatcher;
+  /** Base dir for resolving `sourcePatch.filePath`; defaults to `process.cwd()`. */
+  private readonly repoRoot: string;
 
   constructor(options: ProposalFileWriterOptions) {
     this.rootDir = options.rootDir;
@@ -384,6 +405,8 @@ export class ProposalFileWriter {
     this.usesDefaultCodegen = options.codegen === undefined;
     this.codegen = options.codegen ?? defaultCodegen;
     this.formatter = resolveFormatter(options.formatter);
+    this.sourcePatcher = options.sourcePatcher;
+    this.repoRoot = options.repoRoot ?? process.cwd();
   }
 
   /**
@@ -434,6 +457,18 @@ export class ProposalFileWriter {
           `ProposalFileWriter: skipping delete operation for "${change.name}" — manual removal required`,
           { proposalId: proposal.id, target: change.target, name: change.name },
         );
+        continue;
+      }
+
+      // In-place named-constant patch (#566) — a THIRD graduation path that
+      // takes precedence for a `sourcePatch` change. It does NOT use
+      // `pathResolver` / `rootDir` / codegen: the file already exists and is
+      // edited in place via the injected `SourcePatcher`. Changes WITHOUT a
+      // `sourcePatch` fall through to the unchanged materialized-source / codegen
+      // path below.
+      if (change.sourcePatch) {
+        const patched = await this.applySourcePatch(proposal, change);
+        written.push(patched);
         continue;
       }
 
@@ -495,6 +530,77 @@ export class ProposalFileWriter {
     }
 
     return written;
+  }
+
+  /**
+   * Graduate a `sourcePatch` change by patching a named constant in an EXISTING
+   * file IN PLACE (#566). Returns the absolute path of the patched file.
+   *
+   * Steps (in order):
+   *   1. Require an injected `sourcePatcher` — a `sourcePatch` change cannot be
+   *      graduated by deterministic codegen, so FAIL LOUD if it is missing.
+   *   2. Resolve the absolute path under `repoRoot` and reject any path that
+   *      escapes it (path-traversal safety).
+   *   3. Read the existing file — FAIL LOUD if it is missing.
+   *   4. Call the injected patcher and write its output back in place.
+   */
+  private async applySourcePatch(
+    proposal: ProposalDefinition,
+    change: ProposalChange,
+  ): Promise<string> {
+    // `change.sourcePatch` is guaranteed present by the caller, but narrow it
+    // locally so this helper is self-contained.
+    const patch = change.sourcePatch;
+    if (!patch) {
+      throw new Error(
+        `ProposalFileWriter: applySourcePatch called without a sourcePatch ` +
+          `(proposal "${proposal.id}" change "${change.name}")`,
+      );
+    }
+
+    if (!this.sourcePatcher) {
+      throw new Error(
+        `ProposalFileWriter: change "${change.name}" (proposal "${proposal.id}") carries a ` +
+          `sourcePatch but no \`sourcePatcher\` was injected — an in-place named-constant edit ` +
+          `cannot be graduated by deterministic codegen. Inject a SourcePatcher to enable it.`,
+      );
+    }
+
+    // Path safety: resolve under repoRoot and reject anything that escapes it.
+    const abs = path.resolve(this.repoRoot, patch.filePath);
+    const rel = path.relative(this.repoRoot, abs);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(
+        `ProposalFileWriter: sourcePatch.filePath "${patch.filePath}" escapes repoRoot ` +
+          `"${this.repoRoot}" (proposal "${proposal.id}" change "${change.name}") — refusing to ` +
+          `patch a file outside the repository.`,
+      );
+    }
+
+    if (!existsSync(abs)) {
+      throw new Error(
+        `ProposalFileWriter: sourcePatch target file "${abs}" does not exist ` +
+          `(proposal "${proposal.id}" change "${change.name}") — the file to patch is missing.`,
+      );
+    }
+
+    const source = await readFile(abs, "utf8");
+    const result = this.sourcePatcher({
+      source,
+      constantName: patch.constantName,
+      newValueLiteral: patch.newValueLiteral,
+    });
+    await writeFile(abs, result.source, { encoding: "utf8", flag: "w" });
+
+    this.logger?.info?.(`ProposalFileWriter: patched ${abs}`, {
+      proposalId: proposal.id,
+      target: change.target,
+      name: change.name,
+      constantName: patch.constantName,
+      changed: result.changed,
+    });
+
+    return abs;
   }
 
   /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -60,6 +60,7 @@ export type * from "./rule";
 export type * from "./runtime-config";
 export type * from "./semantic-relation";
 export { defineSemanticRelation } from "./semantic-relation";
+export type * from "./source-patch";
 export type * from "./state";
 export type * from "./template";
 export type * from "./transport";

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -165,6 +165,25 @@ export interface ProposalChange {
    * `inputCaseId` that produced it. Undefined when the change was never dry-run.
    */
   dryRunOutcomes?: DryRunOutcome[];
+  /**
+   * When set, this change graduates by patching a named constant in an EXISTING
+   * source file IN PLACE (#566) — a THIRD graduation path alongside the
+   * declarative codegen and AI-materialized `generatedSource`.
+   *
+   * Used for changes like "把经理审批阈值改成 2 万" that map to editing a single
+   * named constant (`export const MANAGER_APPROVAL_THRESHOLD = 10000;`) rather
+   * than writing a new generated file. The in-place patch is performed by an
+   * injected `SourcePatcher` (the TS-AST patcher lives OUTSIDE core); core only
+   * resolves the path, reads the file, and writes the patcher's output back.
+   */
+  sourcePatch?: {
+    /** Repo-root-relative path to the existing source file to patch. */
+    filePath: string;
+    /** Name of the exported constant to patch. */
+    constantName: string;
+    /** Already-serialized literal to write as the new value, e.g. "20000". */
+    newValueLiteral: string;
+  };
 }
 
 // ── Impact analysis ──────────────────────────────────────

--- a/packages/core/src/types/source-patch.ts
+++ b/packages/core/src/types/source-patch.ts
@@ -1,0 +1,44 @@
+/**
+ * Source-patch seam types (#566, Option A — capability-seam).
+ *
+ * The 说→有 loop needs an approved change like "把经理审批阈值改成 2 万" to graduate
+ * into a real edit of a NAMED CONSTANT (e.g. `export const MANAGER_APPROVAL_THRESHOLD = 10000;`)
+ * inside an EXISTING capability source file — an in-place patch, not a brand-new
+ * generated file.
+ *
+ * The actual TypeScript-AST patcher (`patchNamedConstant`) is a heavy dependency
+ * (`import ... from "typescript"`) and MUST live OUTSIDE `@linchkit/core`. This
+ * seam keeps core typescript-free: core declares only the request/result shapes
+ * and the `SourcePatcher` function type, and the concrete patcher is INJECTED
+ * (e.g. into `ProposalFileWriter`). Core never imports the patcher's
+ * implementation.
+ */
+
+/** Request to an injected source patcher: replace a named const's value in file text. */
+export interface SourcePatchRequest {
+  /** Current file content (the existing source to patch). */
+  source: string;
+  /** Name of the exported constant to patch, e.g. "MANAGER_APPROVAL_THRESHOLD". */
+  constantName: string;
+  /** Already-serialized literal to write, e.g. "20000" or '"manager"'. */
+  newValueLiteral: string;
+}
+
+/** Result returned by an injected source patcher. */
+export interface SourcePatchResult {
+  /** Patched file content. */
+  source: string;
+  /** Previous value text (the literal that was replaced). */
+  oldValueLiteral: string;
+  /** `false` iff the value was unchanged (no-op patch). */
+  changed: boolean;
+}
+
+/**
+ * Injected source patcher — typescript-free from core's point of view.
+ *
+ * The implementation (a `patchNamedConstant` pure function backed by the TS AST)
+ * lives in a NON-core package and is injected at the seam. Core only ever calls
+ * this signature; it never knows how the patch is computed.
+ */
+export type SourcePatcher = (request: SourcePatchRequest) => SourcePatchResult;

--- a/packages/core/src/types/source-patch.ts
+++ b/packages/core/src/types/source-patch.ts
@@ -1,10 +1,10 @@
 /**
  * Source-patch seam types (#566, Option A — capability-seam).
  *
- * The 说→有 loop needs an approved change like "把经理审批阈值改成 2 万" to graduate
- * into a real edit of a NAMED CONSTANT (e.g. `export const MANAGER_APPROVAL_THRESHOLD = 10000;`)
- * inside an EXISTING capability source file — an in-place patch, not a brand-new
- * generated file.
+ * The say-to-code loop needs an approved change like "raise the manager-approval
+ * threshold to 20000" to graduate into a real edit of a NAMED CONSTANT (e.g.
+ * `export const MANAGER_APPROVAL_THRESHOLD = 10000;`) inside an EXISTING
+ * capability source file — an in-place patch, not a brand-new generated file.
  *
  * The actual TypeScript-AST patcher (`patchNamedConstant`) is a heavy dependency
  * (`import ... from "typescript"`) and MUST live OUTSIDE `@linchkit/core`. This
@@ -26,11 +26,16 @@ export interface SourcePatchRequest {
 
 /** Result returned by an injected source patcher. */
 export interface SourcePatchResult {
-  /** Patched file content. */
+  /** Patched file content (equal to the input source when `changed` is false). */
   source: string;
   /** Previous value text (the literal that was replaced). */
   oldValueLiteral: string;
-  /** `false` iff the value was unchanged (no-op patch). */
+  /**
+   * `false` ONLY when the constant was found but its value already equals the
+   * target (an idempotent no-op). It MUST NOT be used to signal "constant not
+   * found" — see the throw-on-absent contract on {@link SourcePatcher}. Callers
+   * may safely skip rewriting the file when this is false.
+   */
   changed: boolean;
 }
 
@@ -40,5 +45,11 @@ export interface SourcePatchResult {
  * The implementation (a `patchNamedConstant` pure function backed by the TS AST)
  * lives in a NON-core package and is injected at the seam. Core only ever calls
  * this signature; it never knows how the patch is computed.
+ *
+ * Contract (so the caller never mistakes a silent failure for a no-op): the
+ * patcher MUST THROW when the named constant cannot be located (or is ambiguous,
+ * or has no initializer). A `changed: false` result is reserved EXCLUSIVELY for
+ * "found, value already at target". The reference impl (`patchNamedConstant`)
+ * throws NOT FOUND / AMBIGUOUS / NO INITIALIZER accordingly.
  */
 export type SourcePatcher = (request: SourcePatchRequest) => SourcePatchResult;


### PR DESCRIPTION
## What

The capability-seam for **#566 Option A** (owner-decided architecture): an approved change can graduate by **patching a named constant in an existing capability source file in place** — instead of only writing a new generated file. Core stays **`typescript`-free**; the heavy TS-AST patcher is **injected**.

## Why

"把经理审批阈值改成2万" must become a real source edit of `export const MANAGER_APPROVAL_THRESHOLD = 10000;`. That edit needs a TS parser (`typescript`, ~60MB) — which must NOT enter minimal core. This PR adds the seam so the patcher lives outside core and is injected at graduation time.

## Changes (core only)

- **`types/source-patch.ts`** (new) — `SourcePatchRequest` / `SourcePatchResult` / `SourcePatcher` (the injected function type). Core declares only the shapes.
- **`ProposalChange.sourcePatch?`** — optional structured intent `{ filePath, constantName, newValueLiteral }`.
- **`ProposalFileWriterOptions`** — `sourcePatcher?` + `repoRoot?` (default `process.cwd()`).
- **write-path precedence** (per change): `revert/delete` skip → **`sourcePatch` in-place patch (new)** → trusted `generatedSource` → `defaultCodegen` (+ #587 fail-loud guard).
- **`applySourcePatch`** — requires an injected patcher (throws otherwise); resolves under `repoRoot` and **rejects any path that escapes it** (no traversal); throws on a missing target; reads → patches → writes back in place. The patched file graduates into a **PR** (double human gate preserved; the value is a deterministic constant, never AI-regenerated logic).

## Tests

5 new (`bun test ./packages/core/__tests__/proposal-file-writer.test.ts` → **38 pass**): in-place patch via a fake injected patcher; no-patcher → throws; path traversal → rejected; missing file → throws; `repoRoot` defaults. Full `packages/core` suite green; **zero `typescript` imports in core src**.

## Scope / follow-ups (tracked on #566)

This is the seam only. Remaining #566-A increments: the `patchNamedConstant` impl in `@linchkit/devtools` (built, 11 tests, not yet landed); a SourceMap registry (rule→file path); structured new-value extraction in the resolver; and the end-to-end NL wiring. Foundation guard already merged in #587.

Note: `proposal-file-writer.ts` is now 653 lines (was 547, already over the 500 soft guidance) — a split is a reasonable follow-up but out of scope here.

Part of #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proposals can now patch existing source files in place, updating specific exported constants.
  * Added path safety features to ensure secure file resolution during patch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->