### PR TITLE
feat(adapter-ag-ui): AG-UI HITL protocol foundation (Spec 71 P1)

### DIFF
--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/protocol.test.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/protocol.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, test } from "bun:test";
-import { EventType, encodeSseEvent, RunAgentInputSchema } from "../src/protocol";
+import {
+  EventType,
+  encodeSseEvent,
+  type Interrupt,
+  InterruptSchema,
+  makeInterruptOutcome,
+  ResumeEntrySchema,
+  RunAgentInputSchema,
+  RunFinishedEventSchema,
+  RunFinishedOutcomeSchema,
+  SUCCESS_OUTCOME,
+} from "../src/protocol";
+
+/** A representative approval interrupt (Spec 71 §4.2). */
+function sampleInterrupt(): Interrupt {
+  return {
+    id: "int_1",
+    reason: "action.approval.required",
+    message: 'Create product "Widget" (price 9.9)?',
+    toolCallId: "lk:propose-mutation:abc",
+    responseSchema: { type: "object", properties: { price: { type: "number" } } },
+    expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    metadata: {
+      action: "create_product",
+      proposedInput: { name: "Widget", price: 9.9 },
+      inputDigest: "digest_xyz",
+    },
+  };
+}
 
 describe("RunAgentInputSchema (official @ag-ui/core schema)", () => {
   test("rejects a minimal input missing the required arrays", () => {
@@ -131,5 +159,140 @@ describe("EventType", () => {
     expect(String(EventType.TOOL_CALL_END)).toBe("TOOL_CALL_END");
     expect(String(EventType.STATE_SNAPSHOT)).toBe("STATE_SNAPSHOT");
     expect(String(EventType.CUSTOM)).toBe("CUSTOM");
+  });
+});
+
+// ── Human-in-the-loop protocol surface (Spec 71 P1) ─────────
+
+describe("makeInterruptOutcome (Spec 71 §3.4 / §4.2)", () => {
+  test("returns the discriminated interrupt shape with the interrupts preserved", () => {
+    const interrupt = sampleInterrupt();
+    const outcome = makeInterruptOutcome([interrupt]);
+
+    expect(outcome.type).toBe("interrupt");
+    expect(outcome.interrupts).toHaveLength(1);
+    expect(outcome.interrupts[0]).toEqual(interrupt);
+  });
+
+  test("validates against the upstream RunFinishedOutcomeSchema (interrupt branch)", () => {
+    const parsed = RunFinishedOutcomeSchema.safeParse(makeInterruptOutcome([sampleInterrupt()]));
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.type).toBe("interrupt");
+    }
+  });
+
+  test("SUCCESS_OUTCOME validates against the success branch", () => {
+    const parsed = RunFinishedOutcomeSchema.safeParse(SUCCESS_OUTCOME);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.type).toBe("success");
+    }
+  });
+});
+
+describe("RunFinishedEvent with outcome (Spec 71 §3.1)", () => {
+  test("an interrupt outcome round-trips through RunFinishedEventSchema.safeParse", () => {
+    const interrupt = sampleInterrupt();
+    const event = {
+      type: EventType.RUN_FINISHED,
+      threadId: "thread_1",
+      runId: "run_a",
+      outcome: makeInterruptOutcome([interrupt]),
+    };
+
+    const parsed = RunFinishedEventSchema.safeParse(event);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      // `outcome` is z.optional(z.nullable(...)) upstream — narrow it.
+      expect(parsed.data.outcome?.type).toBe("interrupt");
+      if (parsed.data.outcome?.type === "interrupt") {
+        expect(parsed.data.outcome.interrupts).toHaveLength(1);
+        expect(parsed.data.outcome.interrupts[0]?.id).toBe("int_1");
+        expect(parsed.data.outcome.interrupts[0]?.reason).toBe("action.approval.required");
+        expect(parsed.data.outcome.interrupts[0]?.metadata?.action).toBe("create_product");
+      }
+    }
+  });
+
+  test("a plain finish (no outcome) still parses and is unchanged", () => {
+    const event = { type: EventType.RUN_FINISHED, threadId: "thread_1", runId: "run_a" };
+
+    const parsed = RunFinishedEventSchema.safeParse(event);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.threadId).toBe("thread_1");
+      expect(parsed.data.runId).toBe("run_a");
+      // No outcome on a plain finish — backward-compatible with the legacy frame.
+      expect(parsed.data.outcome).toBeUndefined();
+    }
+  });
+
+  test("a finish carrying the success outcome parses on the success branch", () => {
+    const parsed = RunFinishedEventSchema.safeParse({
+      type: EventType.RUN_FINISHED,
+      threadId: "thread_1",
+      runId: "run_b",
+      outcome: SUCCESS_OUTCOME,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.outcome?.type).toBe("success");
+    }
+  });
+});
+
+describe("ResumeEntrySchema (Spec 71 §3.3 / §4.2)", () => {
+  test("accepts an approve (resolved) payload with edited input + baseDigest", () => {
+    const parsed = ResumeEntrySchema.safeParse({
+      interruptId: "int_1",
+      status: "resolved",
+      payload: {
+        action: "create_product",
+        input: { name: "Widget", price: 8.9 },
+        baseDigest: "digest_xyz",
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.interruptId).toBe("int_1");
+      expect(parsed.data.status).toBe("resolved");
+    }
+  });
+
+  test("accepts a reject (cancelled) entry with no payload", () => {
+    const parsed = ResumeEntrySchema.safeParse({ interruptId: "int_1", status: "cancelled" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.status).toBe("cancelled");
+      expect(parsed.data.payload).toBeUndefined();
+    }
+  });
+
+  test("rejects an unknown status (not resolved/cancelled)", () => {
+    const parsed = ResumeEntrySchema.safeParse({ interruptId: "int_1", status: "approved" });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects a resume missing interruptId", () => {
+    const parsed = ResumeEntrySchema.safeParse({ status: "resolved" });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("InterruptSchema (Spec 71 §3.2)", () => {
+  test("accepts the full interrupt shape we emit", () => {
+    const parsed = InterruptSchema.safeParse(sampleInterrupt());
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts a minimal interrupt (id + reason only)", () => {
+    const parsed = InterruptSchema.safeParse({ id: "int_2", reason: "action.approval.required" });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("rejects an interrupt missing the required reason", () => {
+    const parsed = InterruptSchema.safeParse({ id: "int_3" });
+    expect(parsed.success).toBe(false);
   });
 });

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/protocol.test.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/protocol.test.ts
@@ -182,6 +182,15 @@ describe("makeInterruptOutcome (Spec 71 §3.4 / §4.2)", () => {
     }
   });
 
+  test("throws on an empty interrupts list (the upstream schema requires .min(1))", () => {
+    expect(() => makeInterruptOutcome([])).toThrow(/at least one interrupt/);
+    // Prove the guard prevents a schema-invalid frame: an empty list WOULD fail
+    // the upstream schema, so the throw is what keeps the encoder safe.
+    expect(RunFinishedOutcomeSchema.safeParse({ type: "interrupt", interrupts: [] }).success).toBe(
+      false,
+    );
+  });
+
   test("SUCCESS_OUTCOME validates against the success branch", () => {
     const parsed = RunFinishedOutcomeSchema.safeParse(SUCCESS_OUTCOME);
     expect(parsed.success).toBe(true);

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/run-endpoint.test.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/run-endpoint.test.ts
@@ -8,8 +8,13 @@
 
 import { describe, expect, test } from "bun:test";
 import type { AICompletionResult, AIService, AIStreamResult } from "@linchkit/core";
-import { type AGUIEvent, EventType } from "../src/protocol";
-import { createAgUiApp } from "../src/run-endpoint";
+import {
+  type AGUIEvent,
+  EventType,
+  makeInterruptOutcome,
+  RunFinishedEventSchema,
+} from "../src/protocol";
+import { createAgUiApp, makeRunFinishedEvent } from "../src/run-endpoint";
 
 const RUN_URL = "http://local.test/api/agui/run";
 
@@ -414,5 +419,57 @@ describe("custom base path", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("");
     expect(aiCalls).toBe(0);
+  });
+});
+
+describe("makeRunFinishedEvent (Spec 71 P1 — outcome-capable finish frame)", () => {
+  test("a no-outcome finish is byte-identical to the legacy frame", () => {
+    const event = makeRunFinishedEvent({ threadId: "thread_1", runId: "run_1" });
+
+    // The legacy frame was a plain object literal with no `outcome` key.
+    expect(event).toEqual({
+      type: EventType.RUN_FINISHED,
+      threadId: "thread_1",
+      runId: "run_1",
+    });
+    expect("outcome" in event).toBe(false);
+    // Encoding stays identical to the pre-HITL wire form.
+    expect(JSON.stringify(event)).toBe(
+      JSON.stringify({ type: "RUN_FINISHED", threadId: "thread_1", runId: "run_1" }),
+    );
+  });
+
+  test("attaches an interrupt outcome and the frame round-trips through the schema", () => {
+    const interrupt = {
+      id: "int_1",
+      reason: "action.approval.required",
+      toolCallId: "lk:propose-mutation:abc",
+      metadata: { action: "create_product", proposedInput: { name: "Widget", price: 9.9 } },
+    };
+    const event = makeRunFinishedEvent({
+      threadId: "thread_1",
+      runId: "run_a",
+      outcome: makeInterruptOutcome([interrupt]),
+    });
+
+    const parsed = RunFinishedEventSchema.safeParse(event);
+    expect(parsed.success).toBe(true);
+    if (parsed.success && parsed.data.outcome?.type === "interrupt") {
+      expect(parsed.data.outcome.interrupts[0]?.id).toBe("int_1");
+    }
+  });
+
+  test("a success outcome parses on the success branch", () => {
+    const event = makeRunFinishedEvent({
+      threadId: "thread_1",
+      runId: "run_b",
+      outcome: { type: "success" },
+    });
+
+    const parsed = RunFinishedEventSchema.safeParse(event);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.outcome?.type).toBe("success");
+    }
   });
 });

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/index.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/index.ts
@@ -22,10 +22,17 @@ export type {
   BaseEvent,
   Context,
   CustomEvent,
+  // Human-in-the-loop (Spec 71) interrupt/resume types.
+  Interrupt,
   Message,
+  ResumeEntry,
+  ResumeStatus,
   RunAgentInput,
   RunErrorEvent,
   RunFinishedEvent,
+  RunFinishedInterruptOutcome,
+  RunFinishedOutcome,
+  RunFinishedSuccessOutcome,
   RunStartedEvent,
   StateDeltaEvent,
   StateSnapshotEvent,
@@ -38,7 +45,19 @@ export type {
   ToolCallEndEvent,
   ToolCallStartEvent,
 } from "./protocol";
-export { EventType, encodeSseEvent, RunAgentInputSchema } from "./protocol";
+export {
+  EventType,
+  encodeSseEvent,
+  // Human-in-the-loop (Spec 71) schemas + outcome helpers.
+  InterruptSchema,
+  makeInterruptOutcome,
+  ResumeEntrySchema,
+  RunAgentInputSchema,
+  RunFinishedEventSchema,
+  RunFinishedInterruptOutcomeSchema,
+  RunFinishedOutcomeSchema,
+  SUCCESS_OUTCOME,
+} from "./protocol";
 // Run endpoint (test seams: inject a fake AIService or a custom runner)
 export type {
   AgUiAgentRunner,
@@ -51,6 +70,7 @@ export {
   createAgUiApp,
   createAgUiRunHandler,
   DEFAULT_AG_UI_BASE_PATH,
+  makeRunFinishedEvent,
   mountAgUiRunRoute,
   toAiMessages,
   toAiTools,

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/protocol.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/protocol.ts
@@ -109,7 +109,17 @@ export const SUCCESS_OUTCOME: RunFinishedSuccessOutcome = { type: "success" };
  * `{ type: "interrupt", interrupts }`. The returned value is the exact
  * `RunFinishedInterruptOutcome` an `RUN_FINISHED.outcome` carries when a
  * model-proposed mutation is awaiting human approval.
+ *
+ * `RunFinishedInterruptOutcomeSchema` enforces `z.array(InterruptSchema).min(1)`,
+ * so an empty `interrupts` list would produce a schema-INVALID frame that fails
+ * downstream `RunFinishedEventSchema.safeParse`. Guard at the source: a caller
+ * must never be able to emit an interrupt outcome with nothing to act on.
  */
 export function makeInterruptOutcome(interrupts: Interrupt[]): RunFinishedInterruptOutcome {
+  if (interrupts.length === 0) {
+    throw new Error(
+      "makeInterruptOutcome requires at least one interrupt — RunFinishedInterruptOutcome.interrupts is .min(1).",
+    );
+  }
   return { type: "interrupt", interrupts };
 }

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/protocol.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/protocol.ts
@@ -24,12 +24,21 @@ export type {
   CustomEvent,
   DeveloperMessage,
   InputContent,
+  // Human-in-the-loop (Spec 71): interrupt/resume types. `Interrupt` and
+  // `resume` here are the AG-UI HITL vocabulary — deliberately NOT the core
+  // evolution `ProposalEngine` vocabulary (Spec 71 §3.6 naming-collision rule).
+  Interrupt,
   Message,
   MessagesSnapshotEvent,
   RawEvent,
+  ResumeEntry,
+  ResumeStatus,
   RunAgentInput,
   RunErrorEvent,
   RunFinishedEvent,
+  RunFinishedInterruptOutcome,
+  RunFinishedOutcome,
+  RunFinishedSuccessOutcome,
   RunStartedEvent,
   StateDeltaEvent,
   StateSnapshotEvent,
@@ -49,17 +58,29 @@ export type {
   ToolMessage,
   UserMessage,
 } from "@ag-ui/core";
-// ── Event type identifiers + input validation schema ────────
+// ── Event type identifiers + validation schemas ─────────────
 export {
   ContextSchema,
   EventType,
+  // Human-in-the-loop (Spec 71) schemas — call THEIR `.safeParse`/`.parse`
+  // directly (zod-3); never compose them into local zod-4 schemas.
+  InterruptSchema,
   MessageSchema,
+  ResumeEntrySchema,
   RunAgentInputSchema,
+  RunFinishedEventSchema,
+  RunFinishedInterruptOutcomeSchema,
+  RunFinishedOutcomeSchema,
   ToolCallSchema,
   ToolSchema,
 } from "@ag-ui/core";
 
-import type { AGUIEvent } from "@ag-ui/core";
+import type {
+  AGUIEvent,
+  Interrupt,
+  RunFinishedInterruptOutcome,
+  RunFinishedSuccessOutcome,
+} from "@ag-ui/core";
 
 // ── SSE framing (local — not provided by @ag-ui/core) ───────
 
@@ -69,4 +90,26 @@ import type { AGUIEvent } from "@ag-ui/core";
  */
 export function encodeSseEvent(event: AGUIEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+// ── Human-in-the-loop run-outcome helpers (Spec 71 §3.1, §4.2) ──
+//
+// The AG-UI HITL protocol carries an approval interrupt as an optional
+// `outcome` field on `RUN_FINISHED` (there is no dedicated INTERRUPT event —
+// Spec 71 §3.1). A run that needs approval *finishes* with
+// `outcome.type === "interrupt"`; the approval + resume is a new run on the
+// same `threadId`. These helpers build those outcomes against the upstream
+// schema so the rest of the addon never hand-writes the discriminated shape.
+
+/** The plain success run outcome (`{ type: "success" }`). */
+export const SUCCESS_OUTCOME: RunFinishedSuccessOutcome = { type: "success" };
+
+/**
+ * Build a typed interrupt run-outcome (Spec 71 §3.4 / §4.2):
+ * `{ type: "interrupt", interrupts }`. The returned value is the exact
+ * `RunFinishedInterruptOutcome` an `RUN_FINISHED.outcome` carries when a
+ * model-proposed mutation is awaiting human approval.
+ */
+export function makeInterruptOutcome(interrupts: Interrupt[]): RunFinishedInterruptOutcome {
+  return { type: "interrupt", interrupts };
 }

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/run-endpoint.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/run-endpoint.ts
@@ -30,11 +30,44 @@ import {
   encodeSseEvent,
   type RunAgentInput,
   RunAgentInputSchema,
+  type RunFinishedEvent,
+  type RunFinishedOutcome,
   type TextInputContent,
 } from "./protocol";
 
 /** Emit callback handed to a custom agent runner. Drops events after disconnect. */
 export type AgUiEmit = (event: AGUIEvent) => void;
+
+/**
+ * Build a `RUN_FINISHED` protocol frame, optionally carrying a run `outcome`
+ * (Spec 71 §3.1 / §4.2).
+ *
+ * The AG-UI HITL protocol delivers an approval interrupt as an optional
+ * `outcome` on `RUN_FINISHED` (there is no dedicated INTERRUPT event). This
+ * helper is the single place that constructs the finish frame so the addon
+ * never hand-writes the optional/nullable `outcome` shape.
+ *
+ * Backward-compatible by construction: when `outcome` is omitted the frame is
+ * byte-identical to the pre-HITL `{ type, threadId, runId }` finish — the
+ * `outcome` key is only added when an outcome is actually supplied. Upstream
+ * types `outcome` as `z.optional(z.nullable(...))`, so an absent outcome and a
+ * plain finish encode identically.
+ */
+export function makeRunFinishedEvent(options: {
+  threadId: string;
+  runId: string;
+  outcome?: RunFinishedOutcome;
+}): RunFinishedEvent {
+  const { threadId, runId, outcome } = options;
+  return {
+    type: EventType.RUN_FINISHED,
+    threadId,
+    runId,
+    // Only attach `outcome` when present so a no-outcome finish stays
+    // byte-identical to the legacy frame (no `outcome: undefined` key).
+    ...(outcome ? { outcome } : {}),
+  };
+}
 
 /**
  * Custom agent runner seam.
@@ -199,7 +232,10 @@ function createRunEventStream(options: {
           // Host-injected full-assistant runner (system prompt + server-side
           // tools + multi-step). The endpoint keeps the RUN_* frame.
           await runner({ input, emit, signal, request });
-          emit({ type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId });
+          // P1: route the finish through the outcome-capable builder. With no
+          // outcome supplied this emits the byte-identical legacy frame; P2
+          // will let the runner hand back an interrupt descriptor here.
+          emit(makeRunFinishedEvent({ threadId: input.threadId, runId: input.runId }));
           return;
         }
 
@@ -250,7 +286,7 @@ function createRunEventStream(options: {
           }
         }
 
-        emit({ type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId });
+        emit(makeRunFinishedEvent({ threadId: input.threadId, runId: input.runId }));
       } catch (err) {
         emit({
           type: EventType.RUN_ERROR,


### PR DESCRIPTION
## What

**Spec 71 Phase 1** (parent #555) — the protocol foundation for native AG-UI human-in-the-loop governance of the assistant write path. Closes #598.

No behavior change yet. This phase only:
1. re-exports the AG-UI 0.0.56 interrupt/resume surface through the addon's one allow-list (`protocol.ts`), and
2. makes the `RUN_FINISHED` frame *capable* of carrying an interrupt `outcome` — keeping the current no-outcome emission byte-identical.

P2 (the execute-less `proposeMutation` tool + interrupt-on-run-end + resume→CommandLayer) builds on this.

## Changes

- **`protocol.ts`** — extend the `@ag-ui/core` re-export allow-list with `Interrupt`, `ResumeEntry`, `ResumeStatus`, `RunFinishedOutcome`, `RunFinishedInterruptOutcome`, `RunFinishedSuccessOutcome` + the matching Zod schemas. Add `makeInterruptOutcome(interrupts)` and `SUCCESS_OUTCOME`, typed against the upstream schemas (no `any`).
- **`run-endpoint.ts`** — add `makeRunFinishedEvent({ threadId, runId, outcome? })` and route **both** existing inline `RUN_FINISHED` emit sites through it. When no `outcome` is passed the key is omitted entirely → the no-outcome wire form is byte-identical to the prior literal (existing SSE happy-path tests assert the exact frame). `AgUiAgentRunner`'s signature is unchanged — the runner-returns-descriptor change is P2 (§4.3).
- **`index.ts`** — mirror the new public exports.

## Verification

- New tests: `makeInterruptOutcome`/`SUCCESS_OUTCOME` shape; `RunFinishedEvent`-with-outcome round-trips through `RunFinishedEventSchema.safeParse`; a no-outcome finish is unchanged; `ResumeEntrySchema` accepts resolved/cancelled payloads; `InterruptSchema` shape.
- `bun test ./addons/adapter-ag-ui/` → **48 pass / 0 fail**.
- `bun test ./addons/adapter-server/` (the consumer of the run endpoint) → **914 pass / 0 fail**.
- `bun run typecheck` + `bun run check` clean. `core` untouched, no new deps.

Spec: `docs/specs/71_agui_hitl_governance.md` (§3 protocol surface, §4.2 data shapes, §7 P1 row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)