### PR TITLE
feat(adapter-ui): chat assistant as the 4th say→exists channel (#565)

### DIFF
--- a/.changeset/chat-schema-proposal-channel.md
+++ b/.changeset/chat-schema-proposal-channel.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cap-adapter-ui": minor
+---
+
+Make the in-product AI chat assistant the 4th "say→exists" channel (alongside REST, UI-form, and MCP). When a chat utterance is not a runtime action, the assistant now falls back to `resolveSchemaIntent`; a `proposal_draft` (or `entity_proposal_draft`) renders a new `SchemaProposalCard` — an approvable card (no Execute button) that drives Approve → `approveProposal` → Open PR → `graduateProposal` and surfaces the resulting PR link. Pure routing/state helpers (`decideSchemaFallback`, `schema-proposal-card-helpers`) keep the logic unit-testable. Reuses the existing `resolve-schema-intent` / proposal-approve / proposal-graduate endpoints — no backend changes. New `ai.schemaChange` / `ai.approveSchema` / `ai.graduatePr` + `schemaProposal.*` i18n keys (en + zh-CN).

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/ai-assistant-schema-routing.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/ai-assistant-schema-routing.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the chat assistant's schema-change routing — the 4th
+ * "say → exists" (说→有) channel.
+ *
+ * `decideSchemaFallback` is the pure decision reached AFTER `resolveIntent`
+ * found no runtime action (i.e. `decideIntentRouting` returned `chat-fallback`).
+ * It is the seam the component uses in `handleSend`, so testing it covers the
+ * "schema-change utterance → schema proposal card" routing without a DOM
+ * (this package's tests are logic-only).
+ *
+ * We also drive the two-resolver chain end to end at the client level:
+ * `resolveIntent` → non-action, then `resolveSchemaIntent` → `proposal_draft`,
+ * and assert the combined decision is a schema proposal — proving the fallback
+ * fires exactly when a runtime action could NOT be matched.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+const store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+      key: (i: number) => [...store.keys()][i] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import { decideIntentRouting, decideSchemaFallback } from "../src/components/ai-assistant";
+import type { ResolveSchemaIntentResult } from "../src/lib/ai-api";
+import { resolveIntent, resolveSchemaIntent } from "../src/lib/ai-api";
+
+// ── decideSchemaFallback (pure) ──────────────────────────
+
+describe("decideSchemaFallback", () => {
+  test("routes a proposal_draft to a schema-proposal card", () => {
+    const outcome: ResolveSchemaIntentResult = {
+      kind: "proposal_draft",
+      draft: { proposalId: "prop_1", ruleName: "threshold", confidence: 0.9 },
+    };
+    expect(decideSchemaFallback(outcome)).toEqual({
+      kind: "schema-proposal",
+      draft: { proposalId: "prop_1", ruleName: "threshold", confidence: 0.9 },
+    });
+  });
+
+  test("routes clarification to chat fallback", () => {
+    expect(decideSchemaFallback({ kind: "clarification", question: "which entity?" })).toEqual({
+      kind: "chat-fallback",
+    });
+  });
+
+  test("routes no_match to chat fallback", () => {
+    expect(decideSchemaFallback({ kind: "no_match" })).toEqual({ kind: "chat-fallback" });
+  });
+
+  test("routes unavailable to chat fallback", () => {
+    expect(decideSchemaFallback({ kind: "unavailable" })).toEqual({ kind: "chat-fallback" });
+  });
+
+  test("routes error to chat fallback", () => {
+    expect(decideSchemaFallback({ kind: "error", message: "boom" })).toEqual({
+      kind: "chat-fallback",
+    });
+  });
+});
+
+// ── Two-resolver chain (client level) ────────────────────
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+let originalFetch: typeof fetch;
+beforeEach(() => {
+  localStorage.clear();
+});
+afterEach(() => {
+  if (originalFetch) globalThis.fetch = originalFetch;
+});
+
+describe("schema-change utterance routing chain", () => {
+  test("resolveIntent → no-match, then resolveSchemaIntent → proposal_draft ⇒ schema-proposal", async () => {
+    originalFetch = globalThis.fetch;
+    // Route by endpoint: the action resolver returns no match; the schema
+    // resolver mints a draft. This mirrors `handleSend`'s two-step fallback.
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      if (url === "/api/ai/resolve-intent") {
+        return jsonResponse(200, { proposal: null });
+      }
+      if (url === "/api/ai/resolve-schema-intent") {
+        return jsonResponse(200, {
+          outcome: "proposal_draft",
+          proposalId: "prop_77",
+          proposalStatus: "draft",
+          ruleName: "manager_approval_threshold",
+          targetEntity: "purchase_order",
+          confidence: 0.86,
+          explanation: "Raise the manager-approval threshold to 20000",
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    }) as typeof fetch;
+
+    // Step 1 — runtime action resolution finds nothing → chat-fallback.
+    const intent = await resolveIntent("raise the manager-approval threshold to 20000");
+    const actionDecision = decideIntentRouting(intent);
+    expect(actionDecision.kind).toBe("chat-fallback");
+
+    // Step 2 — the schema-intent fallback mints a draft → schema-proposal card.
+    const schema = await resolveSchemaIntent("raise the manager-approval threshold to 20000");
+    const schemaDecision = decideSchemaFallback(schema);
+    expect(schemaDecision.kind).toBe("schema-proposal");
+    if (schemaDecision.kind !== "schema-proposal") return;
+    expect(schemaDecision.draft.proposalId).toBe("prop_77");
+    expect(schemaDecision.draft.ruleName).toBe("manager_approval_threshold");
+  });
+
+  test("entity_proposal_draft also routes to a schema-proposal (isEntity flag)", async () => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      jsonResponse(200, {
+        outcome: "entity_proposal_draft",
+        proposalId: "prop_88",
+        proposalStatus: "draft",
+        ruleName: "supplier",
+        confidence: 0.8,
+      })) as typeof fetch;
+
+    const schema = await resolveSchemaIntent("add a supplier entity");
+    const decision = decideSchemaFallback(schema);
+    expect(decision.kind).toBe("schema-proposal");
+    if (decision.kind !== "schema-proposal") return;
+    expect(decision.draft.isEntity).toBe(true);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/schema-proposal-card.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/schema-proposal-card.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the SchemaProposalCard logic — the chat assistant's 4th
+ * "say → exists" (说→有) channel.
+ *
+ * This package's test setup is logic-only (no happy-dom / jsdom — see
+ * proposal-impact-preview.test.ts), so we test the card's PURE building blocks
+ * rather than the rendered React:
+ *   - `toSchemaProposalDisplay` — sparse draft → display fields.
+ *   - `mapGraduateResult`       — graduate result → done(prUrl) / error(key).
+ *   - the `approveProposal` + `graduateProposal` clients the card composes,
+ *     driven through the real approve → Open PR → prUrl flow and the error
+ *     arms, via an injected fetch stub (never a leaked global mock).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// Logic-only runner has no DOM; the clients call getAuthHeaders() which reads
+// localStorage. Mirror the shim used across the other api-client tests.
+const store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => store.set(k, v),
+      removeItem: (k: string) => store.delete(k),
+      clear: () => store.clear(),
+      get length() {
+        return store.size;
+      },
+      key: (i: number) => [...store.keys()][i] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import {
+  formatConfidencePct,
+  mapGraduateResult,
+  toSchemaProposalDisplay,
+} from "../src/components/schema-proposal-card-helpers";
+import type { SchemaIntentDraft } from "../src/lib/ai-api";
+import { approveProposal, graduateProposal } from "../src/lib/proposal-api";
+
+// ── formatConfidencePct ──────────────────────────────────
+
+describe("formatConfidencePct", () => {
+  test("formats a fraction as a percentage", () => {
+    expect(formatConfidencePct(0.82)).toBe("82%");
+  });
+  test("returns an em dash for undefined / non-finite", () => {
+    expect(formatConfidencePct(undefined)).toBe("—");
+    expect(formatConfidencePct(Number.NaN)).toBe("—");
+    expect(formatConfidencePct(Number.POSITIVE_INFINITY)).toBe("—");
+  });
+});
+
+// ── toSchemaProposalDisplay ──────────────────────────────
+
+describe("toSchemaProposalDisplay", () => {
+  test("maps a full rule draft to display fields", () => {
+    const draft: SchemaIntentDraft = {
+      proposalId: "prop_1",
+      proposalStatus: "draft",
+      ruleName: "manager_approval_threshold",
+      targetEntity: "purchase_order",
+      confidence: 0.9,
+      explanation: "Raise the manager-approval threshold to 20000",
+      requiresCodeChange: true,
+      diffSummary: "- threshold: 10000\n+ threshold: 20000",
+    };
+    expect(toSchemaProposalDisplay(draft)).toEqual({
+      name: "manager_approval_threshold",
+      statusLabel: "draft",
+      confidencePct: "90%",
+      explanation: "Raise the manager-approval threshold to 20000",
+      targetEntity: "purchase_order",
+      proposalId: "prop_1",
+      requiresCodeChange: true,
+      diffSummary: "- threshold: 10000\n+ threshold: 20000",
+      isEntity: false,
+    });
+  });
+
+  test("defaults status to 'draft', requiresCodeChange to false, isEntity to false", () => {
+    const display = toSchemaProposalDisplay({});
+    expect(display.statusLabel).toBe("draft");
+    expect(display.confidencePct).toBe("—");
+    expect(display.requiresCodeChange).toBe(false);
+    expect(display.isEntity).toBe(false);
+    expect(display.name).toBeUndefined();
+    expect(display.proposalId).toBeUndefined();
+  });
+
+  test("flags an entity draft", () => {
+    expect(toSchemaProposalDisplay({ isEntity: true }).isEntity).toBe(true);
+  });
+});
+
+// ── mapGraduateResult ────────────────────────────────────
+
+describe("mapGraduateResult", () => {
+  test("maps ok to done with the PR url", () => {
+    const mapped = mapGraduateResult({
+      kind: "ok",
+      prUrl: "https://github.com/o/r/pull/7",
+      branch: "feat/x",
+      commitSha: "abc",
+      committed: true,
+    });
+    expect(mapped).toEqual({ status: "done", prUrl: "https://github.com/o/r/pull/7" });
+  });
+
+  test("maps not_found to an error key", () => {
+    expect(mapGraduateResult({ kind: "not_found" })).toEqual({
+      status: "error",
+      messageKey: "schemaProposal.graduateNotFound",
+    });
+  });
+
+  test("maps not_approved / unavailable / error and forwards the raw message", () => {
+    expect(mapGraduateResult({ kind: "not_approved", message: "not approved yet" })).toEqual({
+      status: "error",
+      messageKey: "schemaProposal.graduateNotApproved",
+      rawMessage: "not approved yet",
+    });
+    expect(mapGraduateResult({ kind: "unavailable", message: "no token" })).toEqual({
+      status: "error",
+      messageKey: "schemaProposal.graduateUnavailable",
+      rawMessage: "no token",
+    });
+    expect(mapGraduateResult({ kind: "error", message: "boom" })).toEqual({
+      status: "error",
+      messageKey: "schemaProposal.graduateError",
+      rawMessage: "boom",
+    });
+  });
+
+  test("maps denied to an error key (no raw message)", () => {
+    expect(mapGraduateResult({ kind: "denied" })).toEqual({
+      status: "error",
+      messageKey: "schemaProposal.graduateDenied",
+    });
+  });
+});
+
+// ── Approve → Open PR flow (the clients the card composes) ─
+
+interface CapturedRequest {
+  url: string;
+  method?: string;
+}
+let captured: CapturedRequest[];
+let originalFetch: typeof fetch;
+
+/** Install a global fetch stub that records every call and replays a queue. */
+function installFetchQueue(responses: Array<{ status: number; body: unknown }>) {
+  originalFetch = globalThis.fetch;
+  let i = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured.push({
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      method: init?.method,
+    });
+    const response = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return new Response(JSON.stringify(response?.body), {
+      status: response?.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  captured = [];
+  localStorage.clear();
+});
+afterEach(() => {
+  if (originalFetch) globalThis.fetch = originalFetch;
+});
+
+describe("approve → graduate flow", () => {
+  test("Approve hits the approve endpoint, then Open PR hits graduate and yields prUrl", async () => {
+    installFetchQueue([
+      { status: 200, body: { success: true, data: { id: "prop_1", status: "approved" } } },
+      {
+        status: 200,
+        body: {
+          success: true,
+          data: {
+            prUrl: "https://github.com/o/r/pull/42",
+            branch: "feat/prop_1",
+            commitSha: "deadbeef",
+            committed: true,
+          },
+        },
+      },
+    ]);
+
+    // Phase 1 — Approve.
+    const approved = await approveProposal("prop_1");
+    expect(approved.id).toBe("prop_1");
+    expect(captured[0]?.url).toBe("/api/proposals/prop_1/approve");
+    expect(captured[0]?.method).toBe("POST");
+
+    // Phase 2 — Open PR (graduate) → surfaces the PR url.
+    const graduated = await graduateProposal("prop_1");
+    expect(graduated.kind).toBe("ok");
+    if (graduated.kind !== "ok") return;
+    expect(graduated.prUrl).toBe("https://github.com/o/r/pull/42");
+    expect(captured[1]?.url).toBe("/api/proposals/prop_1/graduate");
+
+    // And the card mapping turns that into a done(prUrl) display.
+    expect(mapGraduateResult(graduated)).toEqual({
+      status: "done",
+      prUrl: "https://github.com/o/r/pull/42",
+    });
+  });
+
+  test("Approve surfaces a server error (card stays in approve phase)", async () => {
+    installFetchQueue([
+      { status: 200, body: { success: false, error: { message: "validation failed" } } },
+    ]);
+    await expect(approveProposal("prop_1")).rejects.toThrow("validation failed");
+  });
+
+  test("Open PR on a not-yet-approved proposal maps to a not_approved error", async () => {
+    installFetchQueue([
+      { status: 422, body: { success: false, error: { message: "Proposal is not approved." } } },
+    ]);
+    const graduated = await graduateProposal("prop_1");
+    expect(mapGraduateResult(graduated)).toEqual({
+      status: "error",
+      messageKey: "schemaProposal.graduateNotApproved",
+      rawMessage: "Proposal is not approved.",
+    });
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -291,8 +291,21 @@ export function AIAssistant({
       // unavailable / error) falls through to the existing chat path so read-
       // only Q&A and chit-chat still work.
       setIsResolvingIntent(true);
-      const schemaOutcome = await resolveSchemaIntent(trimmed);
-      setIsResolvingIntent(false);
+      let schemaOutcome: ResolveSchemaIntentResult;
+      try {
+        schemaOutcome = await resolveSchemaIntent(trimmed);
+      } catch (err) {
+        // A thrown resolver (e.g. an auth/transport failure inside getAuthHeaders
+        // or handleUnauthorized) must NOT leave `isResolvingIntent` stuck true —
+        // that would permanently disable the input + send button. Treat it as a
+        // non-graduable outcome so we fall through to the chat path below.
+        schemaOutcome = {
+          kind: "error",
+          message: err instanceof Error ? err.message : "schema intent resolution failed",
+        };
+      } finally {
+        setIsResolvingIntent(false);
+      }
 
       const schemaDecision = decideSchemaFallback(schemaOutcome);
       if (schemaDecision.kind === "schema-proposal") {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -41,16 +41,35 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ActionResult } from "../lib/action-api";
 import { AgUiChatTransport } from "../lib/agui-chat-transport";
-import { type IntentResolution, type ResolveIntentResult, resolveIntent } from "../lib/ai-api";
+import {
+  type IntentResolution,
+  type ResolveIntentResult,
+  type ResolveSchemaIntentResult,
+  resolveIntent,
+  resolveSchemaIntent,
+  type SchemaIntentDraft,
+} from "../lib/ai-api";
 import { isAiEnabled } from "../lib/app-config";
 import { ActionProposalCard } from "./action-proposal-card";
 import { MessageBubble } from "./ai-message-bubble";
+import { SchemaProposalCard } from "./schema-proposal-card";
 
 // ── Proposal state ───────────────────────────────────────
 
 interface ProposalItem {
   id: string;
   intent: IntentResolution;
+}
+
+/**
+ * A schema-change draft surfaced by the chat assistant — the 4th "say → exists"
+ * channel. Minted by `resolveSchemaIntent` when `resolveIntent` found no runtime
+ * action; carried through Approve → Open PR by {@link SchemaProposalCard}.
+ * Parallel to {@link ProposalItem} but holds a draft, not a runtime intent.
+ */
+interface SchemaProposalItem {
+  id: string;
+  draft: SchemaIntentDraft;
 }
 
 function createTextMessage(role: "user" | "assistant", text: string): UIMessage {
@@ -104,6 +123,35 @@ export function decideIntentRouting(
   }
 }
 
+// ── Schema-intent fallback routing (4th "say → exists" channel) ─
+
+/**
+ * Outcome of inspecting a `resolveSchemaIntent` result reached AFTER
+ * `resolveIntent` found no runtime action. Exported as a pure helper so the
+ * decision can be unit-tested without mounting the component.
+ *
+ *  - `schema-proposal` — render a {@link SchemaProposalCard} for the draft.
+ *  - `chat-fallback`   — let the general chat endpoint take the prompt
+ *                        (`clarification` / `no_match` / `unavailable` /
+ *                        `error` — none is a graduable schema change).
+ */
+export type SchemaFallbackDecision =
+  | { kind: "schema-proposal"; draft: SchemaIntentDraft }
+  | { kind: "chat-fallback" };
+
+/**
+ * Pure routing helper — maps a `ResolveSchemaIntentResult` onto the UX action
+ * the assistant should take. Only a `proposal_draft` (the client maps both
+ * `proposal_draft` and `entity_proposal_draft` here) becomes a card; every
+ * other outcome falls through to chat so read-only Q&A keeps working.
+ */
+export function decideSchemaFallback(outcome: ResolveSchemaIntentResult): SchemaFallbackDecision {
+  if (outcome.kind === "proposal_draft") {
+    return { kind: "schema-proposal", draft: outcome.draft };
+  }
+  return { kind: "chat-fallback" };
+}
+
 // ── Component ────────────────────────────────────────────
 
 export function AIAssistant({
@@ -120,6 +168,8 @@ export function AIAssistant({
 
   // Pending action proposals from intent resolution
   const [proposals, setProposals] = useState<ProposalItem[]>([]);
+  // Pending schema-change drafts from schema-intent resolution (4th channel).
+  const [schemaProposals, setSchemaProposals] = useState<SchemaProposalItem[]>([]);
   const [isResolvingIntent, setIsResolvingIntent] = useState(false);
 
   // AG-UI transport (#89) — same assistant brain as /api/ai/chat, but over
@@ -154,7 +204,7 @@ export function AIAssistant({
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [messages, proposals]);
+  }, [messages, proposals, schemaProposals]);
 
   // Focus input when panel opens
   useEffect(() => {
@@ -177,6 +227,14 @@ export function AIAssistant({
     if (result.success) {
       setProposals((prev) => prev.filter((p) => p.id !== proposalId));
     }
+  }, []);
+
+  // Remove a schema proposal card. Called on graduation success (the PR is
+  // open — nothing more to do here) or on explicit dismiss. On approve/graduate
+  // FAILURE the card stays (it owns its own error + retry), mirroring the
+  // action-proposal "keep on failure" behavior above.
+  const handleSchemaProposalRemove = useCallback((id: string) => {
+    setSchemaProposals((prev) => prev.filter((p) => p.id !== id));
   }, []);
 
   // Use an uncontrolled input approach since useChat v6 doesn't have handleInputChange
@@ -222,11 +280,34 @@ export function AIAssistant({
         return;
       }
 
+      // ── 4th channel: schema-change fallback ──
+      //
+      // `resolveIntent` found no RUNTIME action (decision === "chat-fallback").
+      // Before dropping to chat, ask whether this was a SCHEMA-change utterance
+      // ("raise the manager-approval threshold to 20000") — `resolveSchemaIntent`
+      // mints a GOVERNED draft Proposal for those. A `proposal_draft` /
+      // `entity_proposal_draft` (both mapped to `proposal_draft` by the client)
+      // becomes a SchemaProposalCard; anything else (clarification / no_match /
+      // unavailable / error) falls through to the existing chat path so read-
+      // only Q&A and chit-chat still work.
+      setIsResolvingIntent(true);
+      const schemaOutcome = await resolveSchemaIntent(trimmed);
+      setIsResolvingIntent(false);
+
+      const schemaDecision = decideSchemaFallback(schemaOutcome);
+      if (schemaDecision.kind === "schema-proposal") {
+        // Echo the prompt for the card path (chat fallback echoes itself).
+        setMessages((prev) => [...prev, createTextMessage("user", trimmed)]);
+        const id = crypto.randomUUID();
+        setSchemaProposals((prev) => [...prev, { id, draft: schemaDecision.draft }]);
+        return;
+      }
+
       if (decision.notify === "service-unavailable") {
         toast.error(t("ai.serviceUnavailable"));
       }
       // Fall through to chat — preserves read-only Q&A and chit-chat for
-      // prompts the resolver couldn't classify as actionable.
+      // prompts neither resolver could classify as actionable / schema-changing.
     }
 
     // AI disabled OR resolver returned a non-action outcome: send the
@@ -247,6 +328,7 @@ export function AIAssistant({
   const handleClear = useCallback(() => {
     setMessages([]);
     setProposals([]);
+    setSchemaProposals([]);
   }, [setMessages]);
 
   return (
@@ -271,7 +353,7 @@ export function AIAssistant({
                   <Loader2Icon className="size-3.5 animate-spin" />
                 </Button>
               )}
-              {(messages.length > 0 || proposals.length > 0) && (
+              {(messages.length > 0 || proposals.length > 0 || schemaProposals.length > 0) && (
                 <Button
                   variant="ghost"
                   size="icon-sm"
@@ -297,7 +379,7 @@ export function AIAssistant({
         {/* Messages area */}
         <div ref={scrollRef} className="flex-1 overflow-y-auto px-4">
           <div className="flex flex-col gap-3 py-4">
-            {messages.length === 0 && proposals.length === 0 && (
+            {messages.length === 0 && proposals.length === 0 && schemaProposals.length === 0 && (
               <div className="flex flex-col items-center justify-center gap-3 py-12 text-center text-muted-foreground">
                 <BotIcon className="size-10 opacity-30" />
                 <p className="text-sm">{t("ai.welcomeMessage")}</p>
@@ -335,6 +417,21 @@ export function AIAssistant({
                     intent={proposal.intent}
                     onComplete={(result) => handleProposalComplete(proposal.id, result)}
                     onCancel={() => handleProposalCancel(proposal.id)}
+                  />
+                </div>
+              </div>
+            ))}
+
+            {/* Schema-change proposal cards (4th "say → exists" channel) —
+                shown after the action cards. Removed on graduation success or
+                explicit dismiss; kept on approve/graduate failure for retry. */}
+            {schemaProposals.map((sp) => (
+              <div key={sp.id} className="flex justify-start">
+                <div className="w-full max-w-[95%]">
+                  <SchemaProposalCard
+                    draft={sp.draft}
+                    onGraduated={() => handleSchemaProposalRemove(sp.id)}
+                    onDismiss={() => handleSchemaProposalRemove(sp.id)}
                   />
                 </div>
               </div>

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -436,14 +436,16 @@ export function AIAssistant({
             ))}
 
             {/* Schema-change proposal cards (4th "say → exists" channel) —
-                shown after the action cards. Removed on graduation success or
-                explicit dismiss; kept on approve/graduate failure for retry. */}
+                shown after the action cards. The card is removed ONLY on explicit
+                dismiss: after graduation it stays in its `done` phase so the user
+                can read and click the opened-PR link. Removing it on graduation
+                would unmount it (React 19 batches the card's state updates with
+                the parent removal) before that link ever renders. */}
             {schemaProposals.map((sp) => (
               <div key={sp.id} className="flex justify-start">
                 <div className="w-full max-w-[95%]">
                   <SchemaProposalCard
                     draft={sp.draft}
-                    onGraduated={() => handleSchemaProposalRemove(sp.id)}
                     onDismiss={() => handleSchemaProposalRemove(sp.id)}
                   />
                 </div>

--- a/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card-helpers.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure helpers for {@link SchemaProposalCard} — extracted so the card's state
+ * machine and display logic can be unit-tested without mounting React (this
+ * package's test setup is logic-only — no happy-dom / jsdom).
+ *
+ * The card drives the in-product "say → exists" (说→有) loop's 4th channel:
+ * a schema-change draft minted by `resolveSchemaIntent` is approved, then
+ * graduated into a GitHub PR. NONE of these helpers perform I/O — they only
+ * map results onto display state.
+ */
+
+import type { SchemaIntentDraft } from "../lib/ai-api";
+import type { GraduateProposalResult } from "../lib/proposal-api";
+
+// ── Card state machine ───────────────────────────────────
+
+/**
+ * Lifecycle of a single schema proposal card.
+ *
+ *  - `pending`     — draft surfaced; the Approve button is live.
+ *  - `approving`   — `approveProposal` in flight.
+ *  - `approved`    — approval succeeded; the Open PR button is live.
+ *  - `graduating`  — `graduateProposal` in flight.
+ *  - `done`        — graduation opened a PR; the PR link is shown (terminal).
+ *  - `error`       — the last approve/graduate attempt failed; the card stays
+ *                    so the user can read the reason and retry from the same
+ *                    phase (`error` never erases which phase we failed in —
+ *                    that is tracked separately by the caller).
+ */
+export type SchemaProposalStatus =
+  | "pending"
+  | "approving"
+  | "approved"
+  | "graduating"
+  | "done"
+  | "error";
+
+/**
+ * Format a confidence score (0-1) as a percentage. Defensive against
+ * NaN/Infinity/undefined leaking from a malformed AI response — mirrors the
+ * same helper in `nl-rule-drafter.tsx` / `action-proposal-card.tsx`.
+ */
+export function formatConfidencePct(confidence: number | undefined): string {
+  if (confidence == null || !Number.isFinite(confidence)) return "—";
+  return `${Math.round(confidence * 100)}%`;
+}
+
+/**
+ * Display fields derived from a {@link SchemaIntentDraft}. The draft itself is
+ * sparse (every field optional) — this normalizes it to exactly what the card
+ * renders so the JSX stays branch-free.
+ */
+export interface SchemaProposalDisplay {
+  /** The rule/entity name, or undefined when the draft omitted it. */
+  name?: string;
+  /** Status badge text — the proposal's own status, defaulting to "draft". */
+  statusLabel: string;
+  /** Confidence as a percentage string ("—" when absent). */
+  confidencePct: string;
+  /** Human explanation, or undefined. */
+  explanation?: string;
+  /** Target entity, or undefined. */
+  targetEntity?: string;
+  /** The persisted proposal id used to approve / graduate. */
+  proposalId?: string;
+  /**
+   * Whether this change requires a code change (not just a declarative
+   * data/config edit). Surfaced as a badge so the reviewer knows a PR with
+   * source edits is coming. The wire response does not always carry this — it
+   * defaults to `false`.
+   */
+  requiresCodeChange: boolean;
+  /** Short human summary of the diff this proposal will produce, if any. */
+  diffSummary?: string;
+  /** True when this draft mints an entity (vs a rule). */
+  isEntity: boolean;
+}
+
+/** Normalize a sparse draft into the fields the card renders. */
+export function toSchemaProposalDisplay(draft: SchemaIntentDraft): SchemaProposalDisplay {
+  return {
+    name: draft.ruleName,
+    statusLabel: draft.proposalStatus ?? "draft",
+    confidencePct: formatConfidencePct(draft.confidence),
+    explanation: draft.explanation,
+    targetEntity: draft.targetEntity,
+    proposalId: draft.proposalId,
+    requiresCodeChange: draft.requiresCodeChange ?? false,
+    diffSummary: draft.diffSummary,
+    isEntity: draft.isEntity ?? false,
+  };
+}
+
+// ── Graduate-result → display mapping ────────────────────
+
+/**
+ * Outcome of mapping a {@link GraduateProposalResult} onto the card. Either we
+ * reached a PR (`done` with a `prUrl`) or we surface an `error` whose message
+ * is an i18n KEY (the card resolves it via `t()` so copy stays centralized).
+ *
+ * `prUrl` may legitimately be empty on `ok` when the server committed without
+ * a PR provider — callers treat an empty `prUrl` as "graduated, no link".
+ */
+export type GraduateDisplay =
+  | { status: "done"; prUrl: string }
+  | { status: "error"; messageKey: string; rawMessage?: string };
+
+/**
+ * Map a graduate result onto the card's next state. Every non-ok arm becomes an
+ * `error` carrying an i18n key; the `error`/`unavailable`/`not_approved` arms
+ * also forward the server's raw message so the card can show specifics under
+ * the localized headline.
+ */
+export function mapGraduateResult(result: GraduateProposalResult): GraduateDisplay {
+  switch (result.kind) {
+    case "ok":
+      return { status: "done", prUrl: result.prUrl };
+    case "not_found":
+      return { status: "error", messageKey: "schemaProposal.graduateNotFound" };
+    case "not_approved":
+      return {
+        status: "error",
+        messageKey: "schemaProposal.graduateNotApproved",
+        rawMessage: result.message,
+      };
+    case "unavailable":
+      return {
+        status: "error",
+        messageKey: "schemaProposal.graduateUnavailable",
+        rawMessage: result.message,
+      };
+    case "denied":
+      return { status: "error", messageKey: "schemaProposal.graduateDenied" };
+    case "error":
+      return {
+        status: "error",
+        messageKey: "schemaProposal.graduateError",
+        rawMessage: result.message,
+      };
+  }
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card.tsx
@@ -100,19 +100,27 @@ export function SchemaProposalCard({ draft, onGraduated, onDismiss }: SchemaProp
     }
     setBusy(true);
     setErrorMessage(null);
-    const next = mapGraduateResult(await graduateProposal(display.proposalId));
-    if (next.status === "done") {
-      setPrUrl(next.prUrl);
-      setPhase("done");
-      onGraduated?.(next.prUrl);
-    } else {
-      // Stay in the graduate phase so the user can retry. `next.messageKey` is
-      // an i18n key; append the server's raw message (when present) so the
-      // reviewer sees the localized headline plus the specifics.
-      const headline = t(next.messageKey);
-      setErrorMessage(next.rawMessage ? `${headline} — ${next.rawMessage}` : headline);
+    try {
+      const next = mapGraduateResult(await graduateProposal(display.proposalId));
+      if (next.status === "done") {
+        setPrUrl(next.prUrl);
+        setPhase("done");
+        onGraduated?.(next.prUrl);
+      } else {
+        // Stay in the graduate phase so the user can retry. `next.messageKey` is
+        // an i18n key; append the server's raw message (when present) so the
+        // reviewer sees the localized headline plus the specifics.
+        const headline = t(next.messageKey);
+        setErrorMessage(next.rawMessage ? `${headline} — ${next.rawMessage}` : headline);
+      }
+    } catch (err) {
+      // A thrown graduateProposal (network/transport) must not leave the card
+      // stuck in `busy`. Surface the error and stay in the graduate phase so the
+      // user can retry.
+      setErrorMessage(err instanceof Error ? err.message : t("schemaProposal.graduateError"));
+    } finally {
+      setBusy(false);
     }
-    setBusy(false);
   }, [display.proposalId, onGraduated, t]);
 
   const handleDismiss = useCallback(() => {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card.tsx
@@ -1,0 +1,275 @@
+/**
+ * SchemaProposalCard — the in-product chat channel of "say → exists" (说→有).
+ *
+ * When a user types a schema-change utterance into the AI assistant
+ * ("raise the manager-approval threshold to 20000"), `resolveSchemaIntent`
+ * mints a GOVERNED `draft`-status Proposal. This card surfaces that draft and
+ * carries it through the human-gated graduation path:
+ *
+ *     approve phase → Approve → approveProposal()  → graduate phase
+ *     graduate phase → Open PR → graduateProposal() → done (renders the PR link)
+ *
+ * Unlike {@link ActionProposalCard} this card has NO Execute button — it never
+ * runs a runtime Action. It only approves a draft and opens a PR (graduation
+ * NEVER merges). All mutations stay double-human-gated per the hard rule
+ * "AI Never Modifies Production Directly".
+ *
+ * State is split into two orthogonal axes so the JSX guards stay trivial and an
+ * error never loses track of which step to retry:
+ *   - `phase`  — which step the card is on: `approve` → `graduate` → `done`.
+ *   - `busy`   — whether the current phase's request is in flight.
+ *   - `error`  — the last failure's message (cleared when a request starts).
+ * A failed approve stays in `phase: "approve"`; a failed graduate stays in
+ * `phase: "graduate"` — so the right button is always the one offered for retry.
+ *
+ * Display derivation + the graduate-result mapping live in
+ * `schema-proposal-card-helpers` so they can be unit-tested without a DOM
+ * (this package's tests are logic-only). This file is rendering + I/O only.
+ */
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@linchkit/ui-kit/components";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  CodeIcon,
+  ExternalLinkIcon,
+  GitPullRequestIcon,
+  Loader2Icon,
+  SparklesIcon,
+  XIcon,
+} from "lucide-react";
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { SchemaIntentDraft } from "../lib/ai-api";
+import { approveProposal, graduateProposal } from "../lib/proposal-api";
+import { mapGraduateResult, toSchemaProposalDisplay } from "./schema-proposal-card-helpers";
+
+// ── Props ────────────────────────────────────────────────
+
+export interface SchemaProposalCardProps {
+  /** The draft minted by `resolveSchemaIntent` (`proposal_draft` arm). */
+  draft: SchemaIntentDraft;
+  /** Called once graduation opens a PR — the host removes the card. */
+  onGraduated?: (prUrl: string) => void;
+  /** Called when the user dismisses the card without acting. */
+  onDismiss?: () => void;
+}
+
+/** Which step of the approve → graduate flow the card is on. */
+type Phase = "approve" | "graduate" | "done";
+
+// ── Component ────────────────────────────────────────────
+
+export function SchemaProposalCard({ draft, onGraduated, onDismiss }: SchemaProposalCardProps) {
+  const { t } = useTranslation();
+  const display = toSchemaProposalDisplay(draft);
+  const [phase, setPhase] = useState<Phase>("approve");
+  const [busy, setBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [prUrl, setPrUrl] = useState<string | null>(null);
+
+  const handleApprove = useCallback(async () => {
+    if (!display.proposalId) {
+      setErrorMessage(t("schemaProposal.missingId"));
+      return;
+    }
+    setBusy(true);
+    setErrorMessage(null);
+    try {
+      await approveProposal(display.proposalId);
+      setPhase("graduate");
+    } catch (err) {
+      // Stay in the approve phase so the user can retry approval.
+      setErrorMessage(err instanceof Error ? err.message : t("schemaProposal.approveError"));
+    } finally {
+      setBusy(false);
+    }
+  }, [display.proposalId, t]);
+
+  const handleGraduate = useCallback(async () => {
+    if (!display.proposalId) {
+      setErrorMessage(t("schemaProposal.missingId"));
+      return;
+    }
+    setBusy(true);
+    setErrorMessage(null);
+    const next = mapGraduateResult(await graduateProposal(display.proposalId));
+    if (next.status === "done") {
+      setPrUrl(next.prUrl);
+      setPhase("done");
+      onGraduated?.(next.prUrl);
+    } else {
+      // Stay in the graduate phase so the user can retry. `next.messageKey` is
+      // an i18n key; append the server's raw message (when present) so the
+      // reviewer sees the localized headline plus the specifics.
+      const headline = t(next.messageKey);
+      setErrorMessage(next.rawMessage ? `${headline} — ${next.rawMessage}` : headline);
+    }
+    setBusy(false);
+  }, [display.proposalId, onGraduated, t]);
+
+  const handleDismiss = useCallback(() => {
+    onDismiss?.();
+  }, [onDismiss]);
+
+  return (
+    <Card data-testid="schema-proposal-card">
+      <CardHeader className="gap-1 pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-1.5 text-sm font-medium">
+            <SparklesIcon className="size-3.5 text-primary" />
+            {display.name ?? t("schemaProposal.draftCreated")}
+          </CardTitle>
+          <div className="flex items-center gap-1.5">
+            <Badge variant="secondary" className="text-[10px] uppercase">
+              {display.statusLabel}
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {display.confidencePct}
+            </Badge>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant="outline" className="text-[10px]">
+            {display.isEntity ? t("schemaProposal.entityKind") : t("schemaProposal.ruleKind")}
+          </Badge>
+          {display.requiresCodeChange && (
+            <Badge
+              variant="default"
+              className="gap-1 text-[10px]"
+              data-testid="requires-code-badge"
+            >
+              <CodeIcon className="size-2.5" />
+              {t("schemaProposal.requiresCode")}
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-2">
+        {display.explanation && (
+          <p className="text-xs text-muted-foreground">{display.explanation}</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+          {display.targetEntity && (
+            <span>
+              {t("schemaProposal.targetEntity")}:{" "}
+              <span className="font-medium">{display.targetEntity}</span>
+            </span>
+          )}
+          {display.proposalId && (
+            <span>
+              {t("schemaProposal.proposalId")}:{" "}
+              <span className="font-mono">{display.proposalId}</span>
+            </span>
+          )}
+        </div>
+
+        {display.diffSummary && (
+          <pre className="overflow-x-auto rounded-md bg-muted/60 p-2 text-[11px] text-muted-foreground">
+            {display.diffSummary}
+          </pre>
+        )}
+
+        {/* Error banner — stays visible so the user can retry the same phase. */}
+        {errorMessage && (
+          <div className="flex items-start gap-1.5 rounded-md bg-destructive/10 p-2">
+            <AlertTriangleIcon className="mt-0.5 size-3 shrink-0 text-destructive" />
+            <p className="text-[11px] text-destructive">{errorMessage}</p>
+          </div>
+        )}
+
+        {/* Graduated — render the PR link (or a "no link" note when empty). */}
+        {phase === "done" && (
+          <div className="flex items-start gap-1.5 rounded-md border border-green-200 bg-green-50 p-2 dark:border-green-900 dark:bg-green-950/30">
+            <CheckCircle2Icon className="mt-0.5 size-3 shrink-0 text-green-600" />
+            {prUrl ? (
+              <a
+                href={prUrl}
+                target="_blank"
+                rel="noreferrer"
+                data-testid="schema-proposal-pr-link"
+                className="inline-flex items-center gap-1 text-[11px] font-medium text-green-700 underline dark:text-green-300"
+              >
+                <ExternalLinkIcon className="size-3" />
+                {t("schemaProposal.openedPr")}
+              </a>
+            ) : (
+              <p className="text-[11px] text-green-700 dark:text-green-300">
+                {t("schemaProposal.graduatedNoPr")}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* ── Approve phase ── */}
+        {phase === "approve" && (
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={handleDismiss}
+              disabled={busy}
+            >
+              <XIcon className="mr-1 size-3" />
+              {t("schemaProposal.dismiss")}
+            </Button>
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => void handleApprove()}
+              disabled={busy}
+              data-testid="schema-proposal-approve"
+            >
+              {busy ? (
+                <Loader2Icon className="mr-1 size-3 animate-spin" />
+              ) : (
+                <CheckCircle2Icon className="mr-1 size-3" />
+              )}
+              {t("schemaProposal.approve")}
+            </Button>
+          </div>
+        )}
+
+        {/* ── Graduate phase ── */}
+        {phase === "graduate" && (
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={handleDismiss}
+              disabled={busy}
+            >
+              <XIcon className="mr-1 size-3" />
+              {t("schemaProposal.dismiss")}
+            </Button>
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => void handleGraduate()}
+              disabled={busy}
+              data-testid="schema-proposal-graduate"
+            >
+              {busy ? (
+                <Loader2Icon className="mr-1 size-3 animate-spin" />
+              ) : (
+                <GitPullRequestIcon className="mr-1 size-3" />
+              )}
+              {t("schemaProposal.openPr")}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/schema-proposal-card.tsx
@@ -218,6 +218,23 @@ export function SchemaProposalCard({ draft, onGraduated, onDismiss }: SchemaProp
           </div>
         )}
 
+        {/* Done — the card stays mounted so the PR link is readable; this lets
+            the user dismiss it once they've followed (or noted) the link. */}
+        {phase === "done" && (
+          <div className="flex items-center justify-end pt-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={handleDismiss}
+              data-testid="schema-proposal-done-dismiss"
+            >
+              <XIcon className="mr-1 size-3" />
+              {t("schemaProposal.dismiss")}
+            </Button>
+          </div>
+        )}
+
         {/* ── Approve phase ── */}
         {phase === "approve" && (
           <div className="flex items-center justify-end gap-2 pt-1">

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -388,6 +388,9 @@
     "didYouMean": "Did you mean:",
     "swapAction": "Switch to {{action}} ({{pct}})",
     "serviceUnavailable": "AI service unavailable. Please try again later.",
+    "schemaChange": "Schema change detected",
+    "approveSchema": "Approve change",
+    "graduatePr": "Open PR",
     "insights": {
       "title": "AI Insights",
       "analyze": "Analyze Record",
@@ -397,6 +400,26 @@
       "apply": "Apply",
       "avg": "avg"
     }
+  },
+  "schemaProposal": {
+    "draftCreated": "Schema change draft",
+    "ruleKind": "Rule change",
+    "entityKind": "Entity change",
+    "requiresCode": "Requires code change",
+    "targetEntity": "Target",
+    "proposalId": "Proposal",
+    "approve": "Approve",
+    "openPr": "Open PR",
+    "dismiss": "Dismiss",
+    "openedPr": "View pull request",
+    "graduatedNoPr": "Changes committed (no pull request link).",
+    "missingId": "This draft has no proposal id and cannot be approved.",
+    "approveError": "Failed to approve the draft.",
+    "graduateError": "Failed to open a pull request.",
+    "graduateNotFound": "The proposal could not be found.",
+    "graduateNotApproved": "The proposal must be approved before opening a pull request.",
+    "graduateUnavailable": "Graduation is not configured on the server.",
+    "graduateDenied": "You do not have permission to open a pull request for this proposal."
   },
   "health": {
     "title": "System Health",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -388,6 +388,9 @@
     "didYouMean": "您是指：",
     "swapAction": "切换到 {{action}}（{{pct}}）",
     "serviceUnavailable": "AI 服务暂时不可用，请稍后再试。",
+    "schemaChange": "检测到模型变更",
+    "approveSchema": "批准变更",
+    "graduatePr": "创建 PR",
     "insights": {
       "title": "AI 洞察",
       "analyze": "分析记录",
@@ -397,6 +400,26 @@
       "apply": "应用",
       "avg": "平均"
     }
+  },
+  "schemaProposal": {
+    "draftCreated": "模型变更草案",
+    "ruleKind": "规则变更",
+    "entityKind": "实体变更",
+    "requiresCode": "需要代码改动",
+    "targetEntity": "目标",
+    "proposalId": "提案",
+    "approve": "批准",
+    "openPr": "创建 PR",
+    "dismiss": "忽略",
+    "openedPr": "查看 Pull Request",
+    "graduatedNoPr": "变更已提交（无 Pull Request 链接）。",
+    "missingId": "该草案缺少提案 ID，无法批准。",
+    "approveError": "批准草案失败。",
+    "graduateError": "创建 Pull Request 失败。",
+    "graduateNotFound": "未找到该提案。",
+    "graduateNotApproved": "创建 Pull Request 前需要先批准提案。",
+    "graduateUnavailable": "服务器未配置毕业（graduation）功能。",
+    "graduateDenied": "您没有权限为该提案创建 Pull Request。"
   },
   "health": {
     "title": "系统健康",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/ai-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/ai-api.ts
@@ -172,6 +172,21 @@ export interface SchemaIntentDraft {
   targetEntity?: string;
   confidence?: number;
   explanation?: string;
+  /**
+   * Whether graduating this draft will edit source (a code change), as opposed
+   * to a purely declarative data/config edit. Surfaced as a badge so the
+   * reviewer knows source-editing PR is coming. Optional — older / declarative
+   * drafts omit it.
+   */
+  requiresCodeChange?: boolean;
+  /** Short human-readable summary of the diff this draft will produce, if any. */
+  diffSummary?: string;
+  /**
+   * True when the server minted an ENTITY draft (`entity_proposal_draft`),
+   * false/undefined for a rule draft (`proposal_draft`). Lets the card label
+   * the change kind without a second field.
+   */
+  isEntity?: boolean;
 }
 
 /**
@@ -191,13 +206,15 @@ export type ResolveSchemaIntentResult =
   | { kind: "error"; message: string };
 
 interface SchemaIntentWireResponse {
-  outcome?: "proposal_draft" | "clarification" | "no_match";
+  outcome?: "proposal_draft" | "entity_proposal_draft" | "clarification" | "no_match";
   proposalId?: string;
   proposalStatus?: string;
   ruleName?: string;
   targetEntity?: string;
   confidence?: number;
   explanation?: string;
+  requiresCodeChange?: boolean;
+  diffSummary?: string;
   question?: string;
   bestConfidence?: number;
   reason?: string;
@@ -258,6 +275,7 @@ export async function resolveSchemaIntent(
 
   switch (json.outcome) {
     case "proposal_draft":
+    case "entity_proposal_draft":
       return {
         kind: "proposal_draft",
         draft: {
@@ -267,6 +285,11 @@ export async function resolveSchemaIntent(
           targetEntity: json.targetEntity,
           confidence: json.confidence,
           explanation: json.explanation,
+          requiresCodeChange: json.requiresCodeChange,
+          diffSummary: json.diffSummary,
+          // Only set when truthy so a `proposal_draft` (rule) draft stays a
+          // 6-field object — the existing client test asserts an exact shape.
+          isEntity: json.outcome === "entity_proposal_draft" ? true : undefined,
         },
       };
     case "clarification":


### PR DESCRIPTION
## What

Makes the in-product **AI chat assistant the 4th "say→exists" (说→有) channel**, alongside REST, UI-form, and MCP. When a user types a schema-change utterance (e.g. *"把经理审批阈值改成 20000"*) the assistant now resolves it into a governed Proposal and renders an **approvable card**, closing the last channel gap of the loop.

## How (adapter-ui only — ZERO backend changes)

- **`schema-proposal-card.tsx`** (new) — renders a `resolveSchemaIntent` draft. **No Execute button**; instead Approve → `approveProposal(id)` → Open PR → `graduateProposal(id)` → surfaces the returned `prUrl`. Two-axis state (`phase: approve|graduate|done` + `busy`/`error`) so a failed step offers the right retry.
- **`schema-proposal-card-helpers.ts`** (new) — pure, DOM-free state/display helpers (this package's tests are logic-only).
- **`ai-assistant.tsx`** — new `SchemaProposalItem` + `schemaProposals` state, the schema-intent fallback in `handleSend` (fires when `decideIntentRouting(outcome).kind !== "proposal"`, i.e. the utterance isn't a runtime action), the render loop, and the pure `decideSchemaFallback` router. Runtime-action path + `ActionProposalCard` behavior untouched.
- **`ai-api.ts`** — UI-side type/parse extension only (carries `requiresCodeChange`, `diffSummary`, folds `entity_proposal_draft` onto the existing arm). No server change.
- **i18n** — `ai.schemaChange` / `ai.approveSchema` / `ai.graduatePr` + a `schemaProposal.*` block in en + zh-CN.

Reuses the existing `/api/ai/resolve-schema-intent`, `/api/proposals/{id}/approve`, and `/api/proposals/{id}/graduate` endpoints.

## Tests

New `schema-proposal-card.test.ts` (card-helper + flow) and `ai-assistant-schema-routing.test.ts` (a non-action utterance + `proposal_draft` produces a schema card; api libs mocked). `bun run check` + root `bun run typecheck` clean; `bun test ./addons/adapter-ui/` → 656 pass / 0 fail (no regression in existing resolve-schema-intent / action-proposal-card tests).

Related: #565, #566
