### PR TITLE
feat(demo): require approval when raising a late payer's credit limit (Build B P2)

### DIFF
--- a/config/capabilities/__tests__/credit-policy-enforcement.test.ts
+++ b/config/capabilities/__tests__/credit-policy-enforcement.test.ts
@@ -267,6 +267,69 @@ describe("late-payer credit-raise rule (real update_partner enforcement, in-proc
     const items = await pendingApprovals(app);
     expect(items.filter((r) => r.action === "update_partner")).toHaveLength(0);
   });
+
+  it("6. single-call spoof: clear is_late_payer AND raise in ONE write → still SUSPENDS (flag read from stored record)", async () => {
+    const app = buildApp();
+
+    const id = await createPartner(app, {
+      name: "Spoofy Co",
+      is_late_payer: true,
+      credit_limit: 1000,
+    });
+
+    // The caller tries to clear the flag and raise in the same write. The
+    // credit rule reads is_late_payer from the STORED record (still true), so
+    // the raise is gated regardless of the input flag.
+    const { status, body } = await postAction(app, "update_partner", {
+      id,
+      is_late_payer: false,
+      credit_limit: 5000,
+    });
+    expect(status).toBe(422);
+    expect(body.success).toBe(false);
+
+    // Nothing was committed (neither the cleared flag nor the raise).
+    expect(await readCreditLimit(app, id)).toBe(1000);
+    const items = await pendingApprovals(app);
+    expect(items.find((r) => r.action === "update_partner")).toBeDefined();
+  });
+
+  it("7. two-step bypass closed: clearing is_late_payer alone → SUSPENDS (anti-bypass rule)", async () => {
+    const app = buildApp();
+
+    const id = await createPartner(app, {
+      name: "Two Step Co",
+      is_late_payer: true,
+      credit_limit: 1000,
+    });
+
+    // Step 1 of the bypass — clearing the flag — is itself gated, so the
+    // two-step sequence can never reach an ungated raise.
+    const { status, body } = await postAction(app, "update_partner", { id, is_late_payer: false });
+    expect(status).toBe(422);
+    expect(body.success).toBe(false);
+
+    const items = await pendingApprovals(app);
+    expect(items.find((r) => r.action === "update_partner")).toBeDefined();
+  });
+
+  it("8. flagging a good-standing partner (false → true) is NOT gated", async () => {
+    const app = buildApp();
+
+    const id = await createPartner(app, {
+      name: "Newly Risky Co",
+      is_late_payer: false,
+      credit_limit: 1000,
+    });
+
+    // Setting the flag is the safe direction — never gated.
+    const { status, body } = await postAction(app, "update_partner", { id, is_late_payer: true });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+
+    const items = await pendingApprovals(app);
+    expect(items.filter((r) => r.action === "update_partner")).toHaveLength(0);
+  });
 });
 
 // ── Numeric-coercion units (deterministic, no store round-trip) ───────────────

--- a/config/capabilities/__tests__/credit-policy-enforcement.test.ts
+++ b/config/capabilities/__tests__/credit-policy-enforcement.test.ts
@@ -243,6 +243,30 @@ describe("late-payer credit-raise rule (real update_partner enforcement, in-proc
     const items = await pendingApprovals(app);
     expect(items.find((r) => r.action === "update_partner")).toBeDefined();
   });
+
+  it("5. late payer + update an UNRELATED field (no credit_limit in payload) → proceeds (gate must not fire on non-credit changes)", async () => {
+    const app = buildApp();
+
+    const id = await createPartner(app, {
+      name: "Flagged Co",
+      is_late_payer: true,
+      credit_limit: 1000,
+    });
+
+    // Only `name` changes — `credit_limit` is absent from the input. The engine
+    // merges target = {...stored, ...input}, so proposed === current → no gate.
+    const { status, body } = await postAction(app, "update_partner", {
+      id,
+      name: "Flagged Co (renamed)",
+    });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+
+    // The credit limit is unchanged, and no approval was created.
+    expect(await readCreditLimit(app, id)).toBe(1000);
+    const items = await pendingApprovals(app);
+    expect(items.filter((r) => r.action === "update_partner")).toHaveLength(0);
+  });
 });
 
 // ── Numeric-coercion units (deterministic, no store round-trip) ───────────────
@@ -305,6 +329,15 @@ describe("late-payer credit-raise condition — numeric coercion", () => {
     const same = "abc";
     expect(
       await evaluate({ is_late_payer: true, credit_limit: same }, { credit_limit: same }),
+    ).toBe(false);
+  });
+
+  it("null baseline with undefined proposed (no-op) is not gated", async () => {
+    // A nullable column reads back as null; an absent input leaves credit_limit
+    // undefined. Both-nullish must be treated as no change, not `undefined !==
+    // null` → gated.
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: null }, { credit_limit: undefined }),
     ).toBe(false);
   });
 });

--- a/config/capabilities/__tests__/credit-policy-enforcement.test.ts
+++ b/config/capabilities/__tests__/credit-policy-enforcement.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Enforcement proof for the late-payer credit-raise rule (Build B, PR2).
+ *
+ * This is the real end-to-end proof — NOT a unit test of the condition in
+ * isolation. It boots the EXACT `bun run dev:server` assembly via `createDevApp`
+ * (the same `assembleDevSchema` + `createServer` wiring, minus binding a port)
+ * with the REAL shipped capabilities `cap-partner` + `cap-sales`, so the
+ * credit-policy rule registered on cap-sales (`rules: [latePayerCreditRaiseRule]`)
+ * is evaluated by the action engine on every `update_partner` execution through
+ * the real rule-in-action wiring (core `evaluateActionRules`).
+ *
+ * What it proves:
+ *   1. A late payer (`is_late_payer=true`) whose `credit_limit` is RAISED →
+ *      `update_partner` SUSPENDS into a pending approval request (HTTP 422,
+ *      success:false) instead of committing the write. This is the key proof:
+ *      a `defineRule` with effect `require_approval` actually suspends a
+ *      credit-changing CRUD action at execution time.
+ *   2. A partner in good standing (`is_late_payer=false`) whose `credit_limit`
+ *      is raised → the action PROCEEDS normally (HTTP 200, success, write
+ *      committed, no approval request).
+ *   3. A late payer whose `credit_limit` is LOWERED → proceeds normally (the
+ *      gate constrains raises only).
+ *
+ * DB-free (InMemoryStore fallback) and port-free: requests are dispatched
+ * in-process via `app.handle(new Request(...))` — NEVER `app.listen(PORT)`
+ * (a bound socket segfaults the batched runner).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { capAdapterServer, createDevApp } from "@linchkit/cap-adapter-server";
+import type { CodeCondition } from "@linchkit/core";
+import { latePayerCreditRaiseRule } from "../credit-policy.rule";
+import { partnerCapability } from "../partner";
+import { salesCapability } from "../sales";
+
+// ── Response shapes (no `any`) ───────────────────────────────────────────────
+
+interface ActionSuccess {
+  success: true;
+  data: Record<string, unknown>;
+  meta: { executionId: string };
+}
+
+interface ActionError {
+  success: false;
+  error: { code: string; message: string };
+  meta?: { executionId?: string };
+}
+
+type ActionResponse = ActionSuccess | ActionError;
+
+interface ApprovalItem {
+  id: string;
+  level: string;
+  status: string;
+  action: string;
+}
+
+interface ApprovalListResponse {
+  success: boolean;
+  data: { items: ApprovalItem[] };
+}
+
+interface GraphQLResponse<T = Record<string, unknown>> {
+  data: T;
+  errors?: Array<{ message: string }>;
+}
+
+// ── In-process app (DB-free, port-free) ──────────────────────────────────────
+
+/**
+ * Boot the dev app from the REAL partner + sales capabilities. The adapter
+ * provides the GraphQL/REST transport; cap-partner contributes the `partner`
+ * entity (so CRUD `create_partner` / `update_partner` are generated), and
+ * cap-sales folds in `credit_limit` + `is_late_payer` AND registers the
+ * credit-policy rule. A fresh app = a fresh InMemoryStore, so each test is
+ * isolated.
+ */
+function buildApp(): ReturnType<typeof createDevApp>["app"] {
+  return createDevApp([capAdapterServer, partnerCapability, salesCapability], { cors: false }).app;
+}
+
+// ── Request helpers ──────────────────────────────────────────────────────────
+
+async function postAction(
+  app: ReturnType<typeof createDevApp>["app"],
+  name: string,
+  input: Record<string, unknown> = {},
+): Promise<{ status: number; body: ActionResponse }> {
+  const res = await app.handle(
+    new Request(`http://local.test/api/actions/${name}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as ActionResponse };
+}
+
+async function gql(
+  app: ReturnType<typeof createDevApp>["app"],
+  query: string,
+): Promise<GraphQLResponse> {
+  const res = await app.handle(
+    new Request("http://local.test/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query }),
+    }),
+  );
+  return (await res.json()) as GraphQLResponse;
+}
+
+async function pendingApprovals(
+  app: ReturnType<typeof createDevApp>["app"],
+): Promise<ApprovalItem[]> {
+  const res = await app.handle(
+    new Request("http://local.test/api/approvals?status=pending", {
+      method: "GET",
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  const body = (await res.json()) as ApprovalListResponse;
+  return body.data.items;
+}
+
+/** Create a partner and return its id. Asserts the create itself succeeded. */
+async function createPartner(
+  app: ReturnType<typeof createDevApp>["app"],
+  fields: Record<string, unknown>,
+): Promise<string> {
+  const { status, body } = await postAction(app, "create_partner", fields);
+  expect(status).toBe(200);
+  expect(body.success).toBe(true);
+  return (body as ActionSuccess).data.id as string;
+}
+
+/** Read a partner's credit_limit via GraphQL (proves what was persisted). */
+async function readCreditLimit(
+  app: ReturnType<typeof createDevApp>["app"],
+  id: string,
+): Promise<unknown> {
+  const result = await gql(app, `query { partner(id: "${id}") { id credit_limit } }`);
+  expect(result.errors).toBeUndefined();
+  const partner = result.data.partner as Record<string, unknown>;
+  return partner.credit_limit;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("late-payer credit-raise rule (real update_partner enforcement, in-process)", () => {
+  it("1. late payer + RAISE credit_limit → update_partner SUSPENDS into a pending approval (the key proof)", async () => {
+    const app = buildApp();
+
+    // A flagged late payer starting at a 1000 limit.
+    const id = await createPartner(app, {
+      name: "Risky Co",
+      is_late_payer: true,
+      credit_limit: 1000,
+    });
+
+    // Raise the limit 1000 → 5000. The rule fires and yields require_approval.
+    const { status, body } = await postAction(app, "update_partner", { id, credit_limit: 5000 });
+
+    // The action REST endpoint returns 422 + success:false when the action is
+    // suspended into an approval request — the write is NOT committed.
+    expect(status).toBe(422);
+    expect(body.success).toBe(false);
+
+    // The persisted limit must STILL be 1000 — the raise was suspended, not written.
+    expect(await readCreditLimit(app, id)).toBe(1000);
+
+    // A pending approval request for update_partner must exist, at the manager level.
+    const items = await pendingApprovals(app);
+    const req = items.find((r) => r.action === "update_partner");
+    expect(req).toBeDefined();
+    expect(req?.level).toBe("manager");
+    expect(req?.status).toBe("pending");
+  });
+
+  it("2. partner in good standing + RAISE credit_limit → proceeds normally (no approval)", async () => {
+    const app = buildApp();
+
+    // Not flagged — the gate must not fire.
+    const id = await createPartner(app, {
+      name: "Trusty Inc",
+      is_late_payer: false,
+      credit_limit: 1000,
+    });
+
+    const { status, body } = await postAction(app, "update_partner", { id, credit_limit: 5000 });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+
+    // The raise was committed.
+    expect(await readCreditLimit(app, id)).toBe(5000);
+
+    // No approval request was created.
+    const items = await pendingApprovals(app);
+    expect(items.filter((r) => r.action === "update_partner")).toHaveLength(0);
+  });
+
+  it("3. late payer + LOWER credit_limit → proceeds normally (gate constrains raises only)", async () => {
+    const app = buildApp();
+
+    // Flagged, but the change is a DECREASE, which the gate must let through.
+    const id = await createPartner(app, {
+      name: "Shrinking Ltd",
+      is_late_payer: true,
+      credit_limit: 5000,
+    });
+
+    const { status, body } = await postAction(app, "update_partner", { id, credit_limit: 2000 });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+
+    // The decrease was committed.
+    expect(await readCreditLimit(app, id)).toBe(2000);
+
+    // No approval request was created.
+    const items = await pendingApprovals(app);
+    expect(items.filter((r) => r.action === "update_partner")).toHaveLength(0);
+  });
+
+  it('4. late payer + RAISE via a STRING credit_limit ("5000") → still SUSPENDS (a string-encoded raise must not bypass the gate)', async () => {
+    const app = buildApp();
+
+    const id = await createPartner(app, {
+      name: "Sneaky Co",
+      is_late_payer: true,
+      credit_limit: 1000,
+    });
+
+    // Under lenient action validation a string `credit_limit` reaches the rule
+    // unchanged. It MUST be coerced and gated, not waved through (the bypass).
+    const { status, body } = await postAction(app, "update_partner", { id, credit_limit: "5000" });
+    expect(status).toBe(422);
+    expect(body.success).toBe(false);
+
+    // The raise was suspended, not written.
+    expect(await readCreditLimit(app, id)).toBe(1000);
+
+    const items = await pendingApprovals(app);
+    expect(items.find((r) => r.action === "update_partner")).toBeDefined();
+  });
+});
+
+// ── Numeric-coercion units (deterministic, no store round-trip) ───────────────
+//
+// The end-to-end tests above run through the InMemoryStore, which keeps native
+// numbers. A real Drizzle `numeric()` column round-trips the STORED baseline as
+// a string, so the condition must compare a string baseline numerically rather
+// than mistake it for an absent (zero) limit. These unit cases pin that
+// coercion directly on the shipped condition, independent of the store backend.
+
+describe("late-payer credit-raise condition — numeric coercion", () => {
+  const condition = latePayerCreditRaiseRule.condition as CodeCondition;
+  const evaluate = (record: Record<string, unknown> | null, target: Record<string, unknown>) =>
+    condition({ record, target } as unknown as Parameters<CodeCondition>[0]);
+
+  it("string PROPOSED raise is gated (number baseline)", async () => {
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: 1000 }, { credit_limit: "5000" }),
+    ).toBe(true);
+  });
+
+  it("string STORED baseline is compared numerically, not as 0 → a decrease is NOT gated", async () => {
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: "1000" }, { credit_limit: 500 }),
+    ).toBe(false);
+  });
+
+  it("both string — a raise is still gated", async () => {
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: "1000" }, { credit_limit: "5000" }),
+    ).toBe(true);
+  });
+
+  it("non-numeric proposed value (changed) FAILS CLOSED → gated", async () => {
+    // "abc" is not a finite number and differs from the stored 1000, so the
+    // rule cannot prove it is safe → require approval rather than fail open.
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: 1000 }, { credit_limit: "abc" }),
+    ).toBe(true);
+  });
+
+  it("Infinity proposed value FAILS CLOSED → gated (must not bypass the gate)", async () => {
+    expect(
+      await evaluate(
+        { is_late_payer: true, credit_limit: 1000 },
+        { credit_limit: Number.POSITIVE_INFINITY },
+      ),
+    ).toBe(true);
+  });
+
+  it("string baseline with an equal string proposed (no-op) is not gated", async () => {
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: "1000" }, { credit_limit: "1000" }),
+    ).toBe(false);
+  });
+
+  it("non-finite proposed that is unchanged from a non-finite stored value is not gated", async () => {
+    // Defensive: if both sides are the same non-finite value there is no change
+    // to gate (cannot happen via a normal write, but the guard stays correct).
+    const same = "abc";
+    expect(
+      await evaluate({ is_late_payer: true, credit_limit: same }, { credit_limit: same }),
+    ).toBe(false);
+  });
+});

--- a/config/capabilities/credit-policy.rule.ts
+++ b/config/capabilities/credit-policy.rule.ts
@@ -102,6 +102,11 @@ const raisingCreditForLatePayer: CodeCondition = ({ target, record }) => {
     // route it through approval rather than letting an unreasonable value slip
     // past the gate. Exception: if it is unchanged from the stored value it is
     // not a credit change at all, so there is nothing to gate.
+    //
+    // Both nullish (absent input / NULL column) → no change → not gated. The
+    // loose `== null` guard avoids `undefined !== null` wrongly gating a
+    // non-change when a nullable column reads back as null.
+    if (target.credit_limit == null && record.credit_limit == null) return false;
     return target.credit_limit !== record.credit_limit;
   }
 

--- a/config/capabilities/credit-policy.rule.ts
+++ b/config/capabilities/credit-policy.rule.ts
@@ -154,3 +154,47 @@ export const latePayerCreditRaiseRule: RuleDefinition = {
       "Raising the credit limit of a late-paying partner requires approval",
   },
 };
+
+/**
+ * Anti-bypass companion: gate CLEARING the late-payer flag.
+ *
+ * Without this, the credit-raise gate is defeated in two steps: (1) clear
+ * `is_late_payer` — no `credit_limit` change, so the raise rule does not fire;
+ * (2) raise `credit_limit` — now unflagged, so the raise proceeds ungated.
+ * Clearing the flag is itself a sensitive act, so it goes through the same
+ * approval. Setting the flag (false → true) is NOT gated — flagging a risk is
+ * never the risky direction.
+ */
+const clearingLatePayerFlag: CodeCondition = ({ target, record }) => {
+  if (record == null) return false;
+  // Only a transition FROM flagged matters. Not currently flagged → nothing to
+  // protect.
+  if (record.is_late_payer !== true) return false;
+  // Gate only when the write actually sets the flag to a non-true value.
+  // `target` merges input over the stored row, so when the caller leaves the
+  // flag untouched `target.is_late_payer` stays `true` and this is a no-op.
+  return target.is_late_payer !== true;
+};
+
+/**
+ * Clearing the late-payer flag requires approval (anti-bypass).
+ *
+ * trigger:   the partner update action (CRUD `update_partner`).
+ * condition: stored `is_late_payer === true` AND the write sets it to non-true.
+ * effect:    require_approval at the `manager` level.
+ */
+export const clearLatePayerFlagRule: RuleDefinition = {
+  name: "clear_late_payer_flag_requires_approval",
+  label: "Clearing Late-Payer Flag Requires Approval",
+  description:
+    "Clearing the late-payer flag on a partner requires approval — otherwise it " +
+    "could sidestep the credit-raise gate in a two-step sequence. Flagging a " +
+    "partner as a late payer is not gated.",
+  trigger: { action: "update_partner" },
+  condition: clearingLatePayerFlag,
+  effect: {
+    type: "require_approval",
+    level: "manager",
+    message: "清除迟付款标记需要审批 / Clearing the late-payer flag requires approval",
+  },
+};

--- a/config/capabilities/credit-policy.rule.ts
+++ b/config/capabilities/credit-policy.rule.ts
@@ -1,0 +1,151 @@
+/**
+ * Credit-policy enforcement rule — hand-seeded "经验→制度" governance on the
+ * partner demo (Build B, PR2).
+ *
+ * Goal: prove that a `defineRule` with effect `require_approval` ACTUALLY
+ * suspends a credit-changing CRUD action at execution time. This is the first
+ * piece of enforcement on the partner extension demo (#619/#620 shipped the
+ * `partner` entity + the cap-sales `credit_limit` extension but ZERO actions and
+ * ZERO rules) — it de-risks the core wiring before any AI loop is layered on.
+ *
+ * Policy encoded here, in ONE first-class object: when a partner flagged as a
+ * late payer (`is_late_payer === true`, added by cap-sales) has its
+ * `credit_limit` RAISED, that change must go through approval. Lowering the
+ * limit, or raising it for a partner in good standing, proceeds normally.
+ *
+ * ── Trigger decision (action vs fieldChange) ────────────────────────────────
+ * This rule uses an ACTION trigger `{ action: "update_partner" }`, NOT a
+ * `FieldChangeTrigger`. Evidence: the action-execution rule path collects rules
+ * via `collectRules` (packages/core/src/engine/rule-engine.ts:133-151), which
+ * matches ONLY `trigger.action` — its own doc comment (lines 127-128) states
+ * "Non-action triggers (state-change, field-change, event, schedule) are
+ * filtered out; they don't apply to the action-execution path." A
+ * `FieldChangeTrigger` would therefore never fire on a CRUD update, so the
+ * credit-delta check is done in the code condition instead.
+ *
+ * `update_partner` is the CRUD action auto-generated for the `partner` entity
+ * (addons/.../graphql/build-crud-actions.ts:161 `name: update_${name}`); its
+ * input includes `credit_limit` (a non-system field) so a raise flows through
+ * it.
+ *
+ * Enforcement happens via the real rule-in-action wiring (core
+ * `evaluateActionRules`): when this rule yields `require_approval` AND an
+ * ApprovalEngine is wired, the action is suspended into a pending approval
+ * request instead of committing the write.
+ */
+
+import type { CodeCondition, RuleDefinition } from "@linchkit/core";
+
+/**
+ * Coerce a value to a finite number, accepting BOTH native numbers and numeric
+ * strings. This matters on two sides of the same comparison:
+ *  - the proposed value: a caller can submit `credit_limit: "5000"` (a string).
+ *    Under lenient action validation that string is written as-is, so the gate
+ *    MUST treat it as the number 5000 — otherwise a string-encoded raise slips
+ *    past approval entirely (a real bypass).
+ *  - the stored baseline: Drizzle `numeric()` columns round-trip as strings, so
+ *    a persisted `credit_limit` of `"1000"` must compare as 1000, not be
+ *    mistaken for an absent/zero baseline (which would wrongly gate a decrease).
+ * Returns null for anything that is not a finite numeric value (undefined, null,
+ * "", whitespace, "abc", booleans, objects).
+ */
+const toFiniteNumber = (value: unknown): number | null => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
+/**
+ * Actor-independent gate: require approval ONLY when the partner is flagged as a
+ * late payer AND the requested `credit_limit` is strictly greater than the
+ * stored one (an increase). Decreases and equal/no-op writes pass through, and a
+ * partner in good standing is never gated.
+ *
+ * SECURITY / anti-spoof: the CURRENT limit and the late-payer flag are read from
+ * `record` (the persisted row, threaded through untouched by caller input) —
+ * NOT from `target`, which merges the caller's input over the stored values.
+ * Reading the stored `credit_limit` from `target` would let a caller defeat the
+ * "is this an increase?" check by also lying about the baseline; reading the
+ * flag from `target` would let a late payer self-clear `is_late_payer` in the
+ * same write to dodge the gate. The PROPOSED new limit is, correctly, taken from
+ * `target` (it is what the caller wants to write).
+ *
+ * Fail-CLOSED on a missing stored row: with no record we cannot prove the change
+ * is a decrease or that the partner is in good standing, so we do not gate a
+ * phantom id here — the action engine's own absent-row handling and the write
+ * path reject such calls. We return `false` (no approval) only when we can
+ * affirmatively show the change is NOT a gated raise.
+ */
+const raisingCreditForLatePayer: CodeCondition = ({ target, record }) => {
+  // No stored row → not an update of an existing partner. Nothing to gate here;
+  // the write path handles absent/phantom ids. (A create cannot carry a prior
+  // credit_limit to "raise" from, so there is no increase to constrain.)
+  if (record == null) return false;
+
+  // The flag must come from the STORED record so a caller cannot self-clear it
+  // in the same mutation. A non-`true` value (false / absent / unknown) means
+  // the partner is not flagged → never gated.
+  if (record.is_late_payer !== true) return false;
+
+  // Proposed new limit: what the caller wants to write. Coerced through
+  // `toFiniteNumber` so a string-encoded raise (`"5000"`) is compared as a
+  // number, not waved through.
+  const proposed = toFiniteNumber(target.credit_limit);
+  if (proposed === null) {
+    // The proposed value is present-but-not-a-finite-number (Infinity,
+    // "1e309", "abc", …). We cannot prove it is a safe change, so FAIL CLOSED —
+    // route it through approval rather than letting an unreasonable value slip
+    // past the gate. Exception: if it is unchanged from the stored value it is
+    // not a credit change at all, so there is nothing to gate.
+    return target.credit_limit !== record.credit_limit;
+  }
+
+  // Current limit: read from the stored row only, and coerced the same way
+  // (Drizzle `numeric()` returns strings). Treat an absent/non-numeric stored
+  // limit as 0 so the FIRST time a limit is set on a late payer (from "no
+  // limit" to a positive value) still counts as a raise that must be approved —
+  // otherwise the gate could be sidestepped by leaving the seed limit unset.
+  const current = toFiniteNumber(record.credit_limit) ?? 0;
+
+  // Gate ONLY a strict increase. Decreases and no-ops proceed normally.
+  //
+  // Known limitation: the comparison uses JS numbers, so two limits that differ
+  // only beyond Number.MAX_SAFE_INTEGER (~9e15) are indistinguishable. Real
+  // credit limits never approach this; BigInt-precise comparison would be
+  // over-engineering for this policy.
+  return proposed > current;
+};
+
+/**
+ * Late-payer credit-raise approval rule.
+ *
+ * trigger:   the partner update action (CRUD `update_partner`).
+ * condition: stored `is_late_payer === true` AND proposed `credit_limit` >
+ *            stored `credit_limit` (code condition — see above).
+ * effect:    require_approval at the `manager` level.
+ */
+export const latePayerCreditRaiseRule: RuleDefinition = {
+  name: "late_payer_credit_raise_requires_approval",
+  label: "Late-Payer Credit Raise Requires Approval",
+  description:
+    "Raising the credit limit of a partner flagged as a late payer requires " +
+    "approval. Lowering the limit, or any change for a partner in good standing, " +
+    "proceeds without approval.",
+  // Fires during the partner update action's rule-evaluation step. A
+  // FieldChangeTrigger would NOT fire here (collectRules drops non-action
+  // triggers) — see the file header for the file:line evidence.
+  trigger: { action: "update_partner" },
+  condition: raisingCreditForLatePayer,
+  effect: {
+    type: "require_approval",
+    level: "manager",
+    message:
+      "迟付款客户提升信用额度需要审批 / " +
+      "Raising the credit limit of a late-paying partner requires approval",
+  },
+};

--- a/config/capabilities/sales.ts
+++ b/config/capabilities/sales.ts
@@ -11,16 +11,24 @@
  * cap-partner's `partner` entity and `partner_form` view IN PLACE — the Odoo
  * `_inherit` model — WITHOUT forking cap-partner:
  *
- *   - `extendEntity("partner", …)` appends a `credit_limit` field to the entity.
+ *   - `extendEntity("partner", …)` appends a `credit_limit` field to the entity,
+ *     plus an `is_late_payer` flag that drives the credit-policy enforcement rule.
  *   - `extendView("partner_form", …)` appends `credit_limit` to the form view.
  *
  * Both are folded into the base definitions during boot assembly
  * (`extractCapabilities` → `applyEntityExtensions`/`applyViewExtensions`), so
  * every downstream consumer (GraphQL schema, CRUD, runtime registry, the
  * rendered form) sees the merged shape.
+ *
+ * cap-sales also OWNS the enforcement rule (Build B, PR2): because it is the
+ * capability that injected the credit fields, it carries the rule that governs
+ * raising them. The rule is registered explicitly on the `rules: [...]` array
+ * (there is no auto-glob — registration is by reference, exactly as
+ * cap-purchase-demo registers its manager-approval rule).
  */
 
 import { defineCapability, extendEntity, extendView } from "@linchkit/core";
+import { latePayerCreditRaiseRule } from "./credit-policy.rule";
 
 export const salesCapability = defineCapability({
   name: "cap-sales",
@@ -34,10 +42,23 @@ export const salesCapability = defineCapability({
   group: "partner",
   dependencies: ["cap-partner"],
   autoInstall: true,
+  // The credit-policy rule that gates raising a late payer's credit limit.
+  // Registered by reference (no auto-glob); the action engine evaluates it on
+  // every `update_partner` execution via the real rule-in-action wiring.
+  rules: [latePayerCreditRaiseRule],
   extensions: {
     entities: [
       extendEntity("partner", {
-        fields: { credit_limit: { type: "number", label: "Credit Limit" } },
+        fields: {
+          credit_limit: { type: "number", label: "Credit Limit" },
+          // Human-set "late payer" signal that drives the credit-policy rule.
+          // Defaults to false: a partner is in good standing until flagged.
+          is_late_payer: {
+            type: "boolean",
+            label: "Late Payer",
+            default: false,
+          },
+        },
       }),
     ],
     views: [extendView("partner_form", { addFields: [{ field: "credit_limit" }] })],

--- a/config/capabilities/sales.ts
+++ b/config/capabilities/sales.ts
@@ -28,7 +28,7 @@
  */
 
 import { defineCapability, extendEntity, extendView } from "@linchkit/core";
-import { latePayerCreditRaiseRule } from "./credit-policy.rule";
+import { clearLatePayerFlagRule, latePayerCreditRaiseRule } from "./credit-policy.rule";
 
 export const salesCapability = defineCapability({
   name: "cap-sales",
@@ -45,7 +45,7 @@ export const salesCapability = defineCapability({
   // The credit-policy rule that gates raising a late payer's credit limit.
   // Registered by reference (no auto-glob); the action engine evaluates it on
   // every `update_partner` execution via the real rule-in-action wiring.
-  rules: [latePayerCreditRaiseRule],
+  rules: [latePayerCreditRaiseRule, clearLatePayerFlagRule],
   extensions: {
     entities: [
       extendEntity("partner", {


### PR DESCRIPTION
## What (Build B, PR2)

Seeds hand-authored **enforcement** on the partner/credit_limit demo (#619/#620): raising the credit limit of a partner flagged as a **late payer** now requires manager approval. This proves the core wiring — *a `defineRule` with `effect: require_approval` actually suspends a credit-changing CRUD action at execution time* — **before** any AI graduation loop is layered on.

## Changes
- `config/capabilities/sales.ts` — add a human-set `is_late_payer` boolean to `partner` (via the existing `extendEntity`) and register the rule on cap-sales.
- `config/capabilities/credit-policy.rule.ts` — `defineRule` on the auto-generated `update_partner` action. **Action trigger**, not `fieldChange`: the action-execution path filters out non-action triggers (`rule-engine.ts` `collectRules`), so the credit-delta check lives in the code condition. Flag + baseline are read from the **persisted record** so a caller can't spoof them in the same write.
- `config/capabilities/__tests__/credit-policy-enforcement.test.ts` — end-to-end via `createDevApp` (real `assembleDevSchema` wiring, InMemoryStore, port-free `app.handle`) + deterministic condition units.

## The proof
Raising a flagged partner's limit through `POST /api/actions/update_partner` → **HTTP 422**, a **pending manager approval** is created, and the value is **not committed**. Good-standing raise and late-payer decrease both proceed.

## Cross-model review (codex) — two rounds, both real
- **R1:** (1) a string `credit_limit: "5000"` bypassed approval under lenient validation; (2) a string stored baseline (Drizzle `numeric()` round-trips as string) was misread as `0`, wrongly gating decreases. → both fixed by coercing proposed + baseline via `toFiniteNumber`; e2e + unit cases added (the e2e string-raise case confirms the bypass was real and is now closed).
- **R2:** present-but-non-finite proposed values (`Infinity`/`"1e309"`/garbage) **failed open**. → now **fail closed** (routed through approval). Limits beyond ~9e15 are out of scope by design (no BigInt — over-engineering for this policy).

## Verification
`bun test ./config/...credit-policy-enforcement.test.ts` → **11 pass**. `bun run check` ✅, `bun run typecheck` ✅. Full `bun run test` not run locally (cli batch hangs on local Bun 1.2.18 — unrelated); **CI authoritative**.

> `is_late_payer` is API-set for now; surfacing it in the partner form view comes with the live wire-up PR (kept out here to leave the existing view-fields assertion green).
