### PR TITLE
fix(core): Phase-1 validation must accept sourcePatch rule updates (#566)

### DIFF
--- a/.changeset/sourcepatch-approval-validation.md
+++ b/.changeset/sourcepatch-approval-validation.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/core": patch
+---
+
+Fix Phase-1 proposal validation rejecting `sourcePatch`-carrying rule updates as `MISSING_DEFINITION` (#566). A "say→change an existing code-condition rule's threshold" proposal carries a definition-less change whose `sourcePatch` IS the specification (value-validated at assembly, re-validated by the patcher at graduation). Phase 1 now skips the definition requirement for such a change — like `revert`/`delete` — so the governed draft can reach the approval gate and graduate. Without this, every natural-language rule-threshold update failed Phase 1 and was unapprovable (the resolver produced a correct proposal that could never be approved). Caught by live testing of the chat-assistant approval flow.

--- a/packages/core/__tests__/proposal-validation-phase1.test.ts
+++ b/packages/core/__tests__/proposal-validation-phase1.test.ts
@@ -351,6 +351,28 @@ describe("validatePhase1", () => {
     expect(result.status).toBe("passed");
     expect(result.errors).toHaveLength(0);
   });
+
+  it("fails a code-rule update carrying an invalid (empty filePath) sourcePatch", () => {
+    // The carve-out skips MISSING_DEFINITION but still validates the patch's own
+    // shape: a malformed sourcePatch is caught at Phase 1, not opaquely at graduation.
+    const result = validatePhase1({
+      changes: [
+        {
+          target: "rule",
+          operation: "update",
+          name: "manager_approval_threshold",
+          sourcePatch: {
+            filePath: "",
+            constantName: "MANAGER_APPROVAL_THRESHOLD",
+            newValueLiteral: "20000",
+          },
+        },
+      ],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.errors.some((e) => e.code === "INVALID_SOURCE_PATCH")).toBe(true);
+  });
 });
 
 // ── validatePhase1: duplicate detection ─────────────────

--- a/packages/core/__tests__/proposal-validation-phase1.test.ts
+++ b/packages/core/__tests__/proposal-validation-phase1.test.ts
@@ -373,6 +373,28 @@ describe("validatePhase1", () => {
     expect(result.status).toBe("failed");
     expect(result.errors.some((e) => e.code === "INVALID_SOURCE_PATCH")).toBe(true);
   });
+
+  it("does NOT extend the sourcePatch carve-out to non-rule targets (#596 review)", () => {
+    // A crafted entity change carrying a sourcePatch but no definition must NOT
+    // get the rule-update carve-out — it still fails MISSING_DEFINITION.
+    const result = validatePhase1({
+      changes: [
+        {
+          target: "entity",
+          operation: "create",
+          name: "rogue_entity",
+          sourcePatch: {
+            filePath: "addons/x/y.ts",
+            constantName: "ROGUE",
+            newValueLiteral: "1",
+          },
+        },
+      ],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.errors.some((e) => e.code === "MISSING_DEFINITION")).toBe(true);
+  });
 });
 
 // ── validatePhase1: duplicate detection ─────────────────

--- a/packages/core/__tests__/proposal-validation-phase1.test.ts
+++ b/packages/core/__tests__/proposal-validation-phase1.test.ts
@@ -327,6 +327,30 @@ describe("validatePhase1", () => {
     expect(result.status).toBe("passed");
     expect(result.errors).toHaveLength(0);
   });
+
+  it("passes a code-rule update carrying a sourcePatch despite having no definition (#566)", () => {
+    // A "say→change an existing code-condition rule's threshold" proposal carries
+    // a definition-less change whose `sourcePatch` IS the spec. Phase-1 must NOT
+    // flag MISSING_DEFINITION, or the NL rule-threshold update can never be
+    // approved and graduated (caught by live testing — the approve gate blocked it).
+    const result = validatePhase1({
+      changes: [
+        {
+          target: "rule",
+          operation: "update",
+          name: "manager_approval_threshold",
+          sourcePatch: {
+            filePath: "addons/demo/cap-purchase-demo/src/rules/manager-approval-threshold.ts",
+            constantName: "MANAGER_APPROVAL_THRESHOLD",
+            newValueLiteral: "20000",
+          },
+        },
+      ],
+    });
+
+    expect(result.status).toBe("passed");
+    expect(result.errors).toHaveLength(0);
+  });
 });
 
 // ── validatePhase1: duplicate detection ─────────────────

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -194,6 +194,15 @@ export function validatePhase1(options: {
     // the target-specific definition validation below) just as we skip deletes,
     // so a governance-safe draft rollback Proposal can reach the approval gate.
     if (change.target === "revert") continue;
+    // A change carrying a `sourcePatch` (#566 "say→change an existing
+    // code-condition rule's threshold") intentionally has NO `definition`: it
+    // rewrites a single named constant in existing source, so the sourcePatch IS
+    // the specification (value-validated at assembly via `isSafeValueLiteral`,
+    // and the patcher re-validates at graduation). Skip the MISSING_DEFINITION
+    // requirement — like revert/delete — so the governed draft can reach the
+    // approval gate and graduate. Without this, every NL rule-threshold update
+    // fails Phase 1 and is unapprovable.
+    if (change.sourcePatch) continue;
     if (!change.definition) {
       errors.push({
         code: "MISSING_DEFINITION",

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -213,7 +213,13 @@ export function validatePhase1(options: {
           target: change.name,
         });
       }
-      continue;
+      // A definition-LESS sourcePatch change is self-specifying: skip the
+      // MISSING_DEFINITION requirement AND the target-specific definition
+      // validation below. But if a `definition` is ALSO present (permitted by
+      // the ProposalChange type, though not produced today), fall through so
+      // validateRule()/validateEntity()/… still runs and catches the
+      // inconsistency rather than silently accepting a malformed definition.
+      if (!change.definition) continue;
     }
     if (!change.definition) {
       errors.push({

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -201,8 +201,20 @@ export function validatePhase1(options: {
     // and the patcher re-validates at graduation). Skip the MISSING_DEFINITION
     // requirement — like revert/delete — so the governed draft can reach the
     // approval gate and graduate. Without this, every NL rule-threshold update
-    // fails Phase 1 and is unapprovable.
-    if (change.sourcePatch) continue;
+    // fails Phase 1 and is unapprovable. Still validate the patch's OWN shape
+    // here so a malformed sourcePatch is caught early at Phase 1 rather than
+    // failing opaquely during graduation.
+    if (change.sourcePatch) {
+      const { filePath, constantName, newValueLiteral } = change.sourcePatch;
+      if (!filePath || !constantName || !newValueLiteral) {
+        errors.push({
+          code: "INVALID_SOURCE_PATCH",
+          message: `Change for "${change.name}" has an invalid or incomplete sourcePatch specification`,
+          target: change.name,
+        });
+      }
+      continue;
+    }
     if (!change.definition) {
       errors.push({
         code: "MISSING_DEFINITION",

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -204,7 +204,12 @@ export function validatePhase1(options: {
     // fails Phase 1 and is unapprovable. Still validate the patch's OWN shape
     // here so a malformed sourcePatch is caught early at Phase 1 rather than
     // failing opaquely during graduation.
-    if (change.sourcePatch) {
+    // Scope the carve-out to exactly the production case it exists for — a
+    // `rule` `update` (the NL threshold change). `sourcePatch` is an optional
+    // field on the BASE ProposalChange, so a crafted `entity`/`action` change
+    // carrying a sourcePatch must NOT get the definition-less pass; it falls
+    // through to MISSING_DEFINITION like any other definition-less change.
+    if (change.sourcePatch && change.target === "rule" && change.operation === "update") {
       const { filePath, constantName, newValueLiteral } = change.sourcePatch;
       if (!filePath || !constantName || !newValueLiteral) {
         errors.push({


### PR DESCRIPTION
## What — a real end-to-end gap, found by live testing

Phase-1 proposal validation rejected a `sourcePatch`-carrying rule update as `MISSING_DEFINITION`, so a natural-language "say→change an existing code-condition rule's threshold" proposal could be **resolved but never approved** — the chain was silently broken at the approval gate.

## How it was found

Live-walking the freshly-landed chat-assistant channel (#594): typed *"把经理审批阈值改成 20000"* → the `SchemaProposalCard` rendered correctly → clicked **批准 (Approve)** → `Proposal validation failed. Cannot approve.` The approve envelope showed:

```
Phase 1 failed — MISSING_DEFINITION:
  Change for "manager_approval_threshold" (update) is missing a definition
```

A `sourcePatch` change deliberately has **no `definition`** — it rewrites a single named constant in existing source, so the `sourcePatch` IS its specification. Phase-1 didn't know that and blocked it. #595's integration test passed because it set `status: "approved"` directly, bypassing the approve-validation — so green tests never caught this.

## Fix

Phase-1 now skips the `MISSING_DEFINITION` requirement for a change carrying a `sourcePatch`, exactly like it already does for `revert`/`delete`. Safety is unchanged: the value is validated at assembly (`isSafeValueLiteral`, #593) and re-validated by the patcher at graduation (NOT FOUND / AMBIGUOUS / NO INITIALIZER throw, #591).

## Tests

`proposal-validation-phase1.test.ts` gains a case asserting a definition-less `sourcePatch` rule-update **passes** Phase 1 (mirroring the existing `revert` carve-out test). 149 validation-suite tests green; `bun run check` + `bun run typecheck` clean.

This is the missing middle of #566 — the approve gate now accepts the governed sourcePatch draft, so resolve → approve → graduate completes end-to-end.

Related: #566, #591, #593, #595


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now correctly accepts rule updates containing source patches without separate definitions. Previously these were incorrectly rejected, preventing governed drafts from advancing through the approval process. This fix allows changes to pass the initial approval gate and benefits rule threshold update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->