### PR TITLE
chore(release): auto-sync capability coreVersion after changeset bump (#589)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,10 @@ jobs:
         with:
           title: "chore: version packages"
           commit: "chore: version packages"
-          version: bunx changeset version
+          # Bump versions/peerDeps, THEN sync each capability's linchkit.coreVersion
+          # to the new @linchkit/core version so Capability Lint does not fail on
+          # every subsequent PR (issue #589). Runs inside the "version packages" PR.
+          version: bunx changeset version && bun scripts/sync-core-version.ts
           publish: bun scripts/release.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "db:migrate": "bun ./node_modules/.bin/drizzle-kit migrate",
     "db:studio": "bun ./node_modules/.bin/drizzle-kit studio",
     "changeset": "bunx changeset",
-    "version-packages": "bunx changeset version",
+    "version-packages": "bunx changeset version && bun scripts/sync-core-version.ts",
+    "sync-core-version": "bun scripts/sync-core-version.ts",
     "release": "bun scripts/release.ts"
   },
   "devDependencies": {

--- a/scripts/__tests__/sync-core-version.test.ts
+++ b/scripts/__tests__/sync-core-version.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for the deterministic `sync-core-version` logic (issue #589).
+ *
+ * Exercises the PURE sync functions against in-memory fixtures (no filesystem,
+ * no real version bump): a JSON package.json/capability.json site, the cap-lock
+ * factory.ts literal, and the cap-lock test assertion literal. Covers the happy
+ * path, idempotency, drift detection, and edge cases (alt quote style,
+ * whitespace, non-JSON/no-field inputs, trailing-newline preservation).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  applySync,
+  coreVersionRange,
+  readCoreVersion,
+  syncFactoryCoreVersion,
+  syncJsonCoreVersion,
+  syncTestCoreVersion,
+} from "../sync-core-version";
+
+// -- coreVersionRange / readCoreVersion ----------------------------------
+
+describe("coreVersionRange", () => {
+  test("builds a caret range from a concrete version", () => {
+    expect(coreVersionRange("0.3.0")).toBe("^0.3.0");
+    expect(coreVersionRange("1.2.3")).toBe("^1.2.3");
+  });
+});
+
+describe("readCoreVersion", () => {
+  test("reads the .version field", () => {
+    expect(readCoreVersion('{ "name": "@linchkit/core", "version": "0.4.0" }')).toBe("0.4.0");
+  });
+
+  test("throws when version is missing", () => {
+    expect(() => readCoreVersion('{ "name": "@linchkit/core" }')).toThrow();
+  });
+});
+
+// -- syncJsonCoreVersion -------------------------------------------------
+
+describe("syncJsonCoreVersion", () => {
+  const pkg = (cv: string) =>
+    `${JSON.stringify({ name: "@linchkit/cap-x", linchkit: { coreVersion: cv } }, null, 2)}\n`;
+
+  test("rewrites a stale coreVersion to the target range", () => {
+    const { text, changed } = syncJsonCoreVersion(pkg("^0.2.0"), "^0.3.0");
+    expect(changed).toBe(true);
+    const parsed = JSON.parse(text) as { linchkit: { coreVersion: string } };
+    expect(parsed.linchkit.coreVersion).toBe("^0.3.0");
+  });
+
+  test("preserves 2-space indent and trailing newline", () => {
+    const { text } = syncJsonCoreVersion(pkg("^0.2.0"), "^0.3.0");
+    expect(text.endsWith("\n")).toBe(true);
+    expect(text).toContain('\n  "linchkit": {');
+    expect(text).toContain('\n    "coreVersion": "^0.3.0"');
+  });
+
+  test("is idempotent when already in sync (no change)", () => {
+    const inSync = pkg("^0.3.0");
+    const { text, changed } = syncJsonCoreVersion(inSync, "^0.3.0");
+    expect(changed).toBe(false);
+    expect(text).toBe(inSync);
+  });
+
+  test("detects drift (changed flag) without a coreVersion field returns unchanged", () => {
+    const noField = `${JSON.stringify({ name: "@linchkit/cap-x", linchkit: {} }, null, 2)}\n`;
+    const { changed } = syncJsonCoreVersion(noField, "^0.3.0");
+    expect(changed).toBe(false);
+  });
+
+  test("ignores a package.json without a linchkit block", () => {
+    const plain = `${JSON.stringify({ name: "x", version: "1.0.0" }, null, 2)}\n`;
+    const { text, changed } = syncJsonCoreVersion(plain, "^0.3.0");
+    expect(changed).toBe(false);
+    expect(text).toBe(plain);
+  });
+
+  test("does not invent a trailing newline that was absent", () => {
+    const noNewline = JSON.stringify({ name: "x", linchkit: { coreVersion: "^0.2.0" } }, null, 2);
+    const { text } = syncJsonCoreVersion(noNewline, "^0.3.0");
+    expect(text.endsWith("\n")).toBe(false);
+  });
+});
+
+// -- syncFactoryCoreVersion ----------------------------------------------
+
+describe("syncFactoryCoreVersion", () => {
+  const factory = (cv: string) =>
+    [
+      "return defineCapability({",
+      '  name: "cap-lock",',
+      '  version: "1.0.0",',
+      `  coreVersion: "${cv}",`,
+      "});",
+    ].join("\n");
+
+  test("rewrites the coreVersion literal", () => {
+    const { text, changed } = syncFactoryCoreVersion(factory("^0.2.0"), "^0.3.0");
+    expect(changed).toBe(true);
+    expect(text).toContain('coreVersion: "^0.3.0"');
+    expect(text).not.toContain("^0.2.0");
+  });
+
+  test("is idempotent when already in sync", () => {
+    const inSync = factory("^0.3.0");
+    const { text, changed } = syncFactoryCoreVersion(inSync, "^0.3.0");
+    expect(changed).toBe(false);
+    expect(text).toBe(inSync);
+  });
+
+  test("tolerates single quotes and extra whitespace", () => {
+    const src = "coreVersion :   '^0.1.0'";
+    const { text, changed } = syncFactoryCoreVersion(src, "^0.3.0");
+    expect(changed).toBe(true);
+    expect(text).toBe("coreVersion :   '^0.3.0'");
+  });
+
+  test("leaves source untouched when there is no coreVersion property", () => {
+    const src = 'const x = "^0.2.0";';
+    const { text, changed } = syncFactoryCoreVersion(src, "^0.3.0");
+    expect(changed).toBe(false);
+    expect(text).toBe(src);
+  });
+});
+
+// -- syncTestCoreVersion -------------------------------------------------
+
+describe("syncTestCoreVersion", () => {
+  const assertion = (cv: string) => `    expect(capLock.coreVersion).toBe("${cv}");`;
+
+  test("rewrites the asserted version literal", () => {
+    const { text, changed } = syncTestCoreVersion(assertion("^0.2.0"), "^0.3.0");
+    expect(changed).toBe(true);
+    expect(text).toBe(assertion("^0.3.0"));
+  });
+
+  test("is idempotent when already in sync", () => {
+    const inSync = assertion("^0.3.0");
+    const { text, changed } = syncTestCoreVersion(inSync, "^0.3.0");
+    expect(changed).toBe(false);
+    expect(text).toBe(inSync);
+  });
+
+  test("does not touch an unrelated toBe assertion", () => {
+    const src = 'expect(capLock.version).toBe("1.0.0");';
+    const { text, changed } = syncTestCoreVersion(src, "^0.3.0");
+    expect(changed).toBe(false);
+    expect(text).toBe(src);
+  });
+});
+
+// -- applySync dispatcher + full-plan fixture ----------------------------
+
+describe("applySync (full plan over a fake capability set)", () => {
+  const coreVersion = "0.4.0";
+  const range = coreVersionRange(coreVersion);
+
+  const fixtures: Record<string, { strategy: "json" | "factory" | "test"; before: string }> = {
+    "addons/a/cap-a/package.json": {
+      strategy: "json",
+      before: `${JSON.stringify(
+        {
+          name: "@linchkit/cap-a",
+          peerDependencies: { "@linchkit/core": "^0.3.0" },
+          linchkit: { coreVersion: "^0.3.0" },
+        },
+        null,
+        2,
+      )}\n`,
+    },
+    "addons/lock/cap-lock/capability.json": {
+      strategy: "json",
+      before: `${JSON.stringify(
+        { name: "@linchkit/cap-lock", linchkit: { coreVersion: "^0.3.0" } },
+        null,
+        2,
+      )}\n`,
+    },
+    "addons/lock/cap-lock/src/factory.ts": {
+      strategy: "factory",
+      before: '  coreVersion: "^0.3.0",',
+    },
+    "addons/lock/cap-lock/__tests__/capability.test.ts": {
+      strategy: "test",
+      before: '    expect(capLock.coreVersion).toBe("^0.3.0");',
+    },
+  };
+
+  test("syncs every site from a fake core bump to ^0.4.0", () => {
+    for (const [path, { strategy, before }] of Object.entries(fixtures)) {
+      const { text, changed } = applySync(strategy, before, range);
+      expect(changed).toBe(true);
+      expect(text).toContain(range);
+      // The coreVersion-bearing token must move to ^0.4.0. The package.json
+      // fixture keeps a peerDependencies "^0.3.0" the sync does NOT own (that
+      // is changeset's job), so assert against the coreVersion token only.
+      if (path.endsWith("package.json")) {
+        const parsed = JSON.parse(text) as { linchkit: { coreVersion: string } };
+        expect(parsed.linchkit.coreVersion).toBe(range);
+      } else if (path.endsWith("capability.json")) {
+        const parsed = JSON.parse(text) as { linchkit: { coreVersion: string } };
+        expect(parsed.linchkit.coreVersion).toBe(range);
+        expect(text).not.toContain("^0.3.0");
+      } else {
+        expect(text).not.toContain("^0.3.0");
+      }
+    }
+  });
+
+  test("running the plan a second time is a no-op (idempotent)", () => {
+    for (const { strategy, before } of Object.values(fixtures)) {
+      const first = applySync(strategy, before, range).text;
+      const second = applySync(strategy, first, range);
+      expect(second.changed).toBe(false);
+      expect(second.text).toBe(first);
+    }
+  });
+
+  test("detects drift: a stale site reports changed=true", () => {
+    const staleFixture = fixtures["addons/a/cap-a/package.json"];
+    expect(staleFixture).toBeDefined();
+    const stale = applySync("json", (staleFixture as { before: string }).before, range);
+    expect(stale.changed).toBe(true);
+  });
+});

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -139,6 +139,7 @@ run_batch() {
 run_batch "packages/core"     ./packages/core/
 run_batch "packages/devtools" ./packages/devtools/
 run_batch "packages/starters" ./packages/starters/
+run_batch "scripts"           ./scripts/
 run_batch "e2e"               ./e2e/
 run_batch "addons"            ./addons/
 

--- a/scripts/sync-core-version.ts
+++ b/scripts/sync-core-version.ts
@@ -205,6 +205,7 @@ async function main(): Promise<void> {
   );
 
   const drifted: string[] = [];
+  const missing: string[] = [];
 
   for (const target of targets) {
     const full = resolve(ROOT, target.path);
@@ -212,10 +213,10 @@ async function main(): Promise<void> {
     try {
       source = readFileSync(full, "utf-8");
     } catch {
-      // A non-JSON cap-lock site could be moved/renamed; surface it loudly so a
-      // refactor that drops a mirror site can't silently leave it un-synced.
-      console.error(`[sync-core-version] MISSING target: ${target.path}`);
-      process.exitCode = 1;
+      // A non-JSON cap-lock site could be moved/renamed; collect it and fail
+      // loudly below so a refactor that drops a mirror site can't silently
+      // leave it un-synced.
+      missing.push(target.path);
       continue;
     }
 
@@ -226,6 +227,18 @@ async function main(): Promise<void> {
     if (!checkOnly) {
       writeFileSync(full, text, "utf-8");
     }
+  }
+
+  // A missing mirror site is a hard error in BOTH modes. Report it and exit
+  // before any success-style logging, so the output is never self-contradictory
+  // (exit 1 paired with an "in sync" message).
+  if (missing.length > 0) {
+    console.error(
+      `[sync-core-version] MISSING target file(s) (${missing.length}) — a mirror site was moved or renamed:`,
+    );
+    for (const p of missing) console.error(`  - ${p}`);
+    console.error("Update CAP_LOCK_EXTRA_TARGETS in scripts/sync-core-version.ts.");
+    process.exit(1);
   }
 
   if (checkOnly) {

--- a/scripts/sync-core-version.ts
+++ b/scripts/sync-core-version.ts
@@ -206,7 +206,11 @@ async function main(): Promise<void> {
 
   const drifted: string[] = [];
   const missing: string[] = [];
+  const plannedWrites: { full: string; text: string }[] = [];
 
+  // Pass 1 — read every target and compute the plan. NO file is written here, so
+  // a moved/renamed mirror site is detected BEFORE anything is mutated; the
+  // missing-target failure below can never leave a partially-synced tree.
   for (const target of targets) {
     const full = resolve(ROOT, target.path);
     let source: string;
@@ -224,14 +228,13 @@ async function main(): Promise<void> {
     if (!changed) continue;
 
     drifted.push(target.path);
-    if (!checkOnly) {
-      writeFileSync(full, text, "utf-8");
-    }
+    plannedWrites.push({ full, text });
   }
 
   // A missing mirror site is a hard error in BOTH modes. Report it and exit
-  // before any success-style logging, so the output is never self-contradictory
-  // (exit 1 paired with an "in sync" message).
+  // BEFORE any write or success-style logging, so the output is never
+  // self-contradictory (exit 1 paired with an "in sync" message) AND no file is
+  // written when another target is missing (no partial sync).
   if (missing.length > 0) {
     console.error(
       `[sync-core-version] MISSING target file(s) (${missing.length}) — a mirror site was moved or renamed:`,
@@ -239,6 +242,14 @@ async function main(): Promise<void> {
     for (const p of missing) console.error(`  - ${p}`);
     console.error("Update CAP_LOCK_EXTRA_TARGETS in scripts/sync-core-version.ts.");
     process.exit(1);
+  }
+
+  // Pass 2 — apply the planned writes. Only reached when every target was
+  // readable, so the sync is all-or-nothing with respect to a missing mirror.
+  if (!checkOnly) {
+    for (const { full, text } of plannedWrites) {
+      writeFileSync(full, text, "utf-8");
+    }
   }
 
   if (checkOnly) {

--- a/scripts/sync-core-version.ts
+++ b/scripts/sync-core-version.ts
@@ -1,0 +1,258 @@
+/**
+ * sync-core-version — keep every capability's declared `coreVersion` in lockstep
+ * with the actual `@linchkit/core` version (issue #589).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The repo versions/publishes with Changesets. `changeset version` bumps
+ * `@linchkit/core` (e.g. 0.2.0 → 0.3.0) and rewrites each capability's
+ * `peerDependencies["@linchkit/core"]` caret range — but it does NOT touch the
+ * `linchkit.coreVersion` field that Capability Lint (Spec 21 §10.1) checks. The
+ * lint requires (a) `coreVersion` to EQUAL the concrete peerDep range and (b)
+ * `coreVersion` to SATISFY the local core version. So after a core bump
+ * `coreVersion` is stale (`^0.2.0`) while core is `0.3.0`, and Capability Lint
+ * FAILS on every subsequent PR until a human sweeps all package.json files by
+ * hand (this happened — PR #588). This script automates that sweep so a core
+ * bump can never again break every PR.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Reads the post-bump `@linchkit/core` version from `packages/core/package.json`
+ * (the source of truth) and rewrites every `coreVersion` site to the matching
+ * caret range `^x.y.z`. It is deterministic and idempotent: running it when
+ * already in sync produces no changes.
+ *
+ * COVERED SITES (see CAP_LOCK_EXTRA_TARGETS + the package.json glob)
+ * -----------------------------------------------------------------
+ *  - Every `addons/[*]/cap-[*]/package.json` with a `linchkit.coreVersion` field
+ *    (JSON read/write, indent + trailing newline preserved).
+ *  - cap-lock is the only addon with the value mirrored in extra places:
+ *      - `addons/lock/cap-lock/capability.json`            (JSON: linchkit.coreVersion)
+ *      - `addons/lock/cap-lock/src/factory.ts`             (literal: `coreVersion: "^x.y.z"`)
+ *      - `addons/lock/cap-lock/__tests__/capability.test.ts` (literal in a `toBe(...)` assertion)
+ *
+ * HOW IT IS WIRED
+ * ---------------
+ * The release `version` step runs `bunx changeset version && bun scripts/sync-core-version.ts`
+ * (see `.github/workflows/publish.yml` and the root `version-packages` script),
+ * so the sync runs immediately after the bump, inside the same version commit /
+ * "version packages" PR. Choosing the changeset `version` command as the hook —
+ * rather than an npm `postversion` lifecycle script — is deliberate: changesets
+ * drives versioning through its own `version` command (it does NOT invoke
+ * `npm version`, so the `postversion` lifecycle never fires here), and the
+ * GitHub Action's `version:` input is the single, documented seam changesets
+ * exposes for "run extra work after the bump".
+ *
+ * USAGE
+ *   bun scripts/sync-core-version.ts            # rewrite all coreVersion sites in place
+ *   bun scripts/sync-core-version.ts --check    # exit 1 if anything is out of sync (no writes)
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Glob } from "bun";
+
+const ROOT = resolve(import.meta.dir, "..");
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no I/O — unit tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * The caret range a capability should declare for a given concrete core version.
+ * Convention (matches the peerDep range changeset writes): `^<core.version>`.
+ */
+export function coreVersionRange(coreVersion: string): string {
+  return `^${coreVersion}`;
+}
+
+/** Read the `.version` field from a parsed `@linchkit/core` package.json string. */
+export function readCoreVersion(corePkgJson: string): string {
+  const parsed = JSON.parse(corePkgJson) as { version?: unknown };
+  if (typeof parsed.version !== "string" || parsed.version.length === 0) {
+    throw new Error("packages/core/package.json has no usable .version field");
+  }
+  return parsed.version;
+}
+
+/**
+ * Rewrite the `linchkit.coreVersion` field of a package.json / capability.json
+ * source string to `range`, preserving the original indentation (2-space) and
+ * trailing newline. Parses + re-stringifies the JSON rather than regexing it.
+ *
+ * Returns `{ text, changed }`. `changed` is false when there is no
+ * `linchkit.coreVersion` field OR it already equals `range` (idempotent).
+ */
+export function syncJsonCoreVersion(
+  source: string,
+  range: string,
+): { text: string; changed: boolean } {
+  const data = JSON.parse(source) as Record<string, unknown>;
+  const linchkit = data.linchkit;
+  if (typeof linchkit !== "object" || linchkit === null) {
+    return { text: source, changed: false };
+  }
+  const block = linchkit as Record<string, unknown>;
+  if (typeof block.coreVersion !== "string") {
+    return { text: source, changed: false };
+  }
+  if (block.coreVersion === range) {
+    return { text: source, changed: false };
+  }
+  block.coreVersion = range;
+  const trailingNewline = source.endsWith("\n") ? "\n" : "";
+  return { text: `${JSON.stringify(data, null, 2)}${trailingNewline}`, changed: true };
+}
+
+/**
+ * Replace a `coreVersion: "<range>"` object-property literal (e.g. inside
+ * cap-lock's `factory.ts` `defineCapability({ ... coreVersion: "^0.2.0" ... })`)
+ * with the target `range`. Robust to surrounding whitespace and either quote
+ * style; only the version string between the quotes is touched. Idempotent.
+ */
+export function syncFactoryCoreVersion(
+  source: string,
+  range: string,
+): { text: string; changed: boolean } {
+  // Matches:  coreVersion <ws> : <ws> ("..." | '...')
+  const re = /(\bcoreVersion[ \t]*:[ \t]*)(["'])[^"']*\2/;
+  const m = source.match(re);
+  if (!m) return { text: source, changed: false };
+  const replacement = `${m[1]}${m[2]}${range}${m[2]}`;
+  if (m[0] === replacement) return { text: source, changed: false };
+  return { text: source.replace(re, replacement), changed: true };
+}
+
+/**
+ * Replace the version literal inside the cap-lock test's
+ * `expect(capLock.coreVersion).toBe("<range>")` assertion with `range`.
+ * Robust to whitespace and quote style; idempotent.
+ */
+export function syncTestCoreVersion(
+  source: string,
+  range: string,
+): { text: string; changed: boolean } {
+  // Matches:  .coreVersion ... toBe ( ("..." | '...') )
+  const re = /(\.coreVersion[\s\S]*?\.toBe[ \t]*\([ \t]*)(["'])[^"']*\2/;
+  const m = source.match(re);
+  if (!m) return { text: source, changed: false };
+  const replacement = `${m[1]}${m[2]}${range}${m[2]}`;
+  if (m[0] === replacement) return { text: source, changed: false };
+  return { text: source.replace(re, replacement), changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Sync plan (which file gets which strategy) — pure, given the file list
+// ---------------------------------------------------------------------------
+
+export type SyncStrategy = "json" | "factory" | "test";
+
+export interface SyncTarget {
+  /** Path relative to repo root. */
+  path: string;
+  strategy: SyncStrategy;
+}
+
+/** cap-lock's capability.json + its two non-JSON mirror sites, relative to ROOT. */
+const CAP_LOCK_EXTRA_TARGETS: SyncTarget[] = [
+  { path: "addons/lock/cap-lock/capability.json", strategy: "json" },
+  { path: "addons/lock/cap-lock/src/factory.ts", strategy: "factory" },
+  { path: "addons/lock/cap-lock/__tests__/capability.test.ts", strategy: "test" },
+];
+
+/**
+ * Apply the strategy that matches a target to its source text. Pure dispatcher
+ * so the test can exercise the full plan against in-memory fixtures.
+ */
+export function applySync(
+  strategy: SyncStrategy,
+  source: string,
+  range: string,
+): { text: string; changed: boolean } {
+  switch (strategy) {
+    case "json":
+      return syncJsonCoreVersion(source, range);
+    case "factory":
+      return syncFactoryCoreVersion(source, range);
+    case "test":
+      return syncTestCoreVersion(source, range);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// I/O orchestration
+// ---------------------------------------------------------------------------
+
+/** Discover every capability package.json that declares a linchkit.coreVersion. */
+async function discoverJsonTargets(): Promise<SyncTarget[]> {
+  const out: SyncTarget[] = [];
+  const glob = new Glob("addons/*/cap-*/package.json");
+  for await (const match of glob.scan({ cwd: ROOT })) {
+    out.push({ path: match, strategy: "json" });
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const checkOnly = Bun.argv.includes("--check");
+
+  const corePkg = readFileSync(resolve(ROOT, "packages/core/package.json"), "utf-8");
+  const range = coreVersionRange(readCoreVersion(corePkg));
+
+  const jsonTargets = await discoverJsonTargets();
+  const targets = [...jsonTargets, ...CAP_LOCK_EXTRA_TARGETS].sort((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+
+  const drifted: string[] = [];
+
+  for (const target of targets) {
+    const full = resolve(ROOT, target.path);
+    let source: string;
+    try {
+      source = readFileSync(full, "utf-8");
+    } catch {
+      // A non-JSON cap-lock site could be moved/renamed; surface it loudly so a
+      // refactor that drops a mirror site can't silently leave it un-synced.
+      console.error(`[sync-core-version] MISSING target: ${target.path}`);
+      process.exitCode = 1;
+      continue;
+    }
+
+    const { text, changed } = applySync(target.strategy, source, range);
+    if (!changed) continue;
+
+    drifted.push(target.path);
+    if (!checkOnly) {
+      writeFileSync(full, text, "utf-8");
+    }
+  }
+
+  if (checkOnly) {
+    if (drifted.length > 0) {
+      console.error(
+        `[sync-core-version] OUT OF SYNC with @linchkit/core ${range} (${drifted.length} file(s)):`,
+      );
+      for (const p of drifted) console.error(`  - ${p}`);
+      console.error("Run: bun scripts/sync-core-version.ts");
+      process.exit(1);
+    }
+    console.log(`[sync-core-version] all coreVersion sites in sync with ${range}`);
+    return;
+  }
+
+  if (drifted.length === 0) {
+    console.log(`[sync-core-version] already in sync with @linchkit/core ${range}`);
+  } else {
+    console.log(`[sync-core-version] synced ${drifted.length} file(s) to ${range}:`);
+    for (const p of drifted) console.log(`  - ${p}`);
+  }
+}
+
+// Run only when invoked directly (not when imported by the unit test).
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("[sync-core-version] failed:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/verify-test-coverage.sh
+++ b/scripts/verify-test-coverage.sh
@@ -35,6 +35,7 @@ packages/core/
 packages/devtools/
 packages/starters/
 packages/cli/
+scripts/
 e2e/
 addons/
 "


### PR DESCRIPTION
## What

Closes #589. Makes a core version bump never again break Capability Lint on every PR.

`changeset version` bumps `@linchkit/core` and each capability's peerDep caret range, but does **not** touch `linchkit.coreVersion`. Capability Lint (Spec 21 §10.1) requires `coreVersion` to **equal** the concrete peerDep range and **satisfy** the local core version — so after a bump `coreVersion` goes stale (`^0.2.0` while core is `0.3.0`) and Lint fails on every subsequent PR until a human sweeps all `package.json` by hand. That happened (#588).

## How

- **`scripts/sync-core-version.ts`** (new) — reads the post-bump core version from `packages/core/package.json` and rewrites every `coreVersion` site to `^x.y.z`. Deterministic + idempotent. `--check` exits 1 on drift without writing (and errors if any expected cap-lock mirror goes missing — a refactor guard).
  - JSON sites (`addons/*/cap-*/package.json` — 31 caps) are parsed/re-stringified; 2-space indent + trailing newline preserved, never regex.
  - cap-lock's 3 non-glob mirrors handled by precise anchored-literal replace: `capability.json`, `src/factory.ts` literal, `__tests__/capability.test.ts` `toBe(...)` literal.
- **`.github/workflows/publish.yml`** — changeset `version` step is now `bunx changeset version && bun scripts/sync-core-version.ts`, so the sync runs right after the bump inside the same "version packages" PR.
- **`package.json`** — `version-packages` chains the sync (keeps local in sync); adds a standalone `sync-core-version` script.

### Why the changeset `version` seam (not `postversion`)
The changeset Action's `version:` input is the single documented post-bump hook. An npm `postversion` lifecycle script would **not** fire — changesets drives versioning through its own command and never invokes `npm version`.

## Verification

- `bun run check` clean (1830 files), `bun run typecheck` clean.
- 19 new `bun:test` cases (happy path, idempotency, drift, indent/newline preservation, alt-quote robustness, full-plan fixture). All pass.
- Verified a **no-op** against current main (in sync at `^0.3.0`, zero file drift).
- End-to-end fixture (core bumped to 0.4.0 with stale `^0.3.0`): all 5 sites rewritten to `^0.4.0`, idempotent on re-run, `--check` green after.
- Full suite (~7591 tests) green except the pre-existing `lint-capability` CLI-subprocess cold-spawn 15s timeout (reproduces on unmodified main; unrelated — this change touches no CLI code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated version synchronization for capability packages during releases to maintain consistency with the core library.
  * Enhanced release workflow with new version management scripts.

* **Tests**
  * Added comprehensive test coverage for version synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->