### PR TITLE
feat(devtools): patchNamedConstant — injectable TS-AST SourcePatcher (#566)

### DIFF
--- a/.changeset/devtools-source-patcher.md
+++ b/.changeset/devtools-source-patcher.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/devtools": minor
+---
+
+Add `patchNamedConstant`, an injectable TS-AST implementation of core's `SourcePatcher` seam (#566). It rewrites a single top-level `export const NAME = <literal>` initializer in an existing source file by splicing the initializer's byte span — comments, type annotations, and the rest of the file are untouched. Throws on NOT FOUND / AMBIGUOUS / NO INITIALIZER and is idempotent (`changed: false`) when the constant already holds the target value. `typescript` is promoted from a dev to a runtime dependency since the patcher ships in the package output.

--- a/packages/devtools/__tests__/patch-named-constant.test.ts
+++ b/packages/devtools/__tests__/patch-named-constant.test.ts
@@ -92,6 +92,22 @@ describe("patchNamedConstant", () => {
     );
   });
 
+  // (8a) `export let` is a mutable binding → NOT a const → throws NOT FOUND
+  it("throws NOT FOUND for an export let (const-only contract)", () => {
+    const source = "export let X = 1;\n";
+    expect(() => patchNamedConstant({ source, constantName: "X", newValueLiteral: "3" })).toThrow(
+      /NOT FOUND/,
+    );
+  });
+
+  // (8b) `export var` is a mutable binding → NOT a const → throws NOT FOUND
+  it("throws NOT FOUND for an export var (const-only contract)", () => {
+    const source = "export var X = 1;\n";
+    expect(() => patchNamedConstant({ source, constantName: "X", newValueLiteral: "3" })).toThrow(
+      /NOT FOUND/,
+    );
+  });
+
   // (9) ambiguous: two top-level `export const X` → throws AMBIGUOUS
   it("throws AMBIGUOUS when two top-level export consts share the name", () => {
     const source = "export const X = 1;\nexport const X = 2;\n";

--- a/packages/devtools/__tests__/patch-named-constant.test.ts
+++ b/packages/devtools/__tests__/patch-named-constant.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import type { SourcePatcher } from "@linchkit/core";
+import { patchNamedConstant } from "../src/patch-named-constant";
+
+// Compile-time guard: the implementation must conform to core's injected
+// SourcePatcher contract. If the signature drifts, typecheck fails here.
+const _patcher: SourcePatcher = patchNamedConstant;
+void _patcher;
+
+describe("patchNamedConstant", () => {
+  // (1) basic numeric replace + rest of file byte-identical
+  it("replaces a numeric initializer and leaves every other byte intact", () => {
+    const source = "export const A = 1;\nexport const B = 2;\n";
+    const result = patchNamedConstant({
+      source,
+      constantName: "A",
+      newValueLiteral: "42",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.oldValueLiteral).toBe("1");
+    expect(result.source).toBe("export const A = 42;\nexport const B = 2;\n");
+  });
+
+  // (2) `: number` type annotation preserved
+  it("preserves a `: number` type annotation", () => {
+    const source = "export const COUNT: number = 5;\n";
+    const result = patchNamedConstant({
+      source,
+      constantName: "COUNT",
+      newValueLiteral: "10",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.oldValueLiteral).toBe("5");
+    expect(result.source).toBe("export const COUNT: number = 10;\n");
+  });
+
+  // (3) trailing comment + indentation preserved
+  it("preserves indentation and a trailing comment", () => {
+    const source = "  export const X = 100; // threshold\n";
+    const result = patchNamedConstant({
+      source,
+      constantName: "X",
+      newValueLiteral: "200",
+    });
+    expect(result.changed).toBe(true);
+    expect(result.oldValueLiteral).toBe("100");
+    expect(result.source).toBe("  export const X = 200; // threshold\n");
+  });
+
+  // (4) no substring match (`X` must not match `X_2`)
+  it("does not match a substring-named constant", () => {
+    const source = "export const X_2 = 7;\n";
+    expect(() => patchNamedConstant({ source, constantName: "X", newValueLiteral: "9" })).toThrow(
+      /NOT FOUND/,
+    );
+  });
+
+  // (5) no match inside a comment or string literal
+  it("does not match the name inside a comment or string literal", () => {
+    const source = '// export const SECRET = 1;\nexport const note = "export const SECRET = 2";\n';
+    expect(() =>
+      patchNamedConstant({ source, constantName: "SECRET", newValueLiteral: "3" }),
+    ).toThrow(/NOT FOUND/);
+  });
+
+  // (6) idempotent: newValue already equals current → changed: false, source unchanged
+  it("is idempotent when the value already equals the target", () => {
+    const source = "export const A = 42;\n";
+    const result = patchNamedConstant({
+      source,
+      constantName: "A",
+      newValueLiteral: "42",
+    });
+    expect(result.changed).toBe(false);
+    expect(result.oldValueLiteral).toBe("42");
+    expect(result.source).toBe(source);
+  });
+
+  // (7) non-exported const → throws NOT FOUND
+  it("throws NOT FOUND for a non-exported const", () => {
+    const source = "const A = 1;\n";
+    expect(() => patchNamedConstant({ source, constantName: "A", newValueLiteral: "2" })).toThrow(
+      /NOT FOUND/,
+    );
+  });
+
+  // (8) nested / in-function const → throws NOT FOUND (top-level walk only)
+  it("throws NOT FOUND for a const declared inside a function", () => {
+    const source = "export function f() {\n  const A = 1;\n  return A;\n}\n";
+    expect(() => patchNamedConstant({ source, constantName: "A", newValueLiteral: "2" })).toThrow(
+      /NOT FOUND/,
+    );
+  });
+
+  // (9) ambiguous: two top-level `export const X` → throws AMBIGUOUS
+  it("throws AMBIGUOUS when two top-level export consts share the name", () => {
+    const source = "export const X = 1;\nexport const X = 2;\n";
+    expect(() => patchNamedConstant({ source, constantName: "X", newValueLiteral: "3" })).toThrow(
+      /AMBIGUOUS/,
+    );
+  });
+
+  // (10) `export declare const X: number;` (no initializer) → throws NO INITIALIZER
+  it("throws NO INITIALIZER for a declare const without an initializer", () => {
+    const source = "export declare const X: number;\n";
+    expect(() => patchNamedConstant({ source, constantName: "X", newValueLiteral: "5" })).toThrow(
+      /NO INITIALIZER/,
+    );
+  });
+
+  // (11) realistic module: patch the threshold; consuming function body untouched
+  it("patches a threshold constant in a realistic module without touching the function", () => {
+    const source = [
+      "/**",
+      " * Approval policy for purchase requests.",
+      " */",
+      "export const MANAGER_APPROVAL_THRESHOLD = 10000;",
+      "",
+      "export function requiresManagerApproval(amount: number): boolean {",
+      "  // amounts at or above MANAGER_APPROVAL_THRESHOLD need sign-off",
+      "  return amount >= MANAGER_APPROVAL_THRESHOLD;",
+      "}",
+      "",
+    ].join("\n");
+
+    const result = patchNamedConstant({
+      source,
+      constantName: "MANAGER_APPROVAL_THRESHOLD",
+      newValueLiteral: "20000",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.oldValueLiteral).toBe("10000");
+    expect(result.source).toContain("export const MANAGER_APPROVAL_THRESHOLD = 20000;");
+    // The function body (which references the name) must be byte-for-byte intact.
+    expect(result.source).toContain("  return amount >= MANAGER_APPROVAL_THRESHOLD;");
+    expect(result.source).toContain(
+      "  // amounts at or above MANAGER_APPROVAL_THRESHOLD need sign-off",
+    );
+    // Exactly one numeric literal changed: only the threshold declaration.
+    expect(result.source).toBe(source.replace("= 10000;", "= 20000;"));
+  });
+});

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -37,9 +37,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@linchkit/core": "workspace:*"
-  },
-  "devDependencies": {
+    "@linchkit/core": "workspace:*",
     "typescript": "^6.0.2"
   }
 }

--- a/packages/devtools/src/index.ts
+++ b/packages/devtools/src/index.ts
@@ -7,6 +7,8 @@
 
 export const VERSION = "0.0.1";
 
+// === Source patcher (#566): injected TS-AST patcher for core's SourcePatcher seam ===
+export type { SourcePatcher, SourcePatchRequest, SourcePatchResult } from "@linchkit/core";
 // === AI Evaluation Framework (spec 69) ===
 export {
   type AnomalyEvalOutput,
@@ -81,7 +83,6 @@ export {
   watcherMatchers,
   writeCanonicalBaseline,
 } from "./ai-eval";
-
 // === Documentation: API doc generation, Markdown, OpenAPI, Capability Spec, Search ===
 export {
   type ActionDoc,
@@ -163,6 +164,7 @@ export {
   validateNamingConventions,
   validateProjectStructure,
 } from "./methodology";
+export { patchNamedConstant } from "./patch-named-constant";
 export type { TestRuleInput } from "./test-rule";
 export { testRule } from "./test-rule";
 export type {

--- a/packages/devtools/src/patch-named-constant.ts
+++ b/packages/devtools/src/patch-named-constant.ts
@@ -34,16 +34,13 @@ interface ConstantMatch {
 /**
  * Returns true when the variable statement carries an `export` modifier.
  *
- * The `export` keyword lives on the statement's modifiers; reading it via the
- * first declaration's combined modifier flags also folds in `declare`, which is
- * fine here — we only care whether the declaration is exported.
+ * The `export` keyword lives directly on the statement's own modifiers, so we
+ * read it from there. Inspecting `statement.modifiers` (instead of the first
+ * declaration's combined modifier flags) avoids depending on parent pointers,
+ * which lets the parse run with `setParentNodes: false`.
  */
 function isExported(statement: ts.VariableStatement): boolean {
-  const declaration = statement.declarationList.declarations[0];
-  if (declaration === undefined) {
-    return false;
-  }
-  return (ts.getCombinedModifierFlags(declaration) & ts.ModifierFlags.Export) !== 0;
+  return statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
 }
 
 /**
@@ -58,12 +55,14 @@ function isExported(statement: ts.VariableStatement): boolean {
 export function patchNamedConstant(request: SourcePatchRequest): SourcePatchResult {
   const { source, constantName, newValueLiteral } = request;
 
-  // `setParentNodes = true` so `getStart(sourceFile)` works on nested nodes.
+  // No parent pointers needed: `export` is read from the statement's own
+  // modifiers, and `initializer.getStart(sourceFile)` is given the source file
+  // explicitly, so `setParentNodes: false` keeps the parse lean.
   const sourceFile = ts.createSourceFile(
     "patch-input.ts",
     source,
     ts.ScriptTarget.Latest,
-    /* setParentNodes */ true,
+    /* setParentNodes */ false,
   );
 
   const matches: ConstantMatch[] = [];
@@ -76,6 +75,12 @@ export function patchNamedConstant(request: SourcePatchRequest): SourcePatchResu
   // inside functions/blocks are never visited, so they stay unmatchable.
   for (const statement of sourceFile.statements) {
     if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    // `const`-only contract: `export let` / `export var` are deliberately NOT
+    // patchable. The error messages and the SourcePatcher semantics all speak
+    // of an `export const`, so a mutable binding must never match.
+    if ((statement.declarationList.flags & ts.NodeFlags.Const) === 0) {
       continue;
     }
     if (!isExported(statement)) {

--- a/packages/devtools/src/patch-named-constant.ts
+++ b/packages/devtools/src/patch-named-constant.ts
@@ -1,0 +1,144 @@
+/**
+ * patchNamedConstant — the concrete TypeScript-AST source patcher injected into
+ * core's typescript-free `SourcePatcher` seam (#566, Option A).
+ *
+ * Core declares only the request/result shapes and the `SourcePatcher` function
+ * type (`packages/core/src/types/source-patch.ts`); it never imports TypeScript.
+ * This module ships the real implementation in `@linchkit/devtools` — which
+ * already depends on `typescript` for capability-lint — and is wired into
+ * `ProposalFileWriter` from outside core.
+ *
+ * It replaces the initializer of a top-level `export const <NAME>` declaration
+ * in TypeScript source text. Locating the declaration via the compiler AST (not
+ * regex) is what makes the patch precise: comments, string literals, substring
+ * names (`X_2`), nested/in-function consts, and non-exported consts are all
+ * correctly unmatchable, and every surrounding byte (indentation, the optional
+ * `: number` annotation, the trailing `;`, trailing comments) is preserved
+ * because only the initializer span is spliced out of the ORIGINAL source.
+ */
+
+import type { SourcePatchRequest, SourcePatchResult } from "@linchkit/core";
+import * as ts from "typescript";
+
+/**
+ * A top-level `export const <constantName> = <initializer>` match, carrying the
+ * byte span of its initializer in the original source.
+ */
+interface ConstantMatch {
+  /** Inclusive start offset of the initializer in the original source. */
+  start: number;
+  /** Exclusive end offset of the initializer in the original source. */
+  end: number;
+}
+
+/**
+ * Returns true when the variable statement carries an `export` modifier.
+ *
+ * The `export` keyword lives on the statement's modifiers; reading it via the
+ * first declaration's combined modifier flags also folds in `declare`, which is
+ * fine here — we only care whether the declaration is exported.
+ */
+function isExported(statement: ts.VariableStatement): boolean {
+  const declaration = statement.declarationList.declarations[0];
+  if (declaration === undefined) {
+    return false;
+  }
+  return (ts.getCombinedModifierFlags(declaration) & ts.ModifierFlags.Export) !== 0;
+}
+
+/**
+ * Patch the value of a named top-level exported constant in TypeScript source.
+ *
+ * Conforms to core's `SourcePatcher` contract. On success returns the patched
+ * source plus the replaced literal; returns `changed: false` ONLY for an
+ * idempotent no-op (found, but the value already equals the target). THROWS
+ * when the constant is not found, is ambiguous (more than one match — we refuse
+ * to guess), or has no initializer.
+ */
+export function patchNamedConstant(request: SourcePatchRequest): SourcePatchResult {
+  const { source, constantName, newValueLiteral } = request;
+
+  // `setParentNodes = true` so `getStart(sourceFile)` works on nested nodes.
+  const sourceFile = ts.createSourceFile(
+    "patch-input.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+
+  const matches: ConstantMatch[] = [];
+  // True when a top-level `export const <name>` was found but had no
+  // initializer (e.g. `export declare const X: number;`). Tracked separately so
+  // we can throw NO INITIALIZER instead of a misleading NOT FOUND.
+  let foundWithoutInitializer = false;
+
+  // Walk ONLY the top-level statements. This is deliberate: consts declared
+  // inside functions/blocks are never visited, so they stay unmatchable.
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    if (!isExported(statement)) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      // Match on the AST identifier — never on raw text — so comments, string
+      // literals, and substring names (`X` vs `X_2`) cannot false-match.
+      if (!ts.isIdentifier(declaration.name)) {
+        continue;
+      }
+      if (declaration.name.text !== constantName) {
+        continue;
+      }
+
+      const initializer = declaration.initializer;
+      if (initializer === undefined) {
+        foundWithoutInitializer = true;
+        continue;
+      }
+
+      matches.push({
+        // getStart(sourceFile) excludes leading trivia/comments; getEnd()
+        // excludes trailing trivia — exactly the initializer's byte span.
+        start: initializer.getStart(sourceFile),
+        end: initializer.getEnd(),
+      });
+    }
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `AMBIGUOUS: found ${matches.length} top-level "export const ${constantName}" declarations; refusing to guess which to patch.`,
+    );
+  }
+
+  const match = matches[0];
+  if (!match) {
+    if (foundWithoutInitializer) {
+      throw new Error(
+        `NO INITIALIZER: top-level "export const ${constantName}" has no initializer to patch.`,
+      );
+    }
+    throw new Error(
+      `NOT FOUND: no top-level "export const ${constantName}" declaration in source.`,
+    );
+  }
+
+  const { start, end } = match;
+  const oldValueLiteral = source.slice(start, end);
+
+  // Idempotent no-op: the constant already holds the target value. This is the
+  // ONLY case that returns `changed: false`; absence/ambiguity throw above. The
+  // source is returned unchanged.
+  if (oldValueLiteral === newValueLiteral) {
+    return { source, oldValueLiteral, changed: false };
+  }
+
+  // Splice the ORIGINAL source: keep every byte outside the initializer span so
+  // indentation, the `: number` annotation, the trailing `;`, and any trailing
+  // comments survive untouched. The whole file is never re-emitted.
+  const patched = source.slice(0, start) + newValueLiteral + source.slice(end);
+
+  return { source: patched, oldValueLiteral, changed: true };
+}


### PR DESCRIPTION
## What

Lands `patchNamedConstant` in `@linchkit/devtools` — the concrete TS-AST implementation of core's typescript-free `SourcePatcher` seam (merged in #590). This is the first brick of the #566 "say→change an existing code-condition rule's threshold and graduate it to real source" chain.

`patchNamedConstant` rewrites a single top-level `export const NAME = <literal>` initializer in an existing source file by splicing the initializer's byte span out of the original source string — the whole file is never re-emitted, so indentation, the `: number` annotation, the trailing `;`, and any trailing comments survive untouched.

- Walks **only** `sourceFile.statements` for an exported `VariableStatement` whose name matches → nested consts, comments, strings, and substring names (`X` vs `X_2`) are unmatchable.
- Throws `NOT FOUND` (0 matches), `AMBIGUOUS` (>1), `NO INITIALIZER` (e.g. `export declare const X: number`).
- Idempotent: returns `changed: false` **only** when the constant already holds the target value.
- Compile-time `const _: SourcePatcher = patchNamedConstant` guard confirms it satisfies core's contract.

`typescript` is promoted from a dev to a runtime dependency since the patcher ships in the package output.

## Why

Core declares the `SourcePatcher` seam but stays typescript-free (Minimal Core). The heavy TS-compiler-API patcher lives here, in devtools, and is injected into `ProposalFileWriter` at the graduation call-site (a follow-up PR wires the injection at `proposal-graduate-api.ts`). This is the deterministic, named-constant graduation primitive for "说→改既有规则".

## Tests

11 new pinned tests + the assignability guard; full devtools suite green. `bun run check` + `bun run typecheck` clean.

> Note on the full-suite gate: the local `bun run test` batched runner currently hangs in an **unrelated** `packages/cli` batch due to a leftover dev server bound to :3001/:3002 + proxy contamination — not this diff. The devtools+core blast radius (4520 tests / 247 files) passes clean in 6.8s. CI clean-install is authoritative.

Related: #566, #590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capability to patch exported TypeScript named constants while preserving surrounding comments, type annotations, indentation, and file structure.

* **Tests**
  * Comprehensive test suite added covering successful patching, edge cases, and error handling scenarios.

* **Dependencies**
  * TypeScript migrated from development to runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->