### PR TITLE
feat(demo): Partner→Sales reference modules — cross-capability in-place extension (live-proven)

### DIFF
--- a/config/capabilities.ts
+++ b/config/capabilities.ts
@@ -16,6 +16,11 @@ import { capAdapterUi } from "@linchkit/cap-adapter-ui";
 import { createCapChatter } from "@linchkit/cap-chatter";
 import { capPurchaseDemo } from "@linchkit/cap-purchase-demo";
 import type { CapabilityDefinition } from "@linchkit/core";
+// Reference/demo capabilities for the in-place extension (Odoo `_inherit`) demo.
+// Authored as plain modules (not workspace packages) so they resolve through the
+// worktree's symlinked node_modules; imported here via relative path.
+import { partnerCapability } from "./capabilities/partner";
+import { salesCapability } from "./capabilities/sales";
 
 // Side-effect imports: register UI panels in the panel/route registry
 import "@linchkit/cap-chatter-ui";
@@ -52,4 +57,9 @@ export const capabilities: CapabilityDefinition[] = [
 
   // Business modules
   capPurchaseDemo,
+  // In-place extension demo: cap-sales adds `credit_limit` to cap-partner's
+  // `partner` entity + `partner_form` view IN PLACE (no fork). Order does not
+  // matter — extensions are folded after all caps are collected.
+  partnerCapability,
+  salesCapability,
 ];

--- a/config/capabilities/__tests__/partner-extension.test.ts
+++ b/config/capabilities/__tests__/partner-extension.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Headless proof for the cap-partner + cap-sales in-place extension demo.
+ *
+ * This is the deterministic, DB-free, port-free guard that runs BEFORE the live
+ * browser e2e (e2e/browser/partner-extension.test.ts). It imports the REAL demo
+ * capability modules (the same ones config/capabilities.ts registers) and the
+ * REAL `assembleDevSchema` — the exact assembly `bun run dev:server` exercises,
+ * minus starting the HTTP server — and proves the `credit_limit` field added by
+ * cap-sales is visible END-TO-END through every downstream consumer:
+ *
+ *   1. the entity registry resolve('partner') surfaces it (type number),
+ *   2. the built GraphQL `Partner` type exposes it (GraphQL reads RAW
+ *      `entity.fields`, so this catches a half-wired fix), and
+ *   3. the contributed `partner_form` view gains the field — while the
+ *      untargeted `partner_list` view stays untouched.
+ *
+ * Modelled on
+ * addons/adapter-server/cap-adapter-server/__tests__/capability-extension-wiring.test.ts,
+ * but against the SHIPPED demo modules rather than inline fixtures. In-process
+ * only (`graphqlSync` introspection); NEVER `app.listen` (segfaults the batched
+ * runner). `assembleDevSchema` falls back to InMemoryStore so it needs no DB.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { assembleDevSchema, capAdapterServer } from "@linchkit/cap-adapter-server";
+import {
+  getIntrospectionQuery,
+  graphqlSync,
+  type IntrospectionObjectType,
+  type IntrospectionQuery,
+} from "graphql";
+import { partnerCapability } from "../partner";
+import { salesCapability } from "../sales";
+
+/** Introspect a built schema and return the named object type, or undefined. */
+function introspectType(
+  schema: ReturnType<typeof assembleDevSchema>["schema"],
+  typeName: string,
+): IntrospectionObjectType | undefined {
+  const result = graphqlSync({ schema, source: getIntrospectionQuery() });
+  expect(result.errors).toBeUndefined();
+  const data = result.data as unknown as IntrospectionQuery;
+  const type = data.__schema.types.find((t) => t.name === typeName);
+  return type?.kind === "OBJECT" ? (type as IntrospectionObjectType) : undefined;
+}
+
+describe("cap-partner + cap-sales in-place extension (dev:server path, end-to-end)", () => {
+  it("entity registry resolve('partner') surfaces the cap-sales credit_limit field", () => {
+    const assembled = assembleDevSchema([capAdapterServer, partnerCapability, salesCapability]);
+    const resolved = assembled.runtime.entityRegistry.resolve("partner");
+    expect(Object.keys(resolved.fields)).toContain("credit_limit");
+    expect(resolved.fields.credit_limit?.definition.type).toBe("number");
+  });
+
+  it("the built GraphQL `Partner` type exposes credit_limit", () => {
+    const assembled = assembleDevSchema([capAdapterServer, partnerCapability, salesCapability]);
+    const partnerType = introspectType(assembled.schema, "Partner");
+    expect(partnerType).toBeDefined();
+    const fieldNames = (partnerType?.fields ?? []).map((f) => f.name);
+    // toCamelCase leaves snake_case field names as-is in the GraphQL object type.
+    expect(fieldNames).toContain("credit_limit");
+  });
+
+  it("the contributed `partner_form` view gains credit_limit; `partner_list` is untouched", () => {
+    const assembled = assembleDevSchema([capAdapterServer, partnerCapability, salesCapability]);
+
+    const form = assembled.contributions.views.find((v) => v.name === "partner_form");
+    expect(form).toBeDefined();
+    expect(form?.fields.map((f) => f.field)).toEqual([
+      "name",
+      "email",
+      "phone",
+      "is_company",
+      "credit_limit",
+    ]);
+
+    const list = assembled.contributions.views.find((v) => v.name === "partner_list");
+    expect(list).toBeDefined();
+    expect(list?.fields.map((f) => f.field)).toEqual(["name", "email"]);
+  });
+});

--- a/config/capabilities/partner.ts
+++ b/config/capabilities/partner.ts
@@ -1,0 +1,72 @@
+/**
+ * cap-partner — base capability for the in-place extension demo.
+ *
+ * Reference/demo module (NOT an npm workspace package). It is authored as a
+ * plain TypeScript module so `config/linchkit.config.ts` can import it via a
+ * relative path: the worktree's `node_modules` is a symlink to the main
+ * checkout, so a brand-new `addons/*` workspace package would not resolve here.
+ * Promotable to a real `addons/partner/cap-partner` package later.
+ *
+ * It defines the `partner` entity plus a `partner_form` (form) and a
+ * `partner_list` (list) view. The form view deliberately has NO explicit
+ * `layout` so it renders straight from `fields[]` — that way a field appended
+ * by an extension capability (see ./sales.ts) automatically surfaces in the
+ * rendered form. This is the LinchKit analogue of Odoo's `_inherit` model.
+ */
+
+import { defineCapability, defineView, type EntityDefinition } from "@linchkit/core";
+
+// ── Entity ───────────────────────────────────────────────────────────────────
+
+const partnerEntity: EntityDefinition = {
+  name: "partner",
+  label: "Partner",
+  description: "A business contact — a person or a company",
+  presentation: {
+    titleField: "name",
+    summaryFields: ["email", "phone"],
+    icon: "users",
+  },
+  fields: {
+    name: { type: "string", required: true, label: "Name", ui: { importance: "primary" } },
+    email: { type: "string", label: "Email" },
+    phone: { type: "string", label: "Phone" },
+    is_company: { type: "boolean", label: "Is Company" },
+  },
+};
+
+// ── Views ──────────────────────────────────────────────────────────────────
+
+// No explicit `layout` — the form renders from `fields[]`, so an appended
+// extension field (credit_limit) surfaces without forking this view.
+const partnerFormView = defineView({
+  name: "partner_form",
+  entity: "partner",
+  type: "form",
+  label: "Partner",
+  fields: [{ field: "name" }, { field: "email" }, { field: "phone" }, { field: "is_company" }],
+});
+
+const partnerListView = defineView({
+  name: "partner_list",
+  entity: "partner",
+  type: "list",
+  label: "Partners",
+  fields: [
+    { field: "name", sortable: true },
+    { field: "email", sortable: true },
+  ],
+});
+
+// ── Capability ───────────────────────────────────────────────────────────────
+
+export const partnerCapability = defineCapability({
+  name: "cap-partner",
+  label: "Partner",
+  description: "Base partner directory: the `partner` entity plus its form/list views",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [partnerEntity],
+  views: [partnerFormView, partnerListView],
+});

--- a/config/capabilities/sales.ts
+++ b/config/capabilities/sales.ts
@@ -1,0 +1,45 @@
+/**
+ * cap-sales — extension (bridge) capability for the in-place extension demo.
+ *
+ * Reference/demo module (NOT an npm workspace package). Authored as a plain
+ * TypeScript module so `config/linchkit.config.ts` can import it via a relative
+ * path (the worktree's symlinked `node_modules` would not resolve a brand-new
+ * `addons/*` workspace package). Promotable to a real
+ * `addons/sales/cap-sales` package later.
+ *
+ * This is the payload of the demo: a SEPARATE capability that patches
+ * cap-partner's `partner` entity and `partner_form` view IN PLACE — the Odoo
+ * `_inherit` model — WITHOUT forking cap-partner:
+ *
+ *   - `extendEntity("partner", …)` appends a `credit_limit` field to the entity.
+ *   - `extendView("partner_form", …)` appends `credit_limit` to the form view.
+ *
+ * Both are folded into the base definitions during boot assembly
+ * (`extractCapabilities` → `applyEntityExtensions`/`applyViewExtensions`), so
+ * every downstream consumer (GraphQL schema, CRUD, runtime registry, the
+ * rendered form) sees the merged shape.
+ */
+
+import { defineCapability, extendEntity, extendView } from "@linchkit/core";
+
+export const salesCapability = defineCapability({
+  name: "cap-sales",
+  label: "Sales",
+  description:
+    "Adds a credit limit to partners in place (extends cap-partner's `partner` " +
+    "entity + `partner_form` view) without forking the base capability",
+  type: "bridge",
+  category: "business",
+  version: "0.1.0",
+  group: "partner",
+  dependencies: ["cap-partner"],
+  autoInstall: true,
+  extensions: {
+    entities: [
+      extendEntity("partner", {
+        fields: { credit_limit: { type: "number", label: "Credit Limit" } },
+      }),
+    ],
+    views: [extendView("partner_form", { addFields: [{ field: "credit_limit" }] })],
+  },
+});

--- a/e2e/browser/partner-extension.test.ts
+++ b/e2e/browser/partner-extension.test.ts
@@ -1,0 +1,202 @@
+/**
+ * In-place capability extension — LIVE browser e2e (the Odoo `_inherit` proof).
+ *
+ * SKELETON — authored, NOT yet run. The orchestrator will run + refine this
+ * against the real stack (see "RUN" note at the bottom of bootStack()).
+ *
+ * What it proves: cap-sales adds a `credit_limit` field to cap-partner's
+ * `partner` entity + `partner_form` view IN PLACE (no fork), and that field
+ * actually RENDERS in the live, schema-driven entity form — the visible payoff
+ * of the headless guard in config/capabilities/__tests__/partner-extension.test.ts.
+ *
+ *   navigate to the partner create form (/entities/partner/new) →
+ *   the form renders the cap-sales-injected `credit_limit` field →
+ *   asserted via the form-field wrapper `[data-field="credit_limit"]`
+ *   (set by addons/adapter-ui/.../auto-form/form-field.tsx) and its
+ *   "Credit Limit" label.
+ *
+ * Boot harness mirrors e2e/browser/agui-hitl.test.ts: self-contained, on
+ * dedicated ports (:3111 API / :3110 UI) so it never collides with a hand-run
+ * dev server (:3001/:3000) or the HITL e2e (:3101/:3100). Drains child stdio so
+ * the OS pipe buffer never fills and hangs the server mid-run. NEVER calls
+ * `app.listen` in-process — it spawns the real `dev.ts` + Vite, same as HITL.
+ *
+ * Gated: self-skips unless LINCHKIT_E2E_BROWSER=1, so the normal `bun run test`
+ * batch that scans ./e2e/ stays green on machines without Chrome.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { Subprocess } from "bun";
+import type { Browser } from "puppeteer-core";
+import { BROWSER_E2E_ENABLED, launchBrowser, newTrackedPage } from "./helpers/browser";
+
+// Dedicated ports so this never clobbers a hand-run dev server (:3001/:3000) or
+// the HITL e2e (:3101/:3100).
+const API_PORT = Number(process.env.LINCHKIT_E2E_PARTNER_API_PORT ?? 3111);
+const UI_PORT = Number(process.env.LINCHKIT_E2E_PARTNER_UI_PORT ?? 3110);
+const API_URL = `http://localhost:${API_PORT}`;
+const UI_URL = `http://localhost:${UI_PORT}`;
+
+/** The schema-driven create-form route for the `partner` entity (see app.tsx). */
+const PARTNER_FORM_PATH = "/entities/partner/new";
+
+/** Booting Vite + the server is slow; give generous per-test + boot budgets. */
+const TEST_TIMEOUT_MS = 120_000;
+const BOOT_TIMEOUT_MS = 90_000;
+
+// ── server + UI boot (self-contained) ───────────────────────────────────────
+
+async function waitForUrl(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok || res.status === 404) return; // up (404 = served but no such route)
+    } catch {
+      // not ready
+    }
+    await new Promise((r) => setTimeout(r, 400));
+  }
+  throw new Error(`Timed out waiting for ${url} after ${timeoutMs}ms`);
+}
+
+interface BootedStack {
+  server: Subprocess;
+  ui: Subprocess;
+}
+
+/**
+ * Continuously drain a spawned child's stdout/stderr so its OS pipe buffer never
+ * fills. A child spawned with `stdout: "pipe"` whose pipe is never read BLOCKS on
+ * its next write once the ~64 KB buffer fills (see agui-hitl.test.ts for the full
+ * rationale). Fire-and-forget; swallow errors (the stream closes on child exit).
+ */
+function drainStream(stream: ReadableStream<Uint8Array> | null | undefined): void {
+  if (!stream) return;
+  void (async () => {
+    try {
+      const reader = stream.getReader();
+      while (!(await reader.read()).done) {
+        // discard — we only need the pipe emptied, not the contents
+      }
+    } catch {
+      // child exited / stream errored — nothing to drain
+    }
+  })();
+}
+
+/**
+ * Boot the API server + the Vite UI, each on a dedicated port. The UI dev server
+ * proxies `/api`, `/graphql`, `/health` to the API server (vite.config.ts reads
+ * LINCHKIT_UI_PROXY_TARGET), so the entity form's schema-bundle fetch reaches OUR
+ * API port. No model stub is needed — this test never touches the AI/AG-UI path.
+ *
+ * RUN (orchestrator): `LINCHKIT_E2E_BROWSER=1 bun test ./e2e/browser/partner-extension.test.ts`
+ * with a system Chrome present (LINCHKIT_CHROME_PATH or a default location).
+ */
+async function bootStack(): Promise<BootedStack> {
+  const baseEnv = {
+    ...process.env,
+    // Match the HITL harness: an explicit dev marker so the spawned server wires
+    // its dev store/feature behavior exactly as `bun run dev:server` does.
+    BUN_ENV: "development",
+  };
+
+  // Boot the API server on an isolated port. Disable its auto-started UI + MCP
+  // child transports so THIS test owns the UI port (no auto-vite-port drift) and
+  // there is no :3002 MCP collision with a hand-run dev server.
+  const server = Bun.spawn(["bun", "addons/adapter-server/cap-adapter-server/src/dev.ts"], {
+    env: {
+      ...baseEnv,
+      PORT: String(API_PORT),
+      HOST: "127.0.0.1",
+      LINCHKIT_DEV_DISABLE_TRANSPORTS: "ui,mcp",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // Drain immediately — an unread pipe buffer fills and HANGS the server mid-run.
+  drainStream(server.stdout as ReadableStream<Uint8Array>);
+  drainStream(server.stderr as ReadableStream<Uint8Array>);
+  await waitForUrl(`${API_URL}/health`, BOOT_TIMEOUT_MS);
+
+  // Boot the Vite UI in the UI package dir on our isolated port with --strictPort
+  // so it never silently drifts. LINCHKIT_UI_PROXY_TARGET points its proxy at OUR
+  // API port instead of the default :3001.
+  const ui = Bun.spawn(
+    ["bunx", "vite", "--configLoader", "runner", "--port", String(UI_PORT), "--strictPort"],
+    {
+      cwd: "addons/adapter-ui/cap-adapter-ui",
+      env: { ...baseEnv, LINCHKIT_UI_PROXY_TARGET: API_URL },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  drainStream(ui.stdout as ReadableStream<Uint8Array>);
+  drainStream(ui.stderr as ReadableStream<Uint8Array>);
+  await waitForUrl(UI_URL, BOOT_TIMEOUT_MS);
+
+  return { server, ui };
+}
+
+function killStack(stack: BootedStack | undefined): void {
+  stack?.server.kill();
+  stack?.ui.kill();
+}
+
+describe.skipIf(!BROWSER_E2E_ENABLED)("partner in-place extension browser e2e", () => {
+  let browser: Browser;
+  let stack: BootedStack | undefined;
+
+  beforeAll(async () => {
+    if (!BROWSER_E2E_ENABLED) return;
+    stack = await bootStack();
+    browser = await launchBrowser();
+  }, BOOT_TIMEOUT_MS + 10_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    killStack(stack);
+  });
+
+  test(
+    "the cap-sales credit_limit field renders on the partner create form",
+    async () => {
+      const { page, context, pageErrors } = await newTrackedPage(browser);
+      try {
+        // Navigate straight to the schema-driven partner create form. The page
+        // (EntityFormPage) fetches the entity bundle from the API and renders the
+        // `partner_form` view — which now carries the cap-sales-injected field.
+        await page.goto(`${UI_URL}${PARTNER_FORM_PATH}`, { waitUntil: "networkidle2" });
+
+        // The form-field wrapper carries `data-field="<field>"` (form-field.tsx),
+        // so the injected `credit_limit` field appears as `[data-field="credit_limit"]`.
+        // This is the authoritative proof that the IN-PLACE extension reached the UI.
+        await page.waitForSelector('[data-field="credit_limit"]', { timeout: 30_000 });
+
+        const found = await page.evaluate(() => {
+          const wrapper = document.querySelector('[data-field="credit_limit"]');
+          // The form-field label cell renders the field's "Credit Limit" label.
+          const labelHit = Array.from(document.querySelectorAll("label")).some((l) =>
+            (l.textContent ?? "").includes("Credit Limit"),
+          );
+          return { hasWrapper: !!wrapper, hasLabel: labelHit };
+        });
+        expect(found.hasWrapper).toBe(true);
+        expect(found.hasLabel).toBe(true);
+
+        // The base fields must still render (the extension AUGMENTS, not replaces).
+        const hasName = await page.$('[data-field="name"]');
+        expect(
+          hasName,
+          "base `name` field missing — extension should augment, not fork",
+        ).not.toBeNull();
+
+        expect(pageErrors.map((e) => e.message)).toHaveLength(0);
+      } finally {
+        await context.close();
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/e2e/browser/partner-extension.test.ts
+++ b/e2e/browser/partner-extension.test.ts
@@ -46,9 +46,16 @@ const BOOT_TIMEOUT_MS = 90_000;
 
 // ── server + UI boot (self-contained) ───────────────────────────────────────
 
-async function waitForUrl(url: string, timeoutMs: number): Promise<void> {
+async function waitForUrl(url: string, timeoutMs: number, proc?: Subprocess): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    // Fail fast if the spawned process already died (port collision, syntax
+    // error, crash) instead of polling uselessly until the full timeout.
+    if (proc && proc.exitCode !== null) {
+      throw new Error(
+        `Process for ${url} exited (code ${proc.exitCode}) before the URL became ready`,
+      );
+    }
     try {
       const res = await fetch(url);
       if (res.ok || res.status === 404) return; // up (404 = served but no such route)
@@ -102,41 +109,51 @@ async function bootStack(): Promise<BootedStack> {
     BUN_ENV: "development",
   };
 
-  // Boot the API server on an isolated port. Disable its auto-started UI + MCP
-  // child transports so THIS test owns the UI port (no auto-vite-port drift) and
-  // there is no :3002 MCP collision with a hand-run dev server.
-  const server = Bun.spawn(["bun", "addons/adapter-server/cap-adapter-server/src/dev.ts"], {
-    env: {
-      ...baseEnv,
-      PORT: String(API_PORT),
-      HOST: "127.0.0.1",
-      LINCHKIT_DEV_DISABLE_TRANSPORTS: "ui,mcp",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  // Drain immediately — an unread pipe buffer fills and HANGS the server mid-run.
-  drainStream(server.stdout as ReadableStream<Uint8Array>);
-  drainStream(server.stderr as ReadableStream<Uint8Array>);
-  await waitForUrl(`${API_URL}/health`, BOOT_TIMEOUT_MS);
-
-  // Boot the Vite UI in the UI package dir on our isolated port with --strictPort
-  // so it never silently drifts. LINCHKIT_UI_PROXY_TARGET points its proxy at OUR
-  // API port instead of the default :3001.
-  const ui = Bun.spawn(
-    ["bunx", "vite", "--configLoader", "runner", "--port", String(UI_PORT), "--strictPort"],
-    {
-      cwd: "addons/adapter-ui/cap-adapter-ui",
-      env: { ...baseEnv, LINCHKIT_UI_PROXY_TARGET: API_URL },
+  let server: Subprocess | undefined;
+  let ui: Subprocess | undefined;
+  try {
+    // Boot the API server on an isolated port. Disable its auto-started UI + MCP
+    // child transports so THIS test owns the UI port (no auto-vite-port drift) and
+    // there is no :3002 MCP collision with a hand-run dev server.
+    server = Bun.spawn(["bun", "addons/adapter-server/cap-adapter-server/src/dev.ts"], {
+      env: {
+        ...baseEnv,
+        PORT: String(API_PORT),
+        HOST: "127.0.0.1",
+        LINCHKIT_DEV_DISABLE_TRANSPORTS: "ui,mcp",
+      },
       stdout: "pipe",
       stderr: "pipe",
-    },
-  );
-  drainStream(ui.stdout as ReadableStream<Uint8Array>);
-  drainStream(ui.stderr as ReadableStream<Uint8Array>);
-  await waitForUrl(UI_URL, BOOT_TIMEOUT_MS);
+    });
+    // Drain immediately — an unread pipe buffer fills and HANGS the server mid-run.
+    drainStream(server.stdout as ReadableStream<Uint8Array>);
+    drainStream(server.stderr as ReadableStream<Uint8Array>);
+    await waitForUrl(`${API_URL}/health`, BOOT_TIMEOUT_MS, server);
 
-  return { server, ui };
+    // Boot the Vite UI in the UI package dir on our isolated port with --strictPort
+    // so it never silently drifts. LINCHKIT_UI_PROXY_TARGET points its proxy at OUR
+    // API port instead of the default :3001.
+    ui = Bun.spawn(
+      ["bunx", "vite", "--configLoader", "runner", "--port", String(UI_PORT), "--strictPort"],
+      {
+        cwd: "addons/adapter-ui/cap-adapter-ui",
+        env: { ...baseEnv, LINCHKIT_UI_PROXY_TARGET: API_URL },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+    drainStream(ui.stdout as ReadableStream<Uint8Array>);
+    drainStream(ui.stderr as ReadableStream<Uint8Array>);
+    await waitForUrl(UI_URL, BOOT_TIMEOUT_MS, ui);
+
+    return { server, ui };
+  } catch (err) {
+    // A boot failure (timeout / early crash) must not leak the already-spawned
+    // children as orphaned background processes — kill whatever started.
+    ui?.kill();
+    server?.kill();
+    throw err;
+  }
 }
 
 function killStack(stack: BootedStack | undefined): void {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -140,6 +140,7 @@ run_batch "packages/core"     ./packages/core/
 run_batch "packages/devtools" ./packages/devtools/
 run_batch "packages/starters" ./packages/starters/
 run_batch "scripts"           ./scripts/
+run_batch "config"            ./config/
 run_batch "e2e"               ./e2e/
 run_batch "addons"            ./addons/
 

--- a/scripts/verify-test-coverage.sh
+++ b/scripts/verify-test-coverage.sh
@@ -36,6 +36,7 @@ packages/devtools/
 packages/starters/
 packages/cli/
 scripts/
+config/
 e2e/
 addons/
 "


### PR DESCRIPTION
## What & why

The first greenfield demo on the foundation #619 just landed: now that the boot paths honor `extensions.entities`/`extensions.views` (the Odoo `_inherit` model), prove it with **two separate capabilities** where module B extends module A's entity **and** view **in place, without forking** — the core of "组件化 ERP".

## Modules

- **`cap-partner`** (base, standard): `partner` entity (`name`/`email`/`phone`/`is_company`) + `partner_form` (no explicit layout → renders from `fields[]`) + `partner_list`.
- **`cap-sales`** (bridge, `autoInstall` on `cap-partner`): `extendEntity("partner", { credit_limit })` + `extendView("partner_form", { addFields: [credit_limit] })`. No fork of cap-partner.
- Registered in `config/capabilities.ts`.

## Proof

- **Headless guardrail** (`config/capabilities/__tests__/partner-extension.test.ts`, 3 tests): `credit_limit` reaches `entityRegistry.resolve("partner")`, the built GraphQL `Partner` type (introspected), and the `partner_form` view — while the untargeted `partner_list` is unchanged.
- **Live browser e2e** (`e2e/browser/partner-extension.test.ts`, opt-in `LINCHKIT_E2E_BROWSER=1`): boots the real dev:server + UI, opens `/entities/partner/new`, asserts `[data-field="credit_limit"]` renders alongside the base `[data-field="name"]`. **Already run green locally** — the real "on-site" proof that the cross-capability injection works on the running stack, not just in units.

## Notes

- The two capabilities are plain TS under `config/` because a fresh worktree's symlinked `node_modules` can't resolve a brand-new workspace package; they're promotable to real `addons/*` packages later.
- The browser e2e self-skips unless `LINCHKIT_E2E_BROWSER=1`, so the normal suite never tries to boot a browser in CI.

## Verification

biome ✓ · typecheck ✓ · headless 3/3 ✓ · live browser e2e ✓ (local, opt-in).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Partner capability module with entity definition including name, email, phone, and company fields, along with form and list views.
  * Added Sales capability that extends Partner with a Credit Limit field, demonstrating in-place extension functionality.

* **Tests**
  * Added capability module test suite and browser E2E tests to verify extension behavior and field visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->