### PR TITLE
feat(adapter-server): inject patchNamedConstant — say→change-rule graduates to real source (#566 capstone)

### DIFF
--- a/.changeset/graduate-sourcepatch-injection.md
+++ b/.changeset/graduate-sourcepatch-injection.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/cap-adapter-server": patch
+---
+
+Make "say→change an existing code-condition rule's threshold" graduate to REAL source (#566 capstone). The proposal graduate API gains an injectable `sourcePatcher` option, and the server composition root wires in `patchNamedConstant` from `@linchkit/devtools` (the TS-AST patcher behind core's typescript-free `SourcePatcher` seam). An approved rule-update proposal carrying a `sourcePatch` now rewrites the named constant in the actual source file during graduation, then opens the usual human-reviewed PR — closing the natural-language → real-code arm across every channel. Adds `@linchkit/devtools` as a dependency.

--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-graduate-sourcepatch.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-graduate-sourcepatch.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Graduation source-patch wiring — the #566 capstone.
+ *
+ * Proves the WHOLE server-side chain for "say→change an existing code-condition
+ * rule's threshold": the graduate route, using its DEFAULT writer with the
+ * injected `sourcePatcher` (the real `patchNamedConstant` from
+ * `@linchkit/devtools`, the same one `server.ts` wires in), rewrites the named
+ * constant in a real source file when an approved proposal carries a
+ * `sourcePatch`. No `createWriter` override — that is the point: the default
+ * factory must thread the injected patcher through to `ProposalFileWriter`.
+ *
+ * The committer is the only stub (no real `git`/`gh`). The patch target is a
+ * temp file created UNDER the repo root so the writer's default repoRoot
+ * (`process.cwd()`) containment accepts it.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import type { CommandLayer, ProposalDefinition } from "@linchkit/core";
+import type { ProposalGitCommitResult } from "@linchkit/core/server";
+import { patchNamedConstant } from "@linchkit/devtools";
+import { Elysia } from "elysia";
+import {
+  type GraduationEngine,
+  type GraduationGitCommitter,
+  mountProposalGraduateAPI,
+} from "../src/proposal-graduate-api";
+
+const BASE = "http://local.test";
+const PASS_COMMAND_LAYER = { execute: async () => ({ success: true }) } as unknown as CommandLayer;
+
+let tempDir: string | null = null;
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+test("graduate patches the real source constant via the injected default sourcePatcher", async () => {
+  // A temp module UNDER the repo root so default repoRoot containment accepts it.
+  tempDir = mkdtempSync(join(process.cwd(), ".tmp-graduate-sp-"));
+  const absFile = join(tempDir, "threshold.ts");
+  writeFileSync(absFile, "/** demo */\nexport const MANAGER_APPROVAL_THRESHOLD = 10000;\n", "utf8");
+  const relFile = relative(process.cwd(), absFile);
+
+  const proposal = {
+    id: "prop-sp-1",
+    title: "Raise manager-approval threshold to 20000",
+    description: "say→change the existing code-condition rule's threshold",
+    author: { type: "ai", id: "schema-intent", name: "Schema Intent" },
+    capability: "cap-purchase-demo",
+    changeType: "minor",
+    changes: [
+      {
+        target: "rule",
+        operation: "update",
+        name: "manager_approval_threshold",
+        sourcePatch: {
+          filePath: relFile,
+          constantName: "MANAGER_APPROVAL_THRESHOLD",
+          newValueLiteral: "20000",
+        },
+      },
+    ],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: ["manager_approval_threshold"],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "approved",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as ProposalDefinition;
+
+  const engine: GraduationEngine = {
+    getProposal: (id) => {
+      if (id !== proposal.id) throw new Error("not found");
+      return proposal;
+    },
+    commitProposal: () => undefined,
+  };
+  const committerCalls: string[][] = [];
+  const committer: GraduationGitCommitter = {
+    async commitAndOpenPR(_p, files) {
+      committerCalls.push([...files]);
+      return {
+        branch: "proposal/sp-1",
+        prUrl: "https://github.com/acme/repo/pull/77",
+        commitSha: "f00dcafe",
+      } satisfies ProposalGitCommitResult;
+    },
+  };
+
+  const app = new Elysia();
+  // NOTE: no createWriter override — the DEFAULT writer must thread sourcePatcher.
+  mountProposalGraduateAPI(app, {
+    commandLayer: PASS_COMMAND_LAYER,
+    engine,
+    resolveConfig: () => ({ rootDir: process.cwd() }),
+    sourcePatcher: patchNamedConstant,
+    createCommitter: () => committer,
+  });
+
+  const res = await app.handle(
+    new Request(`${BASE}/api/proposals/${proposal.id}/graduate`, { method: "POST" }),
+  );
+  const json = (await res.json()) as { success: boolean; data?: { prUrl?: string } };
+
+  expect(res.status).toBe(200);
+  expect(json.success).toBe(true);
+  expect(json.data?.prUrl).toBe("https://github.com/acme/repo/pull/77");
+  // The committer was handed the patched file as a written path.
+  expect(committerCalls).toHaveLength(1);
+  expect(committerCalls[0]?.some((f) => f.endsWith("threshold.ts"))).toBe(true);
+
+  // The REAL source constant changed on disk — the whole say→code chain works.
+  const patched = readFileSync(absFile, "utf8");
+  expect(patched).toContain("export const MANAGER_APPROVAL_THRESHOLD = 20000;");
+  expect(patched).not.toContain("10000");
+  // Comments / surrounding source survive the splice.
+  expect(patched).toContain("/** demo */");
+});
+
+test("default writer ignores sourcePatcher when createWriter is overridden", async () => {
+  // Guard: an explicit createWriter fully controls the writer (the injected
+  // sourcePatcher must not leak into a test's custom writer).
+  const writerCalls: ProposalDefinition[] = [];
+  const app = new Elysia();
+  const proposal = {
+    id: "prop-sp-2",
+    status: "approved",
+    changes: [{ target: "rule", operation: "create", name: "x" }],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: [],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as ProposalDefinition;
+  mountProposalGraduateAPI(app, {
+    commandLayer: PASS_COMMAND_LAYER,
+    engine: { getProposal: () => proposal, commitProposal: () => undefined },
+    resolveConfig: () => ({ rootDir: process.cwd() }),
+    sourcePatcher: patchNamedConstant,
+    createWriter: () => ({
+      async writeApprovedProposal(p) {
+        writerCalls.push(p);
+        return ["/repo/x.rule.ts"];
+      },
+    }),
+    createCommitter: () => ({
+      async commitAndOpenPR() {
+        return { branch: "b", prUrl: "https://x/pr/1", commitSha: "abc" };
+      },
+    }),
+  });
+  const res = await app.handle(
+    new Request(`${BASE}/api/proposals/${proposal.id}/graduate`, { method: "POST" }),
+  );
+  expect(res.status).toBe(200);
+  expect(writerCalls).toHaveLength(1);
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/proposal-graduate-sourcepatch.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/proposal-graduate-sourcepatch.test.ts
@@ -108,9 +108,10 @@ test("graduate patches the real source constant via the injected default sourceP
   const res = await app.handle(
     new Request(`${BASE}/api/proposals/${proposal.id}/graduate`, { method: "POST" }),
   );
-  const json = (await res.json()) as { success: boolean; data?: { prUrl?: string } };
-
+  // Assert status BEFORE parsing the body: a non-JSON error body would otherwise
+  // throw a confusing SyntaxError that masks the real status-code mismatch.
   expect(res.status).toBe(200);
+  const json = (await res.json()) as { success: boolean; data?: { prUrl?: string } };
   expect(json.success).toBe(true);
   expect(json.data?.prUrl).toBe("https://github.com/acme/repo/pull/77");
   // The committer was handed the patched file as a written path.

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -29,7 +29,8 @@
     "@linchkit/cap-adapter-ag-ui": "workspace:*",
     "@linchkit/cap-ai-provider": "^2.0.0",
     "@linchkit/cap-dry-run": "^1.0.0",
-    "@linchkit/core": "^0.3.0"
+    "@linchkit/core": "^0.3.0",
+    "@linchkit/devtools": "^0.3.0"
   },
   "peerDependenciesMeta": {
     "@linchkit/cap-adapter-ag-ui": {
@@ -44,6 +45,7 @@
     "@linchkit/cap-dry-run": "workspace:*",
     "@linchkit/cap-permission": "workspace:*",
     "@linchkit/core": "workspace:*",
+    "@linchkit/devtools": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "typescript": "^6.0.2"
   },

--- a/addons/adapter-server/cap-adapter-server/src/proposal-graduate-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-graduate-api.ts
@@ -21,7 +21,7 @@
  * `proposal-api.ts`.
  */
 
-import type { Actor, CommandLayer, ProposalDefinition } from "@linchkit/core";
+import type { Actor, CommandLayer, ProposalDefinition, SourcePatcher } from "@linchkit/core";
 import {
   createProposalGitCommitter,
   ProposalFileWriter,
@@ -210,6 +210,14 @@ export interface MountProposalGraduateAPIOptions {
    */
   createWriter?: (config: GraduationConfig) => GraduationFileWriter;
   /**
+   * TS-AST source patcher injected into the DEFAULT writer so an approved
+   * code-condition rule update (a change carrying `sourcePatch`) rewrites the
+   * named constant in real source during graduation. Ignored when
+   * `createWriter` is overridden (tests then fully control the writer). The
+   * composition root supplies `patchNamedConstant` from `@linchkit/devtools`.
+   */
+  sourcePatcher?: SourcePatcher;
+  /**
    * Override how the committer is built from config (defaults to a real
    * `ProposalGitCommitter`). Exposed for tests so no real `git`/`gh` runs.
    */
@@ -245,7 +253,11 @@ export function mountProposalGraduateAPI(
       // the same Code Quality gate every other PR faces. Formatting failures are
       // swallowed by the writer (it falls back to un-formatted source), so this
       // can never block graduation.
-      new ProposalFileWriter({ ...config, formatter: true }));
+      new ProposalFileWriter({
+        ...config,
+        formatter: true,
+        sourcePatcher: options?.sourcePatcher,
+      }));
   const createCommitter =
     options?.createCommitter ??
     ((config: GraduationConfig) =>

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -47,6 +47,7 @@ import {
   detectEnvironment,
   getCurrentTrace,
 } from "@linchkit/core/server";
+import { patchNamedConstant } from "@linchkit/devtools";
 import { Elysia } from "elysia";
 import { type GraphQLSchema, NoSchemaIntrospectionCustomRule } from "graphql";
 import { createYoga, type Plugin } from "graphql-yoga";
@@ -445,6 +446,11 @@ export function createServer(
   mountProposalGraduateAPI(app, {
     commandLayer: opts.commandLayer,
     resolveRequestActor: opts.resolveRequestActor,
+    // Inject the concrete TS-AST patcher so an approved code-condition rule
+    // update graduates by rewriting the named constant in real source (#566).
+    // It lives in @linchkit/devtools to keep core typescript-free (the
+    // SourcePatcher capability seam); this is the composition root that wires it.
+    sourcePatcher: patchNamedConstant,
   });
   // On-demand AI code materialization: POST /api/proposals/:id/materialize
   // generates candidate source for a DRAFT proposal's code parts (G5 Phase 4).


### PR DESCRIPTION
## What — the #566 capstone

Wires the live runtime injection that makes **"say→change an existing code-condition rule's threshold" graduate to REAL source**. With this, the chain is end-to-end:

> "raise the manager-approval threshold to 20000" → governed Proposal carrying a `sourcePatch` (#593) → approve → graduate → `export const MANAGER_APPROVAL_THRESHOLD = 10000` is rewritten to `20000` in real source (via `patchNamedConstant`, #591) → human-reviewed PR opened.

## How

- **`proposal-graduate-api.ts`** — `MountProposalGraduateAPIOptions` gains an injectable `sourcePatcher?: SourcePatcher` (a core type), threaded into the **default** `ProposalFileWriter`. Ignored when a test overrides `createWriter`.
- **`server.ts`** (the composition root) — imports `patchNamedConstant` from `@linchkit/devtools` and passes it as `sourcePatcher`. This is the only place the devtools dependency is introduced, keeping the graduate-api module itself devtools-free.
- **`package.json`** — adds `@linchkit/devtools` (peer + workspace dev), matching how the other `@linchkit/*` capabilities are declared.

### Capability-seam design

Core declares the typescript-free `SourcePatcher` seam (#590); the heavy TS-AST patcher lives in `@linchkit/devtools` (#591) and is injected here at the composition root. Core never imports typescript.

## Tests

New `proposal-graduate-sourcepatch.test.ts` drives the **full server-side chain with no `createWriter` override**: the graduate route → default writer with the injected **real** `patchNamedConstant` → a temp source file under the repo root is patched `10000`→`20000` with comments preserved; plus a guard that an explicit `createWriter` override still fully controls the writer. The existing 21 graduate tests stay green. `bun run check` + `bun run typecheck` clean.

> Note: `@linchkit/devtools` becomes a runtime dependency of the server (it pulls in `typescript`). That is the intended capability-seam cost for a governance/dev-native server; graduation is a dev-loop operation. bun.lock is regenerated by CI's (non-frozen) `bun install`.

Related: #566 (closes the code-rule arm), #590, #591, #593
