### PR TITLE
feat(core,adapter): assemble sourcePatch for say→change-rule (#566)

### DIFF
--- a/.changeset/say-change-rule-sourcepatch.md
+++ b/.changeset/say-change-rule-sourcepatch.md
@@ -1,0 +1,9 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": patch
+"@linchkit/cap-adapter-mcp": patch
+---
+
+Wire the natural-language "say→change an existing code-condition rule's threshold" path to a structured `sourcePatch` (#566). When an utterance asks to change a constant a code-condition rule owns (e.g. "raise the manager-approval threshold to 20000"), the resolver now emits a `newValueLiteral` — gated by a strict `isSafeValueLiteral` validator (number / boolean / null / JSON string only, no expressions) — and `draftRuleUpdate` assembles a `ProposalDiff.sourcePatch { filePath, constantName, newValueLiteral }` when the rule opts in via the new `RuleDefinition.patchTarget`. The adapter-server route copies this onto the governed `ProposalChange.sourcePatch` consumed by `ProposalFileWriter`, and both adapter-server and adapter-mcp project `patchTarget` into the AI-facing rule snapshot.
+
+New public API: `isSafeValueLiteral`, `RuleDefinition.patchTarget`, `SchemaIntentRule.patchTarget`, `ProposalDiff.sourcePatch`, `ParsedSchemaIntent.newValueLiteral`.

--- a/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-ontology.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/schema-intent-ontology.ts
@@ -138,6 +138,10 @@ export function buildSchemaIntentOntology(opts: {
       conditionKind: isCode ? "code" : "declarative",
       ...(isCode ? {} : { condition: rule.condition as SchemaIntentRule["condition"] }),
       roundTrippable,
+      // Pass through the rule's opt-in graduation target (#566) so the resolver
+      // can assemble a `sourcePatch` for a code-condition threshold change. Only
+      // present when the rule declared it (deterministic, reviewable).
+      ...(rule.patchTarget ? { patchTarget: rule.patchTarget } : {}),
     };
   };
 

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-schema-intent.ts
@@ -245,12 +245,21 @@ function persistGovernedRuleDraft(opts: {
   // reviewer in /admin/proposals distinguish it from a malformed change.
   // (Text-only on purpose: ProposalChange has no structured extension point.)
   const diffText = outcome.diffSummary ?? explanation;
+  // Carry an assembled in-place named-constant patch (#566) onto the governed
+  // change so graduation can rewrite the real `export const … = …` via the
+  // injected SourcePatcher. Present ONLY when the resolver could turn the
+  // diff-only code-condition update into a machine-applicable patch (the rule
+  // was CODE-condition, declared a `patchTarget`, and the AI produced a SAFE
+  // `newValueLiteral`); absent otherwise (the update stays a developer
+  // change-request). The patch values were validated upstream by the resolver.
+  const sourcePatch = outcome.sourcePatch;
   const change: ProposalChange = {
     target: "rule",
     operation,
     name: ruleName,
     ...(definition ? { definition } : {}),
     diff: diffOnly ? `${REQUIRES_CODE_CHANGE_MARKER} ${diffText}` : diffText,
+    ...(sourcePatch ? { sourcePatch } : {}),
   };
 
   const codeChangeNote = diffOnly

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-schema-intent-ontology.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-schema-intent-ontology.ts
@@ -125,6 +125,10 @@ export function buildSchemaIntentOntology(opts: {
       conditionKind: isCode ? "code" : "declarative",
       ...(isCode ? {} : { condition: rule.condition as SchemaIntentRule["condition"] }),
       roundTrippable,
+      // Pass through the rule's opt-in graduation target (#566) so the resolver
+      // can assemble a `sourcePatch` for a code-condition threshold change. Only
+      // present when the rule declared it (deterministic, reviewable).
+      ...(rule.patchTarget ? { patchTarget: rule.patchTarget } : {}),
     };
   };
 

--- a/addons/demo/cap-purchase-demo/src/rules/manager-approval-threshold.ts
+++ b/addons/demo/cap-purchase-demo/src/rules/manager-approval-threshold.ts
@@ -4,7 +4,11 @@
  * This is the single, first-class object that encodes the procurement policy
  * "large purchases need a manager". A future "说→有" NL loop edits THIS rule
  * (and the {@link MANAGER_APPROVAL_THRESHOLD} constant it owns) to change the
- * policy — no action / flow code has to change.
+ * policy — no action / flow code has to change. The rule opts into that loop by
+ * declaring a `patchTarget` (#566): because its condition is CODE (not
+ * declaratively rebuildable), a "把经理审批阈值改成 20000" request graduates by
+ * patching the {@link MANAGER_APPROVAL_THRESHOLD} constant IN PLACE rather than
+ * fabricating a replacement rule.
  *
  * Enforcement: the rule fires inside `approve_purchase_request` execution via
  * the real rule-in-action wiring (core `evaluateActionRules`, PRs #460-#475).
@@ -108,5 +112,15 @@ export const managerApprovalThresholdRule: RuleDefinition = {
     message:
       `金额超过 ${MANAGER_APPROVAL_THRESHOLD} 需要经理审批 / ` +
       `Amounts over ${MANAGER_APPROVAL_THRESHOLD} require manager approval`,
+  },
+  // Opt-in graduation target for "说→改阈值" (#566). This rule's condition is
+  // code (it cannot be rebuilt declaratively), so a "raise the manager-approval
+  // threshold to 20000" request graduates by patching the MANAGER_APPROVAL_THRESHOLD
+  // constant above IN PLACE rather than fabricating a new declarative rule. The
+  // resolver assembles a `sourcePatch` from this when the AI returns a safe
+  // `newValueLiteral`; an injected TS-AST patcher rewrites the constant.
+  patchTarget: {
+    sourcePath: "addons/demo/cap-purchase-demo/src/rules/manager-approval-threshold.ts",
+    constantName: "MANAGER_APPROVAL_THRESHOLD",
   },
 };

--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -10,7 +10,13 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+// `ai`-side proposal engine + the resolver's update-draft path: used by the
+// full #566 assembly→graduation loop test below. Imported directly (not via the
+// public barrel) because `draftRuleUpdate` is an internal resolver helper.
+import { ProposalEngine as AiProposalEngine } from "../src/ai/proposal-engine";
+import { draftRuleUpdate } from "../src/ai/schema-intent-rule-updater";
+import type { SchemaIntentEntity } from "../src/ai/schema-intent-types";
 import { createProposalEngine, ProposalFileWriter } from "../src/server-entry";
 import type { ProposalChange, ProposalDefinition } from "../src/types/proposal";
 import type { SourcePatchRequest, SourcePatchResult } from "../src/types/source-patch";
@@ -938,6 +944,84 @@ describe("ProposalFileWriter source patch (#566)", () => {
     expect(calls[0].constantName).toBe("MANAGER_APPROVAL_THRESHOLD");
     expect(calls[0].newValueLiteral).toBe("20000");
     expect(calls[0].source).toContain("= 10000");
+  });
+
+  it("graduates the sourcePatch ASSEMBLED by draftRuleUpdate (full #566 loop)", async () => {
+    // End-to-end seam: the sourcePatch the resolver's draftRuleUpdate assembles
+    // for the demo manager-approval rule drives the writer to rewrite the real
+    // MANAGER_APPROVAL_THRESHOLD constant via the injected fake patcher. This
+    // proves the two halves (assembly + graduation) compose without the runtime
+    // TS-AST patcher (that injection is a separate follow-up PR).
+    const entity: SchemaIntentEntity = {
+      name: "purchase_request",
+      label: "Purchase Request",
+      fields: [{ name: "amount", type: "number", required: true }],
+      actionNames: ["approve_purchase_request"],
+      rules: [
+        {
+          name: "manager_approval_threshold",
+          label: "Manager approval threshold",
+          triggerActions: ["approve_purchase_request"],
+          effectType: "block",
+          conditionKind: "code",
+          patchTarget: {
+            // Patch the file we create under tmpDir below (relative to repoRoot).
+            sourcePath: join("rules", "manager-approval-threshold.ts"),
+            constantName: "MANAGER_APPROVAL_THRESHOLD",
+          },
+        },
+      ],
+    };
+    const drafted = draftRuleUpdate({
+      parsed: {
+        kind: "update_rule",
+        targetEntity: "purchase_request",
+        ruleName: "manager_approval_threshold",
+        diff: "Raise the manager-approval threshold to 20000.",
+        newValueLiteral: "20000",
+        confidence: 0.9,
+        explanation: "把经理审批阈值改成2万。",
+      },
+      entity,
+      confidence: 0.9,
+      utterance: "把经理审批阈值改成2万",
+      engine: new AiProposalEngine(),
+    });
+    expect(drafted.kind).toBe("proposal_draft");
+    if (drafted.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    const assembled = drafted.sourcePatch;
+    expect(assembled).toBeDefined();
+    if (!assembled) throw new Error("expected an assembled sourcePatch");
+
+    // Create the on-disk file the patch targets.
+    const absPath = join(tmpDir, assembled.filePath);
+    await mkdir(dirname(absPath), { recursive: true });
+    await writeFile(absPath, "export const MANAGER_APPROVAL_THRESHOLD = 10000;\n", "utf8");
+
+    // Build a governed proposal whose single change carries the ASSEMBLED patch.
+    const change: ProposalChange = {
+      target: "rule",
+      operation: "update",
+      name: "manager_approval_threshold",
+      diff: "Raise the manager-approval threshold to 20000.",
+      sourcePatch: assembled,
+    };
+    const { calls, patcher } = makeFakePatcher();
+    const writer = new ProposalFileWriter({
+      rootDir: tmpDir,
+      repoRoot: tmpDir,
+      sourcePatcher: patcher,
+    });
+
+    const written = await writer.writeApprovedProposal(makeApprovedProposal({ changes: [change] }));
+
+    expect(written).toEqual([absPath]);
+    expect(await readFile(absPath, "utf8")).toBe(
+      "export const MANAGER_APPROVAL_THRESHOLD = 20000;\n",
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].constantName).toBe("MANAGER_APPROVAL_THRESHOLD");
+    expect(calls[0].newValueLiteral).toBe("20000");
   });
 
   it("does NOT rewrite the file when the patch is a no-op (changed: false) (gemini #590)", async () => {

--- a/packages/core/src/ai/__tests__/schema-intent-rule-updater.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-rule-updater.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `draftRuleUpdate` — sourcePatch assembly (#566).
+ *
+ * The "say→change the manager-approval threshold to 20000" path must turn a
+ * CODE-condition rule update into a governed draft whose change carries a
+ * structured `sourcePatch { filePath, constantName, newValueLiteral }`, so that
+ * graduation rewrites the real `export const MANAGER_APPROVAL_THRESHOLD = 10000`.
+ *
+ * The `ai` Proposal model carries its single change as `proposal.diff`, so "the
+ * change" here is `proposal.diff.sourcePatch`; the outcome mirrors it on
+ * `outcome.sourcePatch` for the adapter-server route to copy onto the governed
+ * `ProposalChange.sourcePatch`. These tests pin BOTH carriers, plus the
+ * negative cases where no `sourcePatch` must be built.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ProposalEngine } from "../proposal-engine";
+import type { ParsedSchemaIntent } from "../schema-intent-prompt";
+import { draftRuleUpdate } from "../schema-intent-rule-updater";
+import type { SchemaIntentEntity, SchemaIntentRule } from "../schema-intent-types";
+
+const DEMO_PATCH_PATH = "addons/demo/cap-purchase-demo/src/rules/manager-approval-threshold.ts";
+
+/** A CODE-condition rule snapshot that opted into graduation via `patchTarget`. */
+function codeRuleWithPatchTarget(overrides: Partial<SchemaIntentRule> = {}): SchemaIntentRule {
+  return {
+    name: "manager_approval_threshold",
+    label: "Manager approval threshold",
+    description: "Requires manager approval when the amount exceeds 10000",
+    triggerActions: ["approve_purchase_request"],
+    effectType: "block",
+    conditionKind: "code",
+    patchTarget: { sourcePath: DEMO_PATCH_PATH, constantName: "MANAGER_APPROVAL_THRESHOLD" },
+    ...overrides,
+  };
+}
+
+/** Wrap one rule snapshot in the entity the resolver consumes. */
+function entityWithRule(rule: SchemaIntentRule): SchemaIntentEntity {
+  return {
+    name: "purchase_request",
+    label: "Purchase Request",
+    fields: [{ name: "amount", type: "number", required: true }],
+    actionNames: ["approve_purchase_request"],
+    rules: [rule],
+  };
+}
+
+/** A parsed `update_rule` intent targeting the demo rule. */
+function parsedUpdate(overrides: Partial<ParsedSchemaIntent> = {}): ParsedSchemaIntent {
+  return {
+    kind: "update_rule",
+    targetEntity: "purchase_request",
+    ruleName: "manager_approval_threshold",
+    diff: "Change the manager-approval threshold from 10000 to 20000.",
+    confidence: 0.9,
+    explanation: "把经理审批阈值改成2万。",
+    ...overrides,
+  };
+}
+
+function runDraft(opts: { parsed: ParsedSchemaIntent; rule: SchemaIntentRule }) {
+  const entity = entityWithRule(opts.rule);
+  return draftRuleUpdate({
+    parsed: opts.parsed,
+    entity,
+    confidence: 0.9,
+    utterance: "把经理审批阈值改成2万",
+    engine: new ProposalEngine(),
+  });
+}
+
+describe("draftRuleUpdate — sourcePatch assembly (#566)", () => {
+  it("assembles a sourcePatch for a code rule with patchTarget + safe newValueLiteral", () => {
+    const outcome = runDraft({
+      parsed: parsedUpdate({ newValueLiteral: "20000" }),
+      rule: codeRuleWithPatchTarget(),
+    });
+
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.requiresCodeChange).toBe(true);
+
+    const expected = {
+      filePath: DEMO_PATCH_PATH,
+      constantName: "MANAGER_APPROVAL_THRESHOLD",
+      newValueLiteral: "20000",
+    };
+    // The change (proposal.diff) carries the assembled patch…
+    expect(outcome.proposal.diff.sourcePatch).toEqual(expected);
+    // …and the outcome mirrors it for the route to copy onto the governed change.
+    expect(outcome.sourcePatch).toEqual(expected);
+    // No fabricated declarative definition — this stays an honest code change.
+    expect(outcome.proposal.diff.definition).toBeUndefined();
+  });
+
+  it("builds NO sourcePatch when newValueLiteral is absent", () => {
+    const outcome = runDraft({
+      parsed: parsedUpdate(), // no newValueLiteral
+      rule: codeRuleWithPatchTarget(),
+    });
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.sourcePatch).toBeUndefined();
+    expect(outcome.proposal.diff.sourcePatch).toBeUndefined();
+    // Still an honest diff-only change-request.
+    expect(outcome.requiresCodeChange).toBe(true);
+  });
+
+  it("builds NO sourcePatch from an UNSAFE newValueLiteral", () => {
+    // Defence in depth: even if a caller hands a parsed intent whose
+    // newValueLiteral bypassed the parser gate, the assembler re-validates and
+    // refuses to splice unsafe text into source.
+    const outcome = runDraft({
+      parsed: parsedUpdate({ newValueLiteral: "20000; DROP TABLE rules" }),
+      rule: codeRuleWithPatchTarget(),
+    });
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.sourcePatch).toBeUndefined();
+    expect(outcome.proposal.diff.sourcePatch).toBeUndefined();
+  });
+
+  it("builds NO sourcePatch when the rule declared no patchTarget", () => {
+    const outcome = runDraft({
+      parsed: parsedUpdate({ newValueLiteral: "20000" }),
+      rule: codeRuleWithPatchTarget({ patchTarget: undefined }),
+    });
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    expect(outcome.sourcePatch).toBeUndefined();
+    expect(outcome.proposal.diff.sourcePatch).toBeUndefined();
+  });
+
+  it("builds NO sourcePatch for a declarative (non-code) rule", () => {
+    // A declarative rule takes the rebuild path, never the sourcePatch path —
+    // even if it (nonsensically) carried a patchTarget and a newValueLiteral.
+    const declarativeRule: SchemaIntentRule = {
+      name: "warn_large_amount",
+      label: "Warn on large amount",
+      triggerActions: ["approve_purchase_request"],
+      effectType: "warn",
+      conditionKind: "declarative",
+      condition: { field: "amount", operator: "gt", value: 5000 },
+      roundTrippable: true,
+      effect: { type: "warn", message: "Amount exceeds 5000" },
+      patchTarget: { sourcePath: DEMO_PATCH_PATH, constantName: "MANAGER_APPROVAL_THRESHOLD" },
+    };
+    const outcome = runDraft({
+      parsed: parsedUpdate({
+        ruleName: "warn_large_amount",
+        newValueLiteral: "20000",
+        // A full declarative rule the rebuild path accepts.
+        rule: {
+          name: "warn_large_amount",
+          label: "Warn on large amount",
+          trigger: { action: "approve_purchase_request" },
+          condition: { field: "amount", operator: "gt", value: 20000 },
+          effect: { type: "warn", message: "Amount exceeds 20000" },
+        },
+      }),
+      rule: declarativeRule,
+    });
+    expect(outcome.kind).toBe("proposal_draft");
+    if (outcome.kind !== "proposal_draft") throw new Error("expected proposal_draft");
+    // Declarative rebuild path → a definition, never a sourcePatch.
+    expect(outcome.sourcePatch).toBeUndefined();
+    expect(outcome.proposal.diff.sourcePatch).toBeUndefined();
+    expect(outcome.proposal.diff.definition).toBeDefined();
+    expect(outcome.requiresCodeChange).toBeUndefined();
+  });
+});

--- a/packages/core/src/ai/__tests__/schema-intent-value-literal.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-value-literal.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for `isSafeValueLiteral` (#566 — the security gate for `newValueLiteral`).
+ *
+ * `newValueLiteral` is spliced VERBATIM into capability source code by the
+ * graduation patcher, so it must accept ONLY a self-contained value literal and
+ * REJECT anything that could execute or inject. These tests pin both the safe
+ * surface (numbers / booleans / null / double-quoted JSON strings) and a battery
+ * of malicious / malformed inputs.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isSafeValueLiteral, parseSchemaIntentResponse } from "../schema-intent-prompt";
+
+describe("isSafeValueLiteral — accepts safe value literals", () => {
+  const safe = [
+    "20000",
+    "0",
+    "-1",
+    "+42",
+    "-1.5",
+    "3.14",
+    ".5",
+    "42.",
+    "true",
+    "false",
+    "null",
+    '"manager"',
+    '""',
+    '"a string with spaces"',
+    '"中文"',
+    '"escaped \\" quote"',
+  ];
+  for (const value of safe) {
+    it(`accepts ${JSON.stringify(value)}`, () => {
+      expect(isSafeValueLiteral(value)).toBe(true);
+    });
+  }
+});
+
+describe("isSafeValueLiteral — rejects unsafe / malformed input", () => {
+  const unsafe = [
+    // The exact attack strings called out by the spec.
+    "foo()",
+    "1;DROP",
+    "`x`",
+    "() => 9",
+    // Identifiers / globals masquerading as literals.
+    "MANAGER_APPROVAL_THRESHOLD",
+    "Infinity",
+    "NaN",
+    "undefined",
+    "process",
+    // Operators / expressions.
+    "1 + 1",
+    "20000 || true",
+    "a && b",
+    "x = 9",
+    // Statements / separators / comments.
+    "1; alert(1)",
+    "1, 2",
+    "1 // comment",
+    "1 /* c */",
+    // Object / array literals (not a single value literal).
+    "{}",
+    "[]",
+    "{ a: 1 }",
+    "[1, 2, 3]",
+    // Template / single-quoted / unterminated strings.
+    "'manager'",
+    '"unterminated',
+    'unterminated"',
+    '"a" + "b"',
+    '"a", "b"',
+    // Whitespace-wrapped multi-token (must not pass via a sloppy trim).
+    " 1 ; DROP ",
+    "  20000  ",
+    // Malformed numbers.
+    "0x1F",
+    "1e3",
+    "1_000",
+    "",
+    ".",
+    "-",
+    "+",
+    "1.2.3",
+  ];
+  for (const value of unsafe) {
+    it(`rejects ${JSON.stringify(value)}`, () => {
+      expect(isSafeValueLiteral(value)).toBe(false);
+    });
+  }
+
+  it("rejects a non-string input", () => {
+    // Defensive runtime guard — callers should pass strings, but a malformed
+    // payload must not slip through.
+    expect(isSafeValueLiteral(20000 as unknown as string)).toBe(false);
+    expect(isSafeValueLiteral(null as unknown as string)).toBe(false);
+  });
+});
+
+describe("parseSchemaIntentResponse — newValueLiteral gating (#566)", () => {
+  it("reads a SAFE newValueLiteral into the parsed intent", () => {
+    const parsed = parseSchemaIntentResponse(
+      JSON.stringify({
+        kind: "update_rule",
+        ruleName: "manager_approval_threshold",
+        diff: "Raise the threshold to 20000.",
+        newValueLiteral: "20000",
+        confidence: 0.9,
+      }),
+    );
+    expect(parsed?.newValueLiteral).toBe("20000");
+  });
+
+  it("DROPS an unsafe newValueLiteral (treated as absent)", () => {
+    const parsed = parseSchemaIntentResponse(
+      JSON.stringify({
+        kind: "update_rule",
+        ruleName: "manager_approval_threshold",
+        diff: "Raise the threshold.",
+        newValueLiteral: "foo(); DROP TABLE rules",
+        confidence: 0.9,
+      }),
+    );
+    expect(parsed?.newValueLiteral).toBeUndefined();
+  });
+
+  it("leaves newValueLiteral undefined when omitted", () => {
+    const parsed = parseSchemaIntentResponse(
+      JSON.stringify({
+        kind: "update_rule",
+        ruleName: "manager_approval_threshold",
+        diff: "Raise the threshold.",
+        confidence: 0.9,
+      }),
+    );
+    expect(parsed?.newValueLiteral).toBeUndefined();
+  });
+});

--- a/packages/core/src/ai/__tests__/schema-intent-value-literal.test.ts
+++ b/packages/core/src/ai/__tests__/schema-intent-value-literal.test.ts
@@ -78,6 +78,10 @@ describe("isSafeValueLiteral — rejects unsafe / malformed input", () => {
     "0x1F",
     "1e3",
     "1_000",
+    // Leading zeros splice in as an octal literal → strict-mode TS syntax error.
+    "007",
+    "0123",
+    "00",
     "",
     ".",
     "-",

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -228,6 +228,7 @@ export type {
 } from "./schema-intent-prompt";
 export {
   buildSchemaIntentSystemPrompt,
+  isSafeValueLiteral,
   parseSchemaIntentResponse,
 } from "./schema-intent-prompt";
 export type {

--- a/packages/core/src/ai/proposal-engine.ts
+++ b/packages/core/src/ai/proposal-engine.ts
@@ -70,6 +70,23 @@ export interface ProposalDiff {
   targetName?: string;
   /** Human-readable summary of the change */
   summary: string;
+  /**
+   * Structured in-place named-constant patch for a "say→change a constant this
+   * rule owns" update (#566). Present ONLY on a diff-only CODE-condition update
+   * whose rule declared a `patchTarget` AND for which the AI produced a SAFE
+   * `newValueLiteral`. The graduation pipeline copies this onto the governed
+   * `ProposalChange.sourcePatch`, where the injected `SourcePatcher` rewrites
+   * the real `export const <constantName> = <literal>;`. Absent for every other
+   * update (those stay diff-only — a developer applies the change in source).
+   */
+  sourcePatch?: {
+    /** Repo-root-relative path to the existing source file to patch. */
+    filePath: string;
+    /** Name of the exported constant to patch. */
+    constantName: string;
+    /** Already-validated literal to write as the new value, e.g. "20000". */
+    newValueLiteral: string;
+  };
 }
 
 /** A complete proposal with lifecycle state */

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -412,8 +412,10 @@ export function isSafeValueLiteral(value: string): boolean {
   // trim; instead we forbid any whitespace outright for the non-string forms.)
   // Number literal: optional sign, digits with an optional single decimal point
   // on either side of the dot, but at least one digit overall. No exponent,
-  // hex, underscores, or `Infinity`/`NaN` (those are identifiers, not literals).
-  if (/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(value)) return true;
+  // hex, underscores, or `Infinity`/`NaN` (those are identifiers, not literals),
+  // and no leading zeros on an integer (`007` would splice in as an octal
+  // literal — a syntax error in strict-mode TypeScript).
+  if (/^[+-]?(?:0(?:\.\d*)?|[1-9]\d*\.?\d*|\.\d+)$/.test(value)) return true;
   // Keyword literals.
   if (value === "true" || value === "false" || value === "null") return true;
   // Double-quoted JSON string literal. JSON.parse rejects single quotes,

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -227,9 +227,18 @@ B) The user wants to CHANGE an EXISTING rule (the request clearly refers to one 
      "ruleName": "<the EXISTING rule's name from existingRules — never invent one>",
      "rule": { <the FULL UPDATED rule definition, same shape as in (A)> },
      "diff": "<one short human-readable sentence describing exactly what changes vs the existing rule>",
+     "newValueLiteral": "<OPTIONAL — see rule below>",
      "confidence": <number in [0, 1]>,
      "explanation": "<one short sentence for the review card, in the user's language>"
    }
+
+   - \`newValueLiteral\` (OPTIONAL): include it ONLY when this is a "code" rule
+     (\`conditionKind: "code"\`) AND the request is a SINGLE constant/threshold
+     value change (e.g. "把经理审批阈值改成 20000"). Emit the raw JavaScript
+     literal for the NEW value: a bare number like \`"20000"\` or \`"-1.5"\`, a
+     \`"true"\`/\`"false"\`/\`"null"\` keyword, or a double-quoted string like
+     \`"\\"manager\\""\`. OMIT it when the change is not a simple literal swap
+     (anything involving an expression, multiple values, or a renamed target).
 
    - If the existing rule's \`conditionKind\` is "declarative" AND its \`roundTrippable\`
      is not false: return the FULL updated definition in \`rule\`. Keep everything you
@@ -354,6 +363,15 @@ export interface ParsedSchemaIntent {
   ruleName?: string;
   /** `update_rule` only — human-readable diff summary vs the existing rule. */
   diff?: string;
+  /**
+   * `update_rule` only — the raw JavaScript literal for the NEW value when the
+   * change is a single constant/threshold swap on a CODE-condition rule (#566).
+   * Spliced into source by the graduation patcher, so it is admitted ONLY when
+   * it passes {@link isSafeValueLiteral} (a number / boolean / null / a
+   * double-quoted JSON string). An unsafe / absent value is dropped — no
+   * `sourcePatch` is built from it.
+   */
+  newValueLiteral?: string;
   /** Present for `kind === "add_entity"`. */
   entity?: ParsedEntityShape;
   /** Optional relation accompanying an `add_entity` draft. */
@@ -367,6 +385,48 @@ export interface ParsedSchemaIntent {
   confidence?: number;
   explanation?: string;
   question?: string;
+}
+
+/**
+ * SECURITY GATE for `newValueLiteral` (#566). This string is later SPLICED
+ * verbatim into capability source code by the graduation patcher, so it must be
+ * a self-contained, side-effect-free VALUE literal — never an expression that
+ * could execute. Accepts ONLY:
+ *
+ *   - an integer / decimal number literal, optionally signed (`20000`, `-1.5`,
+ *     `.5`, `42.`),
+ *   - the keyword literals `true` / `false` / `null`,
+ *   - a double-quoted JSON string literal (`"manager"`) that round-trips through
+ *     `JSON.parse` to a string (rejects unterminated / multi-token strings).
+ *
+ * Everything else is REJECTED: identifiers, function calls (`foo()`), operators,
+ * template literals (`` `x` ``), arrow functions (`() => 9`), object / array
+ * literals, statement separators (`1;DROP`), comments, whitespace-wrapped
+ * multi-token input. The caller DROPS a failing value (treats it as absent) so
+ * no `sourcePatch` is ever built from unsafe input.
+ */
+export function isSafeValueLiteral(value: string): boolean {
+  if (typeof value !== "string") return false;
+  // No leading/trailing whitespace, no internal separators — a single token.
+  // (A trimmed-then-checked approach would let `" 1 ; DROP "` look single after
+  // trim; instead we forbid any whitespace outright for the non-string forms.)
+  // Number literal: optional sign, digits with an optional single decimal point
+  // on either side of the dot, but at least one digit overall. No exponent,
+  // hex, underscores, or `Infinity`/`NaN` (those are identifiers, not literals).
+  if (/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(value)) return true;
+  // Keyword literals.
+  if (value === "true" || value === "false" || value === "null") return true;
+  // Double-quoted JSON string literal. JSON.parse rejects single quotes,
+  // unterminated strings, and trailing tokens (`"a" + b`), and we additionally
+  // require the parse result to BE a string so only the string form passes here.
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    try {
+      return typeof JSON.parse(value) === "string";
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }
 
 /**
@@ -395,6 +455,14 @@ export function parseSchemaIntentResponse(raw: string): ParsedSchemaIntent | nul
     rule: rec.rule && typeof rec.rule === "object" ? (rec.rule as ParsedRuleShape) : undefined,
     ruleName: typeof rec.ruleName === "string" ? rec.ruleName : undefined,
     diff: typeof rec.diff === "string" ? rec.diff : undefined,
+    // SECURITY: admit `newValueLiteral` ONLY when it is a safe value literal —
+    // it is spliced into source by graduation. An unsafe (or non-string) value
+    // is DROPPED here (treated as absent) so no `sourcePatch` is ever built
+    // from it (#566).
+    newValueLiteral:
+      typeof rec.newValueLiteral === "string" && isSafeValueLiteral(rec.newValueLiteral)
+        ? rec.newValueLiteral
+        : undefined,
     entity:
       rec.entity && typeof rec.entity === "object" ? (rec.entity as ParsedEntityShape) : undefined,
     relation:

--- a/packages/core/src/ai/schema-intent-rule-updater.ts
+++ b/packages/core/src/ai/schema-intent-rule-updater.ts
@@ -17,8 +17,12 @@
  */
 
 import type { RuleDefinition } from "../types/rule";
-import type { ProposalEngine } from "./proposal-engine";
-import type { ParsedRuleShape, ParsedSchemaIntent } from "./schema-intent-prompt";
+import type { ProposalDiff, ProposalEngine } from "./proposal-engine";
+import {
+  isSafeValueLiteral,
+  type ParsedRuleShape,
+  type ParsedSchemaIntent,
+} from "./schema-intent-prompt";
 import { SCHEMA_INTENT_MESSAGES } from "./schema-intent-resolver-messages";
 import { buildRuleDefinition } from "./schema-intent-rule-builder";
 import type {
@@ -86,6 +90,14 @@ export function draftRuleUpdate(opts: {
     if (!summary) {
       return noMatch("invalid_rule", SCHEMA_INTENT_MESSAGES.missingUpdateDiff);
     }
+    // Try to upgrade the diff-only change-request into a MACHINE-APPLICABLE
+    // in-place source patch (#566). This succeeds ONLY for the narrow,
+    // graduatable case: a CODE condition (declarative rules take the rebuild
+    // path above), an opt-in `patchTarget` declared on the rule, AND a SAFE
+    // `newValueLiteral` produced by the AI (it was validated at parse time;
+    // re-checked here defensively before it is ever spliced into source). Every
+    // other diff-only update stays a developer change-request (no sourcePatch).
+    const sourcePatch = buildSourcePatch(existing, parsed.newValueLiteral);
     const proposal = engine.createProposal({
       type: "update_rule",
       description: explanation,
@@ -95,7 +107,13 @@ export function draftRuleUpdate(opts: {
       // AI saw. The summary is the reviewable spec of the change.
       // `targetName` carries the rule name so downstream security change
       // records still report the real target without a definition.
-      diff: { target: "rule", operation: "update", targetName: existing.name, summary },
+      diff: {
+        target: "rule",
+        operation: "update",
+        targetName: existing.name,
+        summary,
+        ...(sourcePatch ? { sourcePatch } : {}),
+      },
     });
     return {
       kind: "proposal_draft",
@@ -107,6 +125,7 @@ export function draftRuleUpdate(opts: {
       explanation,
       diffSummary: summary,
       requiresCodeChange: true,
+      ...(sourcePatch ? { sourcePatch } : {}),
     };
   }
 
@@ -220,4 +239,36 @@ function backfillUpdateShape(rule: ParsedRuleShape, existing: SchemaIntentRule):
 /** Narrow to a plain object record (not null, not an array). */
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Assemble an in-place named-constant `sourcePatch` for a "say→change the
+ * threshold" code-condition update (#566). Returns `undefined` — leaving the
+ * update a plain diff-only change-request — UNLESS every graduatability
+ * precondition holds:
+ *
+ *   1. The existing rule's condition is CODE (`conditionKind === "code"`). A
+ *      declarative rule never reaches this helper (it takes the rebuild path).
+ *   2. The rule declared an opt-in `patchTarget` (source file + constant name).
+ *   3. The AI produced a `newValueLiteral` that passes {@link isSafeValueLiteral}
+ *      — re-checked here as DEFENCE IN DEPTH because the result is spliced
+ *      verbatim into capability source by the graduation patcher (it was already
+ *      validated at parse time; a second gate guards against any future caller
+ *      that builds a `ParsedSchemaIntent` without going through the parser).
+ */
+function buildSourcePatch(
+  existing: SchemaIntentRule,
+  newValueLiteral: string | undefined,
+): NonNullable<ProposalDiff["sourcePatch"]> | undefined {
+  if (existing.conditionKind !== "code") return undefined;
+  const target = existing.patchTarget;
+  if (!target) return undefined;
+  if (typeof newValueLiteral !== "string" || !isSafeValueLiteral(newValueLiteral)) {
+    return undefined;
+  }
+  return {
+    filePath: target.sourcePath,
+    constantName: target.constantName,
+    newValueLiteral,
+  };
 }

--- a/packages/core/src/ai/schema-intent-types.ts
+++ b/packages/core/src/ai/schema-intent-types.ts
@@ -84,6 +84,23 @@ export interface SchemaIntentProposalDraft {
    * honest, governed change REQUEST.
    */
   requiresCodeChange?: boolean;
+  /**
+   * Present ONLY for a `requiresCodeChange` update that the resolver could turn
+   * into an in-place named-constant patch (#566): the rule was CODE-condition,
+   * declared a `patchTarget`, and the AI produced a SAFE `newValueLiteral`.
+   * Mirrors `proposal.diff.sourcePatch`; the graduation pipeline copies it onto
+   * the governed `ProposalChange.sourcePatch` so the real `export const … = …`
+   * is rewritten. Absent when the diff-only update has no machine-applicable
+   * patch (a developer applies it in source).
+   */
+  sourcePatch?: {
+    /** Repo-root-relative path to the existing source file to patch. */
+    filePath: string;
+    /** Name of the exported constant to patch. */
+    constantName: string;
+    /** Already-validated literal to write as the new value, e.g. "20000". */
+    newValueLiteral: string;
+  };
 }
 
 // ── Entity-draft outcome (issue #575) ────────────────────────
@@ -286,6 +303,14 @@ export interface SchemaIntentRule {
    * snapshots) means round-trippable when `conditionKind` is `"declarative"`.
    */
   roundTrippable?: boolean;
+  /**
+   * Opt-in graduation target projected from `RuleDefinition.patchTarget` (#566)
+   * — the repo-root-relative source file and the exported constant a
+   * code-condition "say→change the threshold" update should patch in place. The
+   * resolver reads this to assemble a `sourcePatch`. Absent for rules that did
+   * not declare a patch target (the update stays diff-only).
+   */
+  patchTarget?: { sourcePath: string; constantName: string };
 }
 
 /**

--- a/packages/core/src/types/rule.ts
+++ b/packages/core/src/types/rule.ts
@@ -195,6 +195,15 @@ export interface RuleDefinition {
   effect: RuleEffect;
   /** Semantic metadata for AI reasoning and ontology search (Spec 67) */
   semantics?: RuleSemantics;
+  /**
+   * Opt-in graduation target for "say→change a constant this rule owns" (#566).
+   * Declares the repo-root-relative source file and the top-level exported
+   * constant whose literal a code-condition update should patch (e.g. raising
+   * `MANAGER_APPROVAL_THRESHOLD`). Explicit and deterministic — no `import.meta`
+   * magic — so the patch target is reviewable. When absent, a code-condition
+   * update stays a diff-only change request (no in-place source patch).
+   */
+  patchTarget?: { sourcePath: string; constantName: string };
 }
 
 // ── Rule evaluation result ──────────────────────────────────


### PR DESCRIPTION
## What

Wires the natural-language **"say→change an existing code-condition rule's threshold"** path to a structured `sourcePatch` (#566). This is the core assembly brick that turns an utterance like *"把经理审批阈值改成 20000"* into a governed Proposal whose change carries the exact `{ filePath, constantName, newValueLiteral }` the `ProposalFileWriter`'s injected `SourcePatcher` (#590 / #591) needs to rewrite the real `export const MANAGER_APPROVAL_THRESHOLD` in source.

## How

- **`schema-intent-prompt.ts`** — `ParsedSchemaIntent.newValueLiteral`, the prompt instruction to emit it, and the strict `isSafeValueLiteral` validator (number / boolean / null / double-quoted JSON string **only** — no expressions, identifiers, `Infinity`/`NaN`, multi-token, or whitespace). Unsafe values are dropped at parse time.
- **`types/rule.ts`** — opt-in `RuleDefinition.patchTarget { sourcePath, constantName }`. A code-condition rule declares the constant it owns; without it, no sourcePatch is built (existing fail-loud guard from #587 still applies).
- **`schema-intent-rule-updater.ts`** — `draftRuleUpdate` assembles `sourcePatch` only when `conditionKind === "code"` + `patchTarget` present + `newValueLiteral` safe (re-validated as defence-in-depth).
- **`proposal-engine.ts` / `schema-intent-types.ts`** — `ProposalDiff.sourcePatch` + `SchemaIntentRule.patchTarget` so the `ai` single-change model can carry it.
- **adapter-server / adapter-mcp** — `toSchemaIntentRule()` projects `patchTarget`; the adapter-server `resolve-schema-intent` route copies `outcome.sourcePatch` onto the governed `ProposalChange.sourcePatch`.
- **demo** — the manager-approval-threshold rule opts in.

## Scope

Runtime injection of the real TS-AST patcher (`patchNamedConstant` from `@linchkit/devtools`, merged in #591) is a **separate capstone PR** — `proposal-graduate-api.ts` is intentionally untouched here. The e2e graduation test proves assembly→patch with an injected **fake** patcher.

## Tests

New `schema-intent-value-literal.test.ts` (validator + parse gating, incl. malicious inputs) and `schema-intent-rule-updater.test.ts` (safe→patch; absent / unsafe / no-patchTarget / declarative → no patch), plus an extended `proposal-file-writer.test.ts` assembly→graduation loop. `bun run check` + `bun run typecheck` clean; targeted core/adapter/demo suites green.

> The local full `bun run test` batched runner currently hangs in an **unrelated** `packages/cli` batch (leftover dev server on :3001/:3002 + proxy) — not this diff. CI clean-install is authoritative.

Related: #566, #587, #590, #591
