### PR TITLE
fix(adapter-server): instruct the model to USE proposeMutation (Spec 71 HITL keystone)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
@@ -283,6 +283,35 @@ describe("buildSystemPrompt — mutation-policy suffix", () => {
     expect(prompt).not.toContain("NEVER claim");
   });
 
+  // Spec 71 HITL keystone (found via live testing): with the execute-less
+  // proposeMutation tool available, the prompt must INSTRUCT the model to
+  // propose writes — NOT the old "you CANNOT write, use the sidebar" refusal
+  // that left the whole HITL path dead because the model never called the tool.
+  test("proposeMutation=true instructs the model to PROPOSE via the tool, not refuse", () => {
+    const prompt = buildSystemPrompt({
+      allowActionExecution: false,
+      proposeMutation: true,
+    });
+    // Tells the model to USE proposeMutation for writes.
+    expect(prompt).toContain("proposeMutation");
+    expect(prompt).toContain("PROPOSES a data change");
+    // Still forbids claiming the write happened (it only proposes).
+    expect(prompt).toContain("NEVER claim");
+    // Must NOT carry the refuse-to-write / sidebar-redirect policy.
+    expect(prompt).not.toContain("CANNOT directly create");
+    expect(prompt).not.toContain("use its create / edit / action buttons");
+  });
+
+  test("proposeMutation takes precedence over allowActionExecution=false", () => {
+    const propose = buildSystemPrompt({ allowActionExecution: false, proposeMutation: true });
+    const refuse = buildSystemPrompt({ allowActionExecution: false });
+    expect(propose).toContain("proposeMutation");
+    expect(propose).not.toContain("CANNOT directly create");
+    // The plain read-only path still gets the refusal.
+    expect(refuse).toContain("CANNOT directly create");
+    expect(refuse).not.toContain("proposeMutation");
+  });
+
   test("mutation-policy suffix is the LAST section — nothing of substance follows", () => {
     const ontology = createMockOntologyRegistry([productDescriptor, orderDescriptor]);
     const prompt = buildSystemPrompt({

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
@@ -312,6 +312,37 @@ describe("buildSystemPrompt — mutation-policy suffix", () => {
     expect(refuse).not.toContain("proposeMutation");
   });
 
+  test("a write-enabled session never gets the contradictory propose policy", () => {
+    // allowActionExecution=true means the model executes directly (executeAction).
+    // The propose policy ("You do NOT execute writes yourself") would contradict
+    // that, so a write-enabled session gets NEITHER policy even if proposeMutation
+    // is accidentally also passed.
+    const prompt = buildSystemPrompt({ allowActionExecution: true, proposeMutation: true });
+    expect(prompt).not.toContain("PROPOSES a data change");
+    expect(prompt).not.toContain("CANNOT directly create");
+  });
+
+  test("propose-policy suffix is the LAST section — the override-proofing invariant", () => {
+    const ontology = createMockOntologyRegistry([productDescriptor, orderDescriptor]);
+    const prompt = buildSystemPrompt({
+      assistantConfig: { systemPrompt: "You are a product catalog assistant." },
+      ontologyRegistry: ontology,
+      context: {
+        entity: "product",
+        recordId: "p-001",
+        recordData: { name: "Laptop", price: 999 },
+        locale: "zh-CN",
+      },
+      allowActionExecution: false,
+      proposeMutation: true,
+    });
+    const parts = prompt.split("## Mutation Policy");
+    expect(parts.length).toBe(2); // exactly one occurrence of the header
+    const tail = parts[1] ?? "";
+    // Everything after the header is the suffix body — no later section header.
+    expect(tail).not.toContain("\n## ");
+  });
+
   test("mutation-policy suffix is the LAST section — nothing of substance follows", () => {
     const ontology = createMockOntologyRegistry([productDescriptor, orderDescriptor]);
     const prompt = buildSystemPrompt({

--- a/addons/adapter-server/cap-adapter-server/src/ai/agui-runner.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/agui-runner.ts
@@ -531,14 +531,18 @@ export function createAssistantAgUiRunner(
     const recordId = agUiContextValue(input, AG_UI_CONTEXT_KEYS.recordId);
     const locale = extractLocale(agUiContextValue(input, AG_UI_CONTEXT_KEYS.locale), request);
 
-    // Chat is read-only — writes go through the propose-and-confirm flow
-    // (intent resolver + ActionProposalCard). See issue #285 / #238.
+    // Spec 71 HITL: the runner exposes the execute-less `proposeMutation` tool
+    // (below), so the prompt instructs the model to PROPOSE writes via that tool
+    // — NOT the old "you cannot write, use the sidebar" refusal. The model still
+    // never executes; a proposal surfaces an approval card and a human approval
+    // runs the action through CommandLayer (§6.5). `executeAction` stays OFF.
     const systemPrompt = buildSystemPrompt({
       assistantConfig,
       ontologyRegistry: options.ontologyRegistry,
       entityRegistry: options.entityRegistry,
       context: { entity, recordId, locale },
       allowActionExecution: false,
+      proposeMutation: true,
     });
 
     const tools = buildTools({

--- a/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
@@ -246,10 +246,15 @@ export function buildSystemPrompt(options: {
   //    Defaults are aligned with `buildTools`: undefined / true → write-
   //    enabled, no suffix. Chat callers always pass `false` here AND to
   //    `buildTools` so the two stay consistent.
-  // The propose-mutation policy (Spec 71 HITL) takes precedence: the model has
-  // the execute-less `proposeMutation` tool and must be told to USE it, not the
-  // refuse-to-write policy. Fall back to the read-only refusal otherwise.
-  if (proposeMutation) {
+  // The propose-mutation policy (Spec 71 HITL) takes precedence over the
+  // refuse-to-write policy: the model has the execute-less `proposeMutation` tool
+  // and must be told to USE it. It is gated on `allowActionExecution !== true`,
+  // though: when the session is genuinely write-enabled (the model executes
+  // directly via `executeAction`), "You do NOT execute writes yourself" would be
+  // a flat contradiction — so a write-enabled session gets neither policy. The
+  // HITL caller pairs `proposeMutation: true` with `allowActionExecution: false`,
+  // so it always lands on the propose policy.
+  if (proposeMutation && allowActionExecution !== true) {
     parts.push(`\n${PROPOSE_POLICY_SUFFIX}`);
   } else if (allowActionExecution === false) {
     parts.push(`\n${MUTATION_POLICY_SUFFIX}`);

--- a/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
@@ -88,6 +88,27 @@ You CANNOT directly create, update, delete, or modify any data via this chat. Th
 - For read-only requests ("show me", "what is", "summarize", "查看", "总结") use the available query / describe / navigate tools normally.`;
 
 /**
+ * Mutation policy for the AG-UI HITL path (Spec 71): the model has an execute-less
+ * `proposeMutation` tool. Unlike {@link MUTATION_POLICY_SUFFIX} — which tells the
+ * model it CANNOT write and to redirect the user to the sidebar — this tells the
+ * model to PROPOSE the write via the tool. The proposal surfaces an approval card;
+ * nothing executes until a human approves and the action runs through CommandLayer
+ * ("AI Never Modifies Production Directly"). Without this the model, told it cannot
+ * write, never calls `proposeMutation` and the whole HITL path stays dead — the
+ * gap a real model (not the scripted test mock) exposes.
+ *
+ * Appended LAST so a user-supplied prompt can never override it.
+ */
+const PROPOSE_POLICY_SUFFIX = `## Mutation Policy (HARD CONSTRAINT — non-negotiable)
+You do NOT execute writes yourself. You have a \`proposeMutation\` tool that PROPOSES a data change for a human to approve — it does not run anything.
+- For any user request involving a write (create / add / submit / approve / reject / delete / update / modify / change / 创建 / 添加 / 提交 / 批准 / 拒绝 / 删除 / 更新 / 修改), you MUST call \`proposeMutation\` with:
+  - \`action\`: the business action name to run (e.g. \`create_product\`, \`approve_order\`). Pick from the entity's "Available actions" listed above; if none fits, say so instead of inventing one.
+  - \`input\`: the field values for that action, extracted from the user's request.
+- Calling \`proposeMutation\` surfaces an approval card; the human reviews/edits the inputs and approves, and only THEN does the action execute through the system's permission checks. You are PROPOSING, not executing.
+- NEVER claim you performed the operation. Do NOT say "created", "saved", "submitted", "done", "成功", "完成", "已创建" — you only propose; the human approves and the system executes.
+- For read-only requests ("show me", "what is", "summarize", "查看", "总结") use the query / describe / navigate tools normally — do NOT call \`proposeMutation\` for reads.`;
+
+/**
  * Build a dynamic system prompt based on assistant config and runtime context.
  */
 export function buildSystemPrompt(options: {
@@ -108,9 +129,24 @@ export function buildSystemPrompt(options: {
    * `buildSystemPrompt` and `buildTools`.
    */
   allowActionExecution?: boolean;
+  /**
+   * Spec 71 HITL: the session exposes the execute-less `proposeMutation` tool.
+   * When `true`, the prompt instructs the model to PROPOSE writes via the tool
+   * (see {@link PROPOSE_POLICY_SUFFIX}) instead of the refuse-to-write
+   * {@link MUTATION_POLICY_SUFFIX}. The model still never executes — proposing
+   * surfaces an approval card, and a human approval runs the action through
+   * CommandLayer. Takes precedence over `allowActionExecution === false`.
+   */
+  proposeMutation?: boolean;
 }): string {
-  const { assistantConfig, ontologyRegistry, entityRegistry, context, allowActionExecution } =
-    options;
+  const {
+    assistantConfig,
+    ontologyRegistry,
+    entityRegistry,
+    context,
+    allowActionExecution,
+    proposeMutation,
+  } = options;
 
   const parts: string[] = [];
 
@@ -210,7 +246,12 @@ export function buildSystemPrompt(options: {
   //    Defaults are aligned with `buildTools`: undefined / true → write-
   //    enabled, no suffix. Chat callers always pass `false` here AND to
   //    `buildTools` so the two stay consistent.
-  if (allowActionExecution === false) {
+  // The propose-mutation policy (Spec 71 HITL) takes precedence: the model has
+  // the execute-less `proposeMutation` tool and must be told to USE it, not the
+  // refuse-to-write policy. Fall back to the read-only refusal otherwise.
+  if (proposeMutation) {
+    parts.push(`\n${PROPOSE_POLICY_SUFFIX}`);
+  } else if (allowActionExecution === false) {
     parts.push(`\n${MUTATION_POLICY_SUFFIX}`);
   }
 


### PR DESCRIPTION
## What

**Keystone wiring fix for the Spec 71 AG-UI HITL path — found by live testing**, not unit tests.

Driving the real `/api/agui/run` endpoint with *"Create a product named Widget price 9.9"* made the model only **chat** ("use the create / action buttons to initiate the operation") and the run finished with a **plain `RUN_FINISHED` — NO interrupt outcome**. The whole P1→P3 HITL path was wired but **dead**.

### Root cause

P2a (#605) registered the execute-less `proposeMutation` tool on the assistant runner, but the runner still built its system prompt with `allowActionExecution:false`, which appends `MUTATION_POLICY_SUFFIX`:

> "You **CANNOT** directly create, update, delete, or modify any data via this chat ... tell the user explicitly that you cannot perform writes from chat ... open the entity in the sidebar and use its create / edit / action buttons."

So the prompt **actively forbade** the model from proposing writes — it correctly (per its prompt) refused and never called `proposeMutation`. The scripted `MockLanguageModelV3` in the P2a/P3 unit tests *always* calls the tool, so green tests never exercised this — exactly the wiring-class gap a real model exposes.

## Fix

- **`system-prompt.ts`** — add `PROPOSE_POLICY_SUFFIX` + a `proposeMutation` option. When set, the prompt tells the model to **PROPOSE** writes via `proposeMutation` (`action` + `input`); the proposal surfaces an approval card, a human approves, and only then does the action run through CommandLayer (§6.5). It still forbids claiming the write happened. Takes precedence over the read-only refusal.
- **`agui-runner.ts`** — pass `proposeMutation: true` (the runner exposes the tool). `executeAction` stays OFF — proposing ≠ executing.

## Verification

- New unit tests: `proposeMutation=true` → propose guidance, NOT the "CANNOT directly create" refusal; precedence over `allowActionExecution=false`. `bun test ./addons/adapter-server/` → **947 pass**. typecheck + biome clean.
- ⚠️ The **end-to-end live proof** (the model actually emitting the interrupt) is currently **blocked by an expired GLM/zhipu provider token** (environment, not code — `RUN_ERROR "令牌已过期或验证不正确"`). The unit tests lock the prompt behavior; the §8 browser e2e (P5) proves it once the token is refreshed.

Spec: `docs/specs/71_agui_hitl_governance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)