### PR TITLE
fix(chatter): wire the missing chatterAddMessage mutation (Build B P1)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-chatter-permission.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-chatter-permission.test.ts
@@ -1,0 +1,268 @@
+/**
+ * E2E Test: cap-chatter's `chatterAddMessage` write is enforced by the real
+ * CommandLayer permission slot.
+ *
+ * `chatterAddMessage` is a capability-contributed GraphQL mutation that is NOT
+ * backed by a meta-model Action — it writes a plain Drizzle row via
+ * `ChatterService.createMessage`. It is raw-merged into the schema's Mutation
+ * type (`...extraMutationFields`), so it does NOT route through
+ * `dispatchAction → commandLayer.execute` and would otherwise SKIP the permission
+ * slot — violating "All API endpoints go through CommandLayer".
+ *
+ * The fix injects a host-built `authorizeChatterWrite` hook onto the GraphQL
+ * context. cap-chatter calls it before writing; the host implementation runs a
+ * CommandLayer non-action dispatch (`skipActionSlots: true`) carrying
+ * `meta.recordWrite = { entity }`, which the real cap-permission middleware
+ * resolves to an entity-level WRITE check on the target record's entity.
+ *
+ * This test wires the REAL `cap-permission` + the REAL `cap-chatter` through
+ * `createDevApp(...)` — real GraphQL schema, real CommandLayer pipeline,
+ * InMemoryStore (DB-free) — driven in-process via `app.handle(new Request(...))`.
+ * No mock of the permission decision.
+ *
+ * Proves:
+ *   (a) an actor WITHOUT write access to the target entity is DENIED, and NO
+ *       chatter message is persisted (read-back via `chatterMessages` is empty);
+ *   (b) an actor WITH write access is ALLOWED and the message persists;
+ *   (c) the gate is WRITE-specific: a read-only actor (data.read:"all",
+ *       data.write:"none") is still denied — proving the slot evaluates WRITE
+ *       access, not mere existence/read.
+ */
+
+import { beforeAll, describe, expect, it } from "bun:test";
+import { createCapChatter } from "@linchkit/cap-chatter";
+import { createCapPermission } from "@linchkit/cap-permission";
+import type {
+  Actor,
+  CapabilityDefinition,
+  EntityDefinition,
+  PermissionGroupDefinition,
+} from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { PermissionRegistry } from "@linchkit/core/server";
+import { createDevApp } from "../src/dev-app";
+
+// ── Target entity ──────────────────────────────────────────
+//
+// `ticket` is the entity chatter comments are posted AGAINST. The chatter write
+// is gated on WRITE access to THIS entity (you may comment on a record iff you
+// may write that record's entity).
+
+const ticketEntity: EntityDefinition = {
+  name: "ticket",
+  label: "Ticket",
+  description: "Synthetic entity chatter comments are posted against",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+  },
+};
+
+const capTicketTest: CapabilityDefinition = defineCapability({
+  name: "cap-ticket-test",
+  label: "Ticket Test",
+  description: "Synthetic capability contributing the ticket entity",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [ticketEntity],
+});
+
+// ── Permission groups ──────────────────────────────────────
+//
+// The permission middleware resolves the WRITE meta-target's capability to the
+// entity name (`ticket`), so grants are keyed `permissions.ticket.ticket`.
+
+/** Full write access — may comment on tickets. */
+const ticketWriterGroup: PermissionGroupDefinition = {
+  name: "ticket_writer",
+  label: "Ticket Writer",
+  permissions: {
+    ticket: {
+      ticket: {
+        actions: {},
+        data: { read: "all", write: "all" },
+      },
+    },
+  },
+};
+
+/** Read-only — explicitly NO write access → comment must be denied. */
+const ticketReaderGroup: PermissionGroupDefinition = {
+  name: "ticket_reader",
+  label: "Ticket Reader",
+  permissions: {
+    ticket: {
+      ticket: {
+        actions: {},
+        data: { read: "all", write: "none" },
+      },
+    },
+  },
+};
+
+/**
+ * Row-level conditional WRITE — may write ONLY own-created tickets. This non-action
+ * gate carries the target `recordId` but does not load the record, so it cannot
+ * prove the condition holds for THIS row. The gate must therefore fail closed:
+ * a conditional grant must NOT be treated as a blanket allow (else a writer scoped
+ * to their own rows could comment on ANY ticket — a row-level bypass).
+ */
+const ticketConditionalWriterGroup: PermissionGroupDefinition = {
+  name: "ticket_conditional_writer",
+  label: "Ticket Conditional Writer",
+  permissions: {
+    ticket: {
+      ticket: {
+        actions: {},
+        data: {
+          read: "all",
+          write: { condition: { field: "created_by", operator: "eq", value: "$actor.id" } },
+        },
+      },
+    },
+  },
+};
+
+function buildRegistry(): PermissionRegistry {
+  const registry = new PermissionRegistry();
+  registry.register(ticketWriterGroup);
+  registry.register(ticketReaderGroup);
+  registry.register(ticketConditionalWriterGroup);
+  return registry;
+}
+
+// ── Actor wiring ───────────────────────────────────────────
+
+const TOKENS: Record<string, Actor> = {
+  "Bearer writer": { type: "human", id: "writer-1", groups: ["ticket_writer"] },
+  "Bearer reader": { type: "human", id: "reader-1", groups: ["ticket_reader"] },
+  // Conditional write grant ("own rows only") → must NOT pass the entity-level gate.
+  "Bearer conditional": {
+    type: "human",
+    id: "conditional-1",
+    groups: ["ticket_conditional_writer"],
+  },
+  // Group not in the registry → engine default-deny.
+  "Bearer stranger": { type: "human", id: "stranger-1", groups: ["unregistered_group"] },
+};
+
+function resolveRequestActor(request: Request): Actor | undefined {
+  const auth = request.headers.get("authorization");
+  if (!auth) return undefined; // → ANONYMOUS_ACTOR (no groups)
+  return TOKENS[auth];
+}
+
+// ── App + helpers ──────────────────────────────────────────
+
+const GQL_URL = "http://local.test/graphql";
+
+let app: ReturnType<typeof createDevApp>["app"];
+
+beforeAll(() => {
+  // Fresh chatter instance (its own InMemoryChatterService) so the write
+  // resolver and the read query share one store, isolated to this test file.
+  const capChatter = createCapChatter();
+  const capPermission = createCapPermission({ registry: buildRegistry() });
+  // The REAL cap-permission middleware occupies the `permission` slot, so the
+  // dev allow-all stub is NOT injected — denials below are genuine.
+  app = createDevApp([capTicketTest, capChatter, capPermission], {
+    cors: false,
+    resolveRequestActor,
+  }).app;
+});
+
+interface GqlResult {
+  data?: Record<string, unknown> | null;
+  errors?: Array<{ message: string }>;
+}
+
+async function gql(query: string, auth?: string): Promise<GqlResult> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (auth) headers.authorization = auth;
+  const res = await app.handle(
+    new Request(GQL_URL, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ query }),
+    }),
+  );
+  return (await res.json()) as GqlResult;
+}
+
+/** Read back how many chatter messages exist on a ticket record. */
+async function messageCount(recordId: string): Promise<number> {
+  const read = await gql(
+    `query { chatterMessages(entityName: "ticket", recordId: "${recordId}") { totalCount } }`,
+    "Bearer writer",
+  );
+  const conn = read.data?.chatterMessages as { totalCount: number } | undefined;
+  return conn?.totalCount ?? 0;
+}
+
+const ADD = (recordId: string, body: string) =>
+  `mutation { chatterAddMessage(entityName: "ticket", recordId: "${recordId}", messageType: comment, body: "${body}") { id body author { id } } }`;
+
+// ── Tests ──────────────────────────────────────────────────
+
+describe("E2E chatter write through the real permission slot (in-process HTTP)", () => {
+  it("(a) ALLOWS a writer to comment — message persists", async () => {
+    const result = await gql(ADD("rec-allow", "looks good"), "Bearer writer");
+
+    expect(result.errors).toBeUndefined();
+    const msg = result.data?.chatterAddMessage as {
+      id: string;
+      body: string;
+      author: { id: string };
+    };
+    expect(msg.id).toBeDefined();
+    expect(msg.body).toBe("looks good");
+    // Author derived server-side from the resolved actor.
+    expect(msg.author.id).toBe("writer-1");
+
+    expect(await messageCount("rec-allow")).toBe(1);
+  });
+
+  it("(b) DENIES a read-only actor — WRITE-specific gate, nothing persisted", async () => {
+    const result = await gql(ADD("rec-deny-reader", "blocked"), "Bearer reader");
+
+    // The denial originates from the real permission slot: the resolver's
+    // authorize hook ran a CommandLayer non-action dispatch, cap-permission threw
+    // AuthorizationError (no WRITE access), the hook re-threw, and the resolver
+    // aborted. graphql-yoga masks the message, but the operation is unambiguously
+    // denied and the field resolves to null.
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBeGreaterThan(0);
+    expect(result.data?.chatterAddMessage ?? null).toBeNull();
+
+    // Side effect must NOT have happened.
+    expect(await messageCount("rec-deny-reader")).toBe(0);
+  });
+
+  it("DENIES a conditional (row-level) writer — gate fails closed on conditions, nothing persisted", async () => {
+    // The actor HAS write access, but only conditionally ("own rows"). The
+    // entity-level gate cannot evaluate that condition against this record, so it
+    // must deny rather than treat the condition as a blanket allow. Otherwise this
+    // actor could comment on any ticket, not just their own.
+    const result = await gql(ADD("rec-deny-conditional", "blocked"), "Bearer conditional");
+
+    expect(result.errors).toBeDefined();
+    expect(result.data?.chatterAddMessage ?? null).toBeNull();
+    expect(await messageCount("rec-deny-conditional")).toBe(0);
+  });
+
+  it("DENIES a stranger whose groups are not registered — default-deny, nothing persisted", async () => {
+    const result = await gql(ADD("rec-deny-stranger", "blocked"), "Bearer stranger");
+
+    expect(result.errors).toBeDefined();
+    expect(result.data?.chatterAddMessage ?? null).toBeNull();
+    expect(await messageCount("rec-deny-stranger")).toBe(0);
+  });
+
+  it("DENIES an anonymous (no-token) actor — no groups, nothing persisted", async () => {
+    const result = await gql(ADD("rec-deny-anon", "blocked"));
+
+    expect(result.errors).toBeDefined();
+    expect(result.data?.chatterAddMessage ?? null).toBeNull();
+    expect(await messageCount("rec-deny-anon")).toBe(0);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/authorize-record-write.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/authorize-record-write.ts
@@ -1,0 +1,70 @@
+/**
+ * Build a standalone "may this actor WRITE this record's entity" permission
+ * gate, backed by the CommandLayer.
+ *
+ * Some capability-contributed GraphQL mutations are NOT backed by a meta-model
+ * Action and therefore cannot route through `dispatchAction → commandLayer`
+ * (which is how every CRUD / action mutation gets the permission slot). The
+ * canonical example is cap-chatter's `chatterAddMessage`: it posts a comment by
+ * writing a plain Drizzle row, not by executing an Action. Raw-merging that
+ * resolver into the schema would let the write skip the permission slot — the
+ * exact invariant ("All API endpoints go through CommandLayer") this guards.
+ *
+ * The CommandLayer already exposes a standalone authorization seam: a non-action
+ * dispatch (`skipActionSlots: true`) runs `pre → auth → permission → tenant`
+ * WITHOUT executing an action, and the permission middleware resolves a
+ * `meta.recordWrite = { entity }` target to an entity-level WRITE check
+ * (mirroring the onchange `meta.onchange` read-target). This helper drives that
+ * seam: it returns a hook the GraphQL context carries, which the chatter resolver
+ * calls before writing. A denial surfaces as a non-success ActionResult; the hook
+ * throws so the resolver aborts the write.
+ */
+
+import type { Actor, CommandLayer } from "@linchkit/core";
+
+/** Input to the record-write authorization gate. */
+export interface AuthorizeRecordWriteInput {
+  /** Entity the record belongs to (the write is gated on WRITE access to this). */
+  entityName: string;
+  /** Record id within that entity (forwarded for tracing / future row-level gates). */
+  recordId: string;
+  /** Request actor, already resolved by the auth slot upstream. */
+  actor: Actor;
+  /** Tenant scope for the write, when present. */
+  tenantId?: string;
+}
+
+/**
+ * Create the record-write authorization hook from a CommandLayer.
+ *
+ * The returned function runs a non-action CommandLayer dispatch that exercises
+ * the real permission slot and THROWS when the actor is not permitted. The
+ * synthetic command name is for metrics/tracing only — the authoritative target
+ * is published in `meta.recordWrite`, so a group never has to grant the
+ * synthetic name.
+ */
+export function createAuthorizeRecordWrite(
+  commandLayer: CommandLayer,
+): (input: AuthorizeRecordWriteInput) => Promise<void> {
+  return async ({ entityName, recordId, actor, tenantId }) => {
+    const result = await commandLayer.execute({
+      command: `${entityName}.record_write`,
+      input: { entity: entityName, recordId },
+      actor,
+      channel: "http",
+      tenantId,
+      meta: {
+        recordWrite: { entity: entityName, recordId },
+      },
+      skipActionSlots: true,
+    });
+
+    if (!result.success) {
+      const errData = result.data as Record<string, unknown> | undefined;
+      const message =
+        (errData?.error as string | undefined) ??
+        `Permission denied: cannot write to "${entityName}".`;
+      throw new Error(message);
+    }
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -95,6 +95,24 @@ export interface GraphQLContext {
   entityMap?: Map<string, EntityDefinition>;
   /** Per-request DataLoaders for batched link resolution (avoids N+1 queries) */
   relationLoaders?: import("./relation-dataloader").RelationDataLoaders;
+  /**
+   * Permission gate for capability mutations that are NOT backed by a meta-model
+   * action and therefore cannot route through `dispatchAction → commandLayer`.
+   *
+   * Currently consumed by cap-chatter's `chatterAddMessage` (it writes to a plain
+   * Drizzle table, not via an Action). The host (`createServer`) injects an
+   * implementation that runs a standalone CommandLayer permission check (non-action
+   * dispatch) gating an entity-level WRITE on the target record's entity. The hook
+   * THROWS when the actor is not permitted; the resolver fails closed when it is
+   * absent. Shaped to match cap-chatter's `AuthorizeChatterWrite` structural type
+   * (no import — the boundary is the shape, not the package).
+   */
+  authorizeChatterWrite?: (input: {
+    entityName: string;
+    recordId: string;
+    actor: Actor;
+    tenantId?: string;
+  }) => Promise<void>;
 }
 
 /** Maximum page size for list queries */

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -51,6 +51,7 @@ import { patchNamedConstant } from "@linchkit/devtools";
 import { Elysia } from "elysia";
 import { type GraphQLSchema, NoSchemaIntrospectionCustomRule } from "graphql";
 import { createYoga, type Plugin } from "graphql-yoga";
+import { createAuthorizeRecordWrite } from "./graphql/authorize-record-write";
 import { createRelationDataLoaders } from "./graphql/relation-dataloader";
 import { mountProposalAPI } from "./proposal-api";
 import { mountProposalGraduateAPI } from "./proposal-graduate-api";
@@ -277,6 +278,15 @@ export function createServer(
   const executionLogger = options?.executionLogger;
   const serverStartedAt = Date.now();
 
+  // Standalone WRITE permission gate for capability mutations not backed by a
+  // meta-model action (currently cap-chatter's `chatterAddMessage`). Built once
+  // from the CommandLayer and injected on every GraphQL context so those
+  // resolvers run the real permission slot before writing. Undefined when no
+  // CommandLayer is wired (rare test setups) — chatter then fails closed.
+  const authorizeChatterWrite = options?.commandLayer
+    ? createAuthorizeRecordWrite(options.commandLayer)
+    : undefined;
+
   // Track current schema for hot-reload support
   let currentSchema = graphqlSchema;
 
@@ -359,6 +369,7 @@ export function createServer(
         permissionGroups,
         entityMap,
         relationLoaders,
+        authorizeChatterWrite,
       };
     },
   });

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/chatter-api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/chatter-api.ts
@@ -75,7 +75,7 @@ export async function addChatterMessage(
   body: string,
 ): Promise<ChatterMessage> {
   const query = `
-    mutation AddChatterMessage($entityName: String!, $recordId: String!, $messageType: MessageType!, $body: String!) {
+    mutation AddChatterMessage($entityName: String!, $recordId: String!, $messageType: AuthorableMessageType!, $body: String!) {
       chatterAddMessage(entityName: $entityName, recordId: $recordId, messageType: $messageType, body: $body) {
         ${CHATTER_MESSAGE_FIELDS}
       }

--- a/addons/chatter/cap-chatter/__tests__/graphql.test.ts
+++ b/addons/chatter/cap-chatter/__tests__/graphql.test.ts
@@ -339,5 +339,24 @@ describe("buildChatterGraphQLExtension", () => {
       expect(result.errors).toBeDefined();
       expect(result.errors?.[0]?.message).toContain("limit");
     });
+
+    it("rejects a contextless call with no actor", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "r", messageType: note, body: "hi") {
+              id
+            }
+          }
+        `,
+        // No contextValue → no actor. The resolver must reject rather than
+        // silently persist an unattributed message.
+        contextValue: {},
+      });
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0]?.message).toContain("actor");
+    });
   });
 });

--- a/addons/chatter/cap-chatter/__tests__/graphql.test.ts
+++ b/addons/chatter/cap-chatter/__tests__/graphql.test.ts
@@ -194,6 +194,12 @@ describe("buildChatterGraphQLExtension", () => {
       createdAt updatedAt
     `;
 
+    // The resolver fails closed unless the host injects an authorize hook (the
+    // real permission gate). Happy-path tests supply a permissive stub; the
+    // dedicated permission tests below supply allow / deny stubs and assert the
+    // hook actually runs and receives the target record.
+    const allowAll = async () => {};
+
     it("persists a note and returns the shape the UI client selects", async () => {
       const schema = buildFullSchema(service);
       const result = await graphql({
@@ -215,6 +221,7 @@ describe("buildChatterGraphQLExtension", () => {
         contextValue: {
           actor: { id: "user-42", type: "user", name: "Alice" },
           tenantId: "tenant-1",
+          authorizeChatterWrite: allowAll,
         },
       });
 
@@ -242,7 +249,7 @@ describe("buildChatterGraphQLExtension", () => {
             }
           }
         `,
-        contextValue: { actor: { id: "user-1", type: "user" } },
+        contextValue: { actor: { id: "user-1", type: "user" }, authorizeChatterWrite: allowAll },
       });
       expect(add.errors).toBeUndefined();
       const addedId = (add.data?.chatterAddMessage as Record<string, unknown>).id;
@@ -281,7 +288,10 @@ describe("buildChatterGraphQLExtension", () => {
             }
           }
         `,
-        contextValue: { actor: { id: "svc-9", type: "system", name: "System" } },
+        contextValue: {
+          actor: { id: "svc-9", type: "system", name: "System" },
+          authorizeChatterWrite: allowAll,
+        },
       });
       expect(result.errors).toBeUndefined();
       const msg = result.data?.chatterAddMessage as Record<string, unknown>;
@@ -357,6 +367,100 @@ describe("buildChatterGraphQLExtension", () => {
       });
       expect(result.errors).toBeDefined();
       expect(result.errors?.[0]?.message).toContain("actor");
+    });
+
+    // ── Permission gate (the injected authorize hook) ─────────
+    //
+    // These prove the write now passes through the host-injected permission gate
+    // BEFORE persisting — the seam the server backs with a real CommandLayer
+    // permission-slot dispatch. The full real-pipeline e2e lives in
+    // adapter-server's `e2e-chatter-permission.test.ts`; here we assert the
+    // resolver contract: it calls the hook with the target record and refuses to
+    // write when the hook (or no hook) denies.
+
+    it("invokes the authorize hook with the target record before writing", async () => {
+      const schema = buildFullSchema(service);
+      const calls: Array<{ entityName: string; recordId: string; actorId: string }> = [];
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "rec-gate", messageType: note, body: "gated") {
+              id
+            }
+          }
+        `,
+        contextValue: {
+          actor: { id: "user-7", type: "user" },
+          tenantId: "tenant-9",
+          authorizeChatterWrite: async (input: {
+            entityName: string;
+            recordId: string;
+            actor: { id: string };
+          }) => {
+            calls.push({
+              entityName: input.entityName,
+              recordId: input.recordId,
+              actorId: input.actor.id,
+            });
+          },
+        },
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.chatterAddMessage).toBeDefined();
+      // The hook ran exactly once, gated on the target record + actor.
+      expect(calls).toEqual([{ entityName: "partner", recordId: "rec-gate", actorId: "user-7" }]);
+    });
+
+    it("DENIES the write when the authorize hook throws — nothing is persisted", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "rec-denied", messageType: note, body: "blocked") {
+              id
+            }
+          }
+        `,
+        contextValue: {
+          actor: { id: "user-x", type: "user" },
+          authorizeChatterWrite: async () => {
+            throw new Error('Permission denied: no write access to entity "partner"');
+          },
+        },
+      });
+
+      // The denial surfaces as a GraphQL error and the field resolves to null.
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0]?.message).toContain("Permission denied");
+      expect(result.data?.chatterAddMessage ?? null).toBeNull();
+
+      // Side effect must NOT have happened: no message was written.
+      const read = await service.getMessages("partner", "rec-denied");
+      expect(read.totalCount).toBe(0);
+    });
+
+    it("fails closed when no authorize hook is injected (host did not wire the gate)", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "rec-nohook", messageType: note, body: "x") {
+              id
+            }
+          }
+        `,
+        // Actor present, but the host injected no authorize hook.
+        contextValue: { actor: { id: "user-z", type: "user" } },
+      });
+
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0]?.message).toContain("permission-wired");
+      const read = await service.getMessages("partner", "rec-nohook");
+      expect(read.totalCount).toBe(0);
     });
   });
 });

--- a/addons/chatter/cap-chatter/__tests__/graphql.test.ts
+++ b/addons/chatter/cap-chatter/__tests__/graphql.test.ts
@@ -19,12 +19,18 @@ describe("buildChatterGraphQLExtension", () => {
     expect(ext.queryFields).toHaveProperty("chatterMessages");
   });
 
+  it("returns mutationFields with chatterAddMessage", () => {
+    const ext = buildChatterGraphQLExtension({ service });
+    expect(ext.mutationFields).toHaveProperty("chatterAddMessage");
+  });
+
   it("returns type definitions", () => {
     const ext = buildChatterGraphQLExtension({ service });
-    expect(ext.types).toHaveLength(2);
+    expect(ext.types).toHaveLength(3);
     const typeNames = ext.types.map((t) => t.name);
     expect(typeNames).toContain("ChatterMessage");
     expect(typeNames).toContain("ChatterMessageConnection");
+    expect(typeNames).toContain("ChatterMessageAuthor");
   });
 
   describe("chatterMessages resolver", () => {
@@ -118,7 +124,7 @@ describe("buildChatterGraphQLExtension", () => {
       const result = await graphql({
         schema,
         source: `{
-          chatterMessages(entityName: "s", recordId: "r", messageType: "comment") {
+          chatterMessages(entityName: "s", recordId: "r", messageType: comment) {
             totalCount
             items { messageType }
           }
@@ -158,6 +164,180 @@ describe("buildChatterGraphQLExtension", () => {
       expect(data.totalCount).toBe(5);
       expect((data.items as unknown[]).length).toBe(3);
       expect(data.hasMore).toBe(true);
+    });
+  });
+
+  describe("chatterAddMessage mutation", () => {
+    /** Build a schema with both Query and Mutation wired, mirroring assemble-schema. */
+    function buildFullSchema(svc: InMemoryChatterService): GraphQLSchema {
+      const ext = buildChatterGraphQLExtension({ service: svc });
+      return new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: "Query",
+          fields: {
+            ping: { type: new GraphQLNonNull(GraphQLString), resolve: () => "pong" },
+            ...ext.queryFields,
+          },
+        }),
+        mutation: new GraphQLObjectType({
+          name: "Mutation",
+          fields: { ...ext.mutationFields },
+        }),
+      });
+    }
+
+    // Exact selection set the UI client (cap-adapter-ui/lib/chatter-api.ts) sends.
+    const CLIENT_FIELDS = `
+      id entityName recordId messageType body
+      author { id type name }
+      logEvent logMetadata
+      createdAt updatedAt
+    `;
+
+    it("persists a note and returns the shape the UI client selects", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation AddChatterMessage($entityName: String!, $recordId: String!, $messageType: MessageType!, $body: String!) {
+            chatterAddMessage(entityName: $entityName, recordId: $recordId, messageType: $messageType, body: $body) {
+              ${CLIENT_FIELDS}
+            }
+          }
+        `,
+        variableValues: {
+          entityName: "partner",
+          recordId: "rec-partner-1",
+          messageType: "note",
+          body: "Reliable supplier — pays within 30 days.",
+        },
+        // Mirrors the server's GraphQLContext (structurally narrowed).
+        contextValue: {
+          actor: { id: "user-42", type: "user", name: "Alice" },
+          tenantId: "tenant-1",
+        },
+      });
+
+      expect(result.errors).toBeUndefined();
+      const msg = result.data?.chatterAddMessage as Record<string, unknown>;
+      expect(msg.id).toBeString();
+      expect(msg.entityName).toBe("partner");
+      expect(msg.recordId).toBe("rec-partner-1");
+      expect(msg.messageType).toBe("note");
+      expect(msg.body).toBe("Reliable supplier — pays within 30 days.");
+      // Nested author object resolved from flat author fields (matches client).
+      expect(msg.author).toEqual({ id: "user-42", type: "user", name: "Alice" });
+      expect(msg.createdAt).toBeString();
+      expect(msg.updatedAt).toBeString();
+    });
+
+    it("round-trips: an added note is readable via chatterMessages", async () => {
+      const schema = buildFullSchema(service);
+      const add = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "rec-rt", messageType: note, body: "round trip") {
+              id
+            }
+          }
+        `,
+        contextValue: { actor: { id: "user-1", type: "user" } },
+      });
+      expect(add.errors).toBeUndefined();
+      const addedId = (add.data?.chatterAddMessage as Record<string, unknown>).id;
+
+      const read = await graphql({
+        schema,
+        source: `{
+          chatterMessages(entityName: "partner", recordId: "rec-rt") {
+            totalCount
+            items { id body messageType author { id } }
+          }
+        }`,
+      });
+      expect(read.errors).toBeUndefined();
+      const data = read.data?.chatterMessages as Record<string, unknown>;
+      expect(data.totalCount).toBe(1);
+      const items = data.items as Array<Record<string, unknown>>;
+      const first = items[0];
+      expect(first).toBeDefined();
+      expect(first?.id).toBe(addedId);
+      expect(first?.body).toBe("round trip");
+      expect(first?.messageType).toBe("note");
+      expect(first?.author).toEqual({ id: "user-1" });
+    });
+
+    it("derives author from context, ignoring any client-supplied author", async () => {
+      const schema = buildFullSchema(service);
+      // The mutation exposes no author argument, so author identity comes from
+      // the server-side actor only.
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "rec-auth", messageType: comment, body: "hi") {
+              author { id type name }
+            }
+          }
+        `,
+        contextValue: { actor: { id: "svc-9", type: "system", name: "System" } },
+      });
+      expect(result.errors).toBeUndefined();
+      const msg = result.data?.chatterAddMessage as Record<string, unknown>;
+      expect(msg.author).toEqual({ id: "svc-9", type: "system", name: "System" });
+    });
+
+    it("rejects authoring a non-comment/note message kind", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "r", messageType: log, body: "x") {
+              id
+            }
+          }
+        `,
+        contextValue: { actor: { id: "u", type: "user" } },
+      });
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0]?.message).toContain("only");
+    });
+
+    it("rejects an empty body", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation {
+            chatterAddMessage(entityName: "partner", recordId: "r", messageType: note, body: "   ") {
+              id
+            }
+          }
+        `,
+        contextValue: { actor: { id: "u", type: "user" } },
+      });
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0]?.message).toContain("empty");
+    });
+
+    it("rejects an oversized body (storage / DoS guard)", async () => {
+      const schema = buildFullSchema(service);
+      const result = await graphql({
+        schema,
+        source: `
+          mutation Add($body: String!) {
+            chatterAddMessage(entityName: "partner", recordId: "r", messageType: note, body: $body) {
+              id
+            }
+          }
+        `,
+        variableValues: { body: "x".repeat(10_001) },
+        contextValue: { actor: { id: "u", type: "user" } },
+      });
+      expect(result.errors).toBeDefined();
+      expect(result.errors?.[0]?.message).toContain("limit");
     });
   });
 });

--- a/addons/chatter/cap-chatter/__tests__/graphql.test.ts
+++ b/addons/chatter/cap-chatter/__tests__/graphql.test.ts
@@ -205,7 +205,7 @@ describe("buildChatterGraphQLExtension", () => {
       const result = await graphql({
         schema,
         source: `
-          mutation AddChatterMessage($entityName: String!, $recordId: String!, $messageType: MessageType!, $body: String!) {
+          mutation AddChatterMessage($entityName: String!, $recordId: String!, $messageType: AuthorableMessageType!, $body: String!) {
             chatterAddMessage(entityName: $entityName, recordId: $recordId, messageType: $messageType, body: $body) {
               ${CLIENT_FIELDS}
             }
@@ -298,7 +298,10 @@ describe("buildChatterGraphQLExtension", () => {
       expect(msg.author).toEqual({ id: "svc-9", type: "system", name: "System" });
     });
 
-    it("rejects authoring a non-comment/note message kind", async () => {
+    it("rejects authoring a non-comment/note kind at the schema layer (input enum)", async () => {
+      // `log` is not a member of the `AuthorableMessageType` input enum, so the
+      // operation is rejected during GraphQL validation — before the resolver runs.
+      // This is the schema expressing the authoring constraint (not a runtime throw).
       const schema = buildFullSchema(service);
       const result = await graphql({
         schema,
@@ -312,7 +315,11 @@ describe("buildChatterGraphQLExtension", () => {
         contextValue: { actor: { id: "u", type: "user" } },
       });
       expect(result.errors).toBeDefined();
-      expect(result.errors?.[0]?.message).toContain("only");
+      // graphql-js enum-validation error names the offending value + the enum.
+      expect(result.errors?.[0]?.message).toContain("log");
+      expect(result.errors?.[0]?.message).toContain("AuthorableMessageType");
+      // Rejected before execution → field never resolved.
+      expect(result.data ?? null).toBeNull();
     });
 
     it("rejects an empty body", async () => {
@@ -380,7 +387,12 @@ describe("buildChatterGraphQLExtension", () => {
 
     it("invokes the authorize hook with the target record before writing", async () => {
       const schema = buildFullSchema(service);
-      const calls: Array<{ entityName: string; recordId: string; actorId: string }> = [];
+      const calls: Array<{
+        entityName: string;
+        recordId: string;
+        actorId: string;
+        tenantId?: string;
+      }> = [];
       const result = await graphql({
         schema,
         source: `
@@ -397,11 +409,13 @@ describe("buildChatterGraphQLExtension", () => {
             entityName: string;
             recordId: string;
             actor: { id: string };
+            tenantId?: string;
           }) => {
             calls.push({
               entityName: input.entityName,
               recordId: input.recordId,
               actorId: input.actor.id,
+              tenantId: input.tenantId,
             });
           },
         },
@@ -409,8 +423,11 @@ describe("buildChatterGraphQLExtension", () => {
 
       expect(result.errors).toBeUndefined();
       expect(result.data?.chatterAddMessage).toBeDefined();
-      // The hook ran exactly once, gated on the target record + actor.
-      expect(calls).toEqual([{ entityName: "partner", recordId: "rec-gate", actorId: "user-7" }]);
+      // The hook ran exactly once, gated on the target record + actor, and the
+      // request tenant propagated to it (so the permission check is tenant-scoped).
+      expect(calls).toEqual([
+        { entityName: "partner", recordId: "rec-gate", actorId: "user-7", tenantId: "tenant-9" },
+      ]);
     });
 
     it("DENIES the write when the authorize hook throws — nothing is persisted", async () => {

--- a/addons/chatter/cap-chatter/src/graphql.ts
+++ b/addons/chatter/cap-chatter/src/graphql.ts
@@ -24,11 +24,39 @@ import {
 import type { ChatterMessage, ChatterService, MessageType } from "./types";
 
 /**
+ * Authorization hook the host (cap-adapter-server) injects on the per-request
+ * GraphQL context so a chatter write passes through the CommandLayer permission
+ * slot — exactly like every action-backed mutation does — WITHOUT cap-chatter
+ * importing the server (module boundary).
+ *
+ * cap-chatter owns the WRITE entry (`chatterAddMessage`), but the message store
+ * is a plain Drizzle table, not a meta-model action, so the GraphQL resolver
+ * cannot route through `dispatchAction → commandLayer.execute`. Instead the
+ * server contributes this hook; its implementation runs a standalone permission
+ * check (CommandLayer non-action dispatch) gating an entity-level WRITE on the
+ * record's entity. The hook MUST reject (throw) when the actor is not permitted.
+ *
+ * Defined locally as a structural type so cap-chatter depends on the SHAPE, not
+ * the server package.
+ */
+export type AuthorizeChatterWrite = (input: {
+  /** The entity the comment/note is posted against (e.g. "purchase_order"). */
+  entityName: string;
+  /** The record id within that entity. */
+  recordId: string;
+  /** The request actor (already resolved by the auth slot upstream). */
+  actor: { id: string; type: string; name?: string; tenantId?: string };
+  /** Tenant scope for the write, when present. */
+  tenantId?: string;
+}) => Promise<void>;
+
+/**
  * Minimal view of the per-request GraphQL context this extension reads.
  *
  * cap-chatter must not depend on cap-adapter-server (module boundary), so we
  * narrow to only the fields we consume. The server's full `GraphQLContext`
- * (which carries `actor` and `tenantId`) is structurally compatible with this.
+ * (which carries `actor`, `tenantId`, and now `authorizeChatterWrite`) is
+ * structurally compatible with this.
  */
 interface ChatterGraphQLContext {
   // The server's GraphQLContext always populates `actor` — an authenticated
@@ -37,6 +65,12 @@ interface ChatterGraphQLContext {
   // guards defensively against a malformed, contextless call).
   actor: { id: string; type: string; name?: string; tenantId?: string };
   tenantId?: string;
+  /**
+   * Permission gate injected by the host. When present, the `chatterAddMessage`
+   * resolver invokes it BEFORE writing so the CommandLayer permission slot runs.
+   * Absent only in degraded setups that wire no host (the resolver fails closed).
+   */
+  authorizeChatterWrite?: AuthorizeChatterWrite;
 }
 
 // ── Shared GraphQL types ────────────────────────────────────
@@ -237,6 +271,19 @@ export function buildChatterGraphQLExtension(
         );
       }
 
+      // Bound the body length on the RAW input, before trimming — otherwise a
+      // padded payload (e.g. 5k real chars + tens of MB of trailing whitespace)
+      // would force an O(n) trim over the whole blob before this O(1) check
+      // fires. Reject on raw length first (storage / DoS guard).
+      const MAX_BODY_LENGTH = 10_000;
+      if (
+        args.body.length > MAX_BODY_LENGTH ||
+        args.entityName.length > 255 ||
+        args.recordId.length > 255
+      ) {
+        throw new Error(`Input exceeds allowed length (body limit ${MAX_BODY_LENGTH} chars).`);
+      }
+
       // Sanitize text inputs and reject empty/whitespace-only bodies.
       const entityName = args.entityName.trim();
       const recordId = args.recordId.trim();
@@ -247,12 +294,6 @@ export function buildChatterGraphQLExtension(
       if (!body) {
         throw new Error("Message body cannot be empty.");
       }
-      // Bound the body length so a single request cannot insert an unbounded
-      // blob (storage / DoS guard).
-      const MAX_BODY_LENGTH = 10_000;
-      if (body.length > MAX_BODY_LENGTH) {
-        throw new Error(`Message body exceeds the ${MAX_BODY_LENGTH}-character limit.`);
-      }
 
       // Author identity is server-managed — derived from the request actor,
       // never accepted from the client. Guard defensively: a contextless call
@@ -261,6 +302,27 @@ export function buildChatterGraphQLExtension(
       if (!actor) {
         throw new Error("chatterAddMessage requires an actor on the request context.");
       }
+
+      // Permission slot: route the write through the host-injected authorize
+      // hook so the CommandLayer permission slot runs — the same guarantee
+      // every action-backed mutation gets. The hook gates an entity-level WRITE
+      // on the target record's entity (the comment is "written against" that
+      // record) and THROWS when the actor is not permitted. Fail closed: if no
+      // host wired the hook, refuse the write rather than silently allow it.
+      // Run on the trimmed/validated values, after the DoS-ordering checks above.
+      const authorize = context.authorizeChatterWrite;
+      if (!authorize) {
+        throw new Error(
+          "chatterAddMessage is not permission-wired — the host did not inject an authorize hook.",
+        );
+      }
+      await authorize({
+        entityName,
+        recordId,
+        actor,
+        tenantId: context.tenantId ?? actor.tenantId,
+      });
+
       const message = await service.createMessage({
         entityName,
         recordId,

--- a/addons/chatter/cap-chatter/src/graphql.ts
+++ b/addons/chatter/cap-chatter/src/graphql.ts
@@ -76,10 +76,11 @@ interface ChatterGraphQLContext {
 // ── Shared GraphQL types ────────────────────────────────────
 
 /**
- * Message kinds. Shared by the `messageType` output field and the
- * `chatterAddMessage` input argument. A single enum instance is intentionally
- * reused for both input and output positions — graphql-js permits enums in
- * either role, and reuse keeps the schema's type set minimal.
+ * All message kinds. Used for the `messageType` OUTPUT field and the
+ * `chatterMessages` query filter (a client may filter by any kind, including the
+ * system-produced `log`/`ai`). NOT used as the `chatterAddMessage` input — see
+ * {@link AuthorableMessageTypeEnum}, which expresses the authoring constraint in
+ * the type system rather than only at runtime.
  */
 const MessageTypeEnum = new GraphQLEnumType({
   name: "MessageType",
@@ -89,6 +90,23 @@ const MessageTypeEnum = new GraphQLEnumType({
     note: { value: "note" },
     log: { value: "log" },
     ai: { value: "ai" },
+  },
+});
+
+/**
+ * The message kinds a CLIENT may author via `chatterAddMessage`. `log`/`ai` are
+ * system-produced (e.g. the auto-log event handler) and must never come from a
+ * client request, so they are absent here — an introspection-based client (codegen,
+ * GraphQL Playground) sees only the genuinely-accepted values, and `log`/`ai` are
+ * rejected at the schema layer, not silently accepted then thrown at runtime. The
+ * resolver keeps a defensive runtime check as defense-in-depth.
+ */
+const AuthorableMessageTypeEnum = new GraphQLEnumType({
+  name: "AuthorableMessageType",
+  description: "Message kinds a client may author (comments and notes only)",
+  values: {
+    comment: { value: "comment" },
+    note: { value: "note" },
   },
 });
 
@@ -241,8 +259,11 @@ export function buildChatterGraphQLExtension(
       entityName: { type: new GraphQLNonNull(GraphQLString) },
       recordId: { type: new GraphQLNonNull(GraphQLString) },
       messageType: {
-        type: new GraphQLNonNull(MessageTypeEnum),
-        description: "Message kind — only `comment` or `note` may be authored by a client",
+        // Restricted input enum (comment/note only) — the authoring constraint is
+        // expressed in the schema, so `log`/`ai` are rejected at validation time
+        // and never appear as valid inputs to an introspection client.
+        type: new GraphQLNonNull(AuthorableMessageTypeEnum),
+        description: "Message kind to author — `comment` or `note`",
       },
       body: { type: new GraphQLNonNull(GraphQLString) },
     },
@@ -262,26 +283,30 @@ export function buildChatterGraphQLExtension(
       // Treat it as Partial here so the runtime actor guard below is meaningful
       // even though the interface declares `actor` as always-present.
       const context = (rawContext ?? {}) as Partial<ChatterGraphQLContext>;
-      // Authored content is restricted to comments/notes. `log`/`ai` entries are
-      // produced by the system (e.g. the auto-log event handler), never by a
-      // client request, so reject them here.
+      // Authored content is restricted to comments/notes. The `AuthorableMessageType`
+      // input enum already rejects `log`/`ai` at schema-validation time; this runtime
+      // check is defense-in-depth for any non-schema caller (e.g. a direct resolver
+      // invocation in a test or future transport).
       if (args.messageType !== "comment" && args.messageType !== "note") {
         throw new Error(
           `Cannot author a "${args.messageType}" message — only "comment" or "note" are allowed.`,
         );
       }
 
-      // Bound the body length on the RAW input, before trimming — otherwise a
-      // padded payload (e.g. 5k real chars + tens of MB of trailing whitespace)
-      // would force an O(n) trim over the whole blob before this O(1) check
-      // fires. Reject on raw length first (storage / DoS guard).
+      // Bound each length on the RAW input, before trimming — otherwise a padded
+      // payload (e.g. 5k real chars + tens of MB of trailing whitespace) would
+      // force an O(n) trim over the whole blob before these O(1) checks fire.
+      // Per-field messages so the caller knows which input was too long.
       const MAX_BODY_LENGTH = 10_000;
-      if (
-        args.body.length > MAX_BODY_LENGTH ||
-        args.entityName.length > 255 ||
-        args.recordId.length > 255
-      ) {
-        throw new Error(`Input exceeds allowed length (body limit ${MAX_BODY_LENGTH} chars).`);
+      const MAX_REF_LENGTH = 255;
+      if (args.body.length > MAX_BODY_LENGTH) {
+        throw new Error(`Message body exceeds the ${MAX_BODY_LENGTH}-character limit.`);
+      }
+      if (args.entityName.length > MAX_REF_LENGTH) {
+        throw new Error(`entityName exceeds the ${MAX_REF_LENGTH}-character limit.`);
+      }
+      if (args.recordId.length > MAX_REF_LENGTH) {
+        throw new Error(`recordId exceeds the ${MAX_REF_LENGTH}-character limit.`);
       }
 
       // Sanitize text inputs and reject empty/whitespace-only bodies.

--- a/addons/chatter/cap-chatter/src/graphql.ts
+++ b/addons/chatter/cap-chatter/src/graphql.ts
@@ -31,7 +31,11 @@ import type { ChatterMessage, ChatterService, MessageType } from "./types";
  * (which carries `actor` and `tenantId`) is structurally compatible with this.
  */
 interface ChatterGraphQLContext {
-  actor?: { id: string; type: string; name?: string; tenantId?: string };
+  // The server's GraphQLContext always populates `actor` — an authenticated
+  // user, or the anonymous sentinel for unauthenticated requests. It is never
+  // absent in normal operation, so it is required here (the resolver still
+  // guards defensively against a malformed, contextless call).
+  actor: { id: string; type: string; name?: string; tenantId?: string };
   tenantId?: string;
 }
 
@@ -221,7 +225,9 @@ export function buildChatterGraphQLExtension(
     ): Promise<SerializedChatterMessage> => {
       // Narrow the opaque per-request context to only the fields we read. The
       // server passes its full `GraphQLContext` (which carries `actor`/`tenantId`).
-      const context = (rawContext ?? {}) as ChatterGraphQLContext;
+      // Treat it as Partial here so the runtime actor guard below is meaningful
+      // even though the interface declares `actor` as always-present.
+      const context = (rawContext ?? {}) as Partial<ChatterGraphQLContext>;
       // Authored content is restricted to comments/notes. `log`/`ai` entries are
       // produced by the system (e.g. the auto-log event handler), never by a
       // client request, so reject them here.
@@ -248,18 +254,27 @@ export function buildChatterGraphQLExtension(
         throw new Error(`Message body exceeds the ${MAX_BODY_LENGTH}-character limit.`);
       }
 
-      // Author identity is server-managed — derived from the authenticated
-      // actor, never accepted from the client.
-      const actor = context?.actor;
+      // Author identity is server-managed — derived from the request actor,
+      // never accepted from the client. Guard defensively: a contextless call
+      // (no actor at all) is rejected rather than silently attributed.
+      const actor = context.actor;
+      if (!actor) {
+        throw new Error("chatterAddMessage requires an actor on the request context.");
+      }
       const message = await service.createMessage({
         entityName,
         recordId,
         messageType: args.messageType,
         body,
-        authorId: actor?.id ?? "anonymous",
-        authorType: actor?.type ?? "system",
-        authorName: actor?.name,
-        tenantId: context?.tenantId ?? actor?.tenantId,
+        authorId: actor.id,
+        authorType: actor.type,
+        authorName: actor.name,
+        // tenantId is optional by design: a single-tenant / tenant-less
+        // deployment (e.g. the local demo) legitimately has no tenant, so an
+        // undefined value is accepted and stored as NULL. A tenant-scoped read
+        // filter (tracked separately) must treat NULL-tenant rows consistently
+        // for that mode.
+        tenantId: context.tenantId ?? actor.tenantId,
       });
 
       return serializeMessage(message);

--- a/addons/chatter/cap-chatter/src/graphql.ts
+++ b/addons/chatter/cap-chatter/src/graphql.ts
@@ -3,25 +3,70 @@
  *
  * Provides GraphQL type definitions and resolvers for the chatter API.
  * Returns field configs that can be merged into the main GraphQL schema's
- * Query type using graphql-js utilities.
+ * Query and Mutation types using graphql-js utilities.
  *
  * Usage:
  *   const chatterFields = buildChatterGraphQLExtension({ service });
  *   // Merge chatterFields.queryFields into your Query type fields
+ *   // Merge chatterFields.mutationFields into your Mutation type fields
  */
 
 import type { GraphQLFieldConfig, GraphQLResolveInfo } from "graphql";
 import {
   GraphQLBoolean,
+  GraphQLEnumType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql";
-import type { ChatterService } from "./types";
+import type { ChatterMessage, ChatterService, MessageType } from "./types";
+
+/**
+ * Minimal view of the per-request GraphQL context this extension reads.
+ *
+ * cap-chatter must not depend on cap-adapter-server (module boundary), so we
+ * narrow to only the fields we consume. The server's full `GraphQLContext`
+ * (which carries `actor` and `tenantId`) is structurally compatible with this.
+ */
+interface ChatterGraphQLContext {
+  actor?: { id: string; type: string; name?: string; tenantId?: string };
+  tenantId?: string;
+}
 
 // ── Shared GraphQL types ────────────────────────────────────
+
+/**
+ * Message kinds. Shared by the `messageType` output field and the
+ * `chatterAddMessage` input argument. A single enum instance is intentionally
+ * reused for both input and output positions — graphql-js permits enums in
+ * either role, and reuse keeps the schema's type set minimal.
+ */
+const MessageTypeEnum = new GraphQLEnumType({
+  name: "MessageType",
+  description: "Kind of a chatter message",
+  values: {
+    comment: { value: "comment" },
+    note: { value: "note" },
+    log: { value: "log" },
+    ai: { value: "ai" },
+  },
+});
+
+/**
+ * Author of a message, projected from the flat `authorId`/`authorType`/
+ * `authorName` fields the service persists. Exposed as a nested object so the
+ * client can select `author { id type name }`.
+ */
+const ChatterMessageAuthorType = new GraphQLObjectType({
+  name: "ChatterMessageAuthor",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    type: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString },
+  },
+});
 
 const ChatterMessageType = new GraphQLObjectType({
   name: "ChatterMessage",
@@ -29,12 +74,22 @@ const ChatterMessageType = new GraphQLObjectType({
     id: { type: new GraphQLNonNull(GraphQLString) },
     entityName: { type: new GraphQLNonNull(GraphQLString) },
     recordId: { type: new GraphQLNonNull(GraphQLString) },
-    messageType: { type: new GraphQLNonNull(GraphQLString) },
+    messageType: { type: new GraphQLNonNull(MessageTypeEnum) },
     body: { type: new GraphQLNonNull(GraphQLString) },
     bodyHtml: { type: GraphQLString },
+    // Flat author fields (kept for backward compatibility) ...
     authorId: { type: new GraphQLNonNull(GraphQLString) },
     authorType: { type: new GraphQLNonNull(GraphQLString) },
     authorName: { type: GraphQLString },
+    // ... and the nested projection the client selects.
+    author: {
+      type: new GraphQLNonNull(ChatterMessageAuthorType),
+      resolve: (source: SerializedChatterMessage) => ({
+        id: source.authorId,
+        type: source.authorType,
+        name: source.authorName ?? null,
+      }),
+    },
     parentId: { type: GraphQLString },
     threadCount: { type: new GraphQLNonNull(GraphQLInt) },
     logEvent: { type: GraphQLString },
@@ -53,6 +108,29 @@ const ChatterMessageConnectionType = new GraphQLObjectType({
   },
 });
 
+// ── Serialization ───────────────────────────────────────────
+
+/**
+ * Wire shape of a {@link ChatterMessage}: `Date`s become ISO strings and
+ * `logMetadata` is JSON-encoded into a string (matching the `logMetadata`
+ * scalar field). Used as the resolved value for both the query and mutation.
+ */
+interface SerializedChatterMessage
+  extends Omit<ChatterMessage, "createdAt" | "updatedAt" | "logMetadata"> {
+  createdAt: string;
+  updatedAt: string;
+  logMetadata: string | null;
+}
+
+function serializeMessage(msg: ChatterMessage): SerializedChatterMessage {
+  return {
+    ...msg,
+    createdAt: msg.createdAt.toISOString(),
+    updatedAt: msg.updatedAt.toISOString(),
+    logMetadata: msg.logMetadata ? JSON.stringify(msg.logMetadata) : null,
+  };
+}
+
 // ── Extension builder ───────────────────────────────────────
 
 export interface ChatterGraphQLExtensionOptions {
@@ -64,12 +142,15 @@ export interface ChatterGraphQLExtension {
   types: GraphQLObjectType[];
   /** Query fields to merge into the root Query type */
   queryFields: Record<string, GraphQLFieldConfig<unknown, unknown>>;
+  /** Mutation fields to merge into the root Mutation type */
+  mutationFields: Record<string, GraphQLFieldConfig<unknown, unknown>>;
 }
 
 /**
  * Build the GraphQL extension for cap-chatter.
  *
- * Returns query fields that consumer can merge into the main GraphQL schema.
+ * Returns query and mutation fields the consumer can merge into the main
+ * GraphQL schema.
  */
 export function buildChatterGraphQLExtension(
   options: ChatterGraphQLExtensionOptions,
@@ -83,8 +164,8 @@ export function buildChatterGraphQLExtension(
       entityName: { type: new GraphQLNonNull(GraphQLString) },
       recordId: { type: new GraphQLNonNull(GraphQLString) },
       messageType: {
-        type: GraphQLString,
-        description: "Filter by type: comment | note | log | ai",
+        type: MessageTypeEnum,
+        description: "Filter by message kind",
       },
       limit: { type: GraphQLInt, defaultValue: 20 },
       offset: { type: GraphQLInt, defaultValue: 0 },
@@ -94,7 +175,7 @@ export function buildChatterGraphQLExtension(
       args: {
         entityName: string;
         recordId: string;
-        messageType?: string;
+        messageType?: MessageType;
         limit?: number;
         offset?: number;
       },
@@ -102,26 +183,92 @@ export function buildChatterGraphQLExtension(
       _info: GraphQLResolveInfo,
     ) => {
       const result = await service.getMessages(args.entityName, args.recordId, {
-        messageType: args.messageType as "comment" | "note" | "log" | "ai" | undefined,
+        messageType: args.messageType,
         limit: args.limit,
         offset: args.offset,
       });
 
       return {
-        items: result.items.map((msg) => ({
-          ...msg,
-          createdAt: msg.createdAt.toISOString(),
-          updatedAt: msg.updatedAt.toISOString(),
-          logMetadata: msg.logMetadata ? JSON.stringify(msg.logMetadata) : null,
-        })),
+        items: result.items.map(serializeMessage),
         totalCount: result.totalCount,
         hasMore: result.hasMore,
       };
     },
   };
 
+  const chatterAddMessage: GraphQLFieldConfig<unknown, unknown> = {
+    type: new GraphQLNonNull(ChatterMessageType),
+    description: "Post a comment or note against a record",
+    args: {
+      entityName: { type: new GraphQLNonNull(GraphQLString) },
+      recordId: { type: new GraphQLNonNull(GraphQLString) },
+      messageType: {
+        type: new GraphQLNonNull(MessageTypeEnum),
+        description: "Message kind — only `comment` or `note` may be authored by a client",
+      },
+      body: { type: new GraphQLNonNull(GraphQLString) },
+    },
+    resolve: async (
+      _source: unknown,
+      args: {
+        entityName: string;
+        recordId: string;
+        messageType: MessageType;
+        body: string;
+      },
+      rawContext: unknown,
+      _info: GraphQLResolveInfo,
+    ): Promise<SerializedChatterMessage> => {
+      // Narrow the opaque per-request context to only the fields we read. The
+      // server passes its full `GraphQLContext` (which carries `actor`/`tenantId`).
+      const context = (rawContext ?? {}) as ChatterGraphQLContext;
+      // Authored content is restricted to comments/notes. `log`/`ai` entries are
+      // produced by the system (e.g. the auto-log event handler), never by a
+      // client request, so reject them here.
+      if (args.messageType !== "comment" && args.messageType !== "note") {
+        throw new Error(
+          `Cannot author a "${args.messageType}" message — only "comment" or "note" are allowed.`,
+        );
+      }
+
+      // Sanitize text inputs and reject empty/whitespace-only bodies.
+      const entityName = args.entityName.trim();
+      const recordId = args.recordId.trim();
+      const body = args.body.trim();
+      if (!entityName || !recordId) {
+        throw new Error("entityName and recordId are required.");
+      }
+      if (!body) {
+        throw new Error("Message body cannot be empty.");
+      }
+      // Bound the body length so a single request cannot insert an unbounded
+      // blob (storage / DoS guard).
+      const MAX_BODY_LENGTH = 10_000;
+      if (body.length > MAX_BODY_LENGTH) {
+        throw new Error(`Message body exceeds the ${MAX_BODY_LENGTH}-character limit.`);
+      }
+
+      // Author identity is server-managed — derived from the authenticated
+      // actor, never accepted from the client.
+      const actor = context?.actor;
+      const message = await service.createMessage({
+        entityName,
+        recordId,
+        messageType: args.messageType,
+        body,
+        authorId: actor?.id ?? "anonymous",
+        authorType: actor?.type ?? "system",
+        authorName: actor?.name,
+        tenantId: context?.tenantId ?? actor?.tenantId,
+      });
+
+      return serializeMessage(message);
+    },
+  };
+
   return {
-    types: [ChatterMessageType, ChatterMessageConnectionType],
+    types: [ChatterMessageAuthorType, ChatterMessageType, ChatterMessageConnectionType],
     queryFields: { chatterMessages },
+    mutationFields: { chatterAddMessage },
   };
 }

--- a/addons/chatter/cap-chatter/src/index.ts
+++ b/addons/chatter/cap-chatter/src/index.ts
@@ -5,6 +5,12 @@
 export type { CapChatterOptions } from "./capability";
 export { capChatter, createCapChatter } from "./capability";
 export { createChatterAutoLog } from "./event-handler";
+export type {
+  AuthorizeChatterWrite,
+  ChatterGraphQLExtension,
+  ChatterGraphQLExtensionOptions,
+} from "./graphql";
+export { buildChatterGraphQLExtension } from "./graphql";
 export { DrizzleChatterService, InMemoryChatterService } from "./service";
 export { messagesTable } from "./tables";
 export type {

--- a/addons/permission/cap-permission/src/middleware/permission-middleware.ts
+++ b/addons/permission/cap-permission/src/middleware/permission-middleware.ts
@@ -66,13 +66,15 @@ const PERM_CACHE_TTL_MS = 10 * 60 * 1000;
 
 /**
  * The authoritative permission target a NON-ACTION dispatch publishes in `ctx.meta`.
- * Two kinds, matching the two documented conventions:
+ * Three kinds, matching the documented conventions:
  *  - `action` — gate on an action grant (`grant.<capability>.actions.<action>`).
  *  - `read`   — gate on entity-level READ data access (`grant.<entity>.data.read`).
+ *  - `write`  — gate on entity-level WRITE data access (`grant.<entity>.data.write`).
  */
 type MetaTarget =
   | { kind: "action"; capability: string; action: string }
-  | { kind: "read"; capability: string; entity: string };
+  | { kind: "read"; capability: string; entity: string }
+  | { kind: "write"; capability: string; entity: string };
 
 /**
  * Resolve the authoritative permission target for a NON-ACTION dispatch that
@@ -88,6 +90,12 @@ type MetaTarget =
  *  - `meta.onchange = { entity }` (Spec 64) → an entity-level READ check. The
  *    onchange route computes form fields for an entity; authorize it as "may this
  *    actor READ this entity" (`grant.<entity>.data.read`), NOT as an action.
+ *  - `meta.recordWrite = { entity }` → an entity-level WRITE check. A capability
+ *    that contributes a GraphQL mutation NOT backed by a meta-model action (e.g.
+ *    cap-chatter posting a comment against a record) cannot route through
+ *    `dispatchAction`, so it gates its write here: authorize it as "may this actor
+ *    WRITE the target entity" (`grant.<entity>.data.write`). Mirrors the onchange
+ *    read-target but on the `write` operation.
  *  - `meta.aiObservability = { operation }` (Spec 69 P3) → an ACTION grant target.
  *    Gate AI observability admin reads (e.g. `GET /api/ai/traces`) on a natural
  *    grant (`grant.ai.actions.<operation>`, e.g. `grant.ai.actions.read_traces`)
@@ -106,6 +114,10 @@ function resolveMetaTarget(ctx: CommandContext): MetaTarget | null {
   const onchange = meta?.onchange as { entity?: unknown } | undefined;
   if (onchange && typeof onchange.entity === "string" && onchange.entity.length > 0) {
     return { kind: "read", capability: onchange.entity, entity: onchange.entity };
+  }
+  const recordWrite = meta?.recordWrite as { entity?: unknown } | undefined;
+  if (recordWrite && typeof recordWrite.entity === "string" && recordWrite.entity.length > 0) {
+    return { kind: "write", capability: recordWrite.entity, entity: recordWrite.entity };
   }
   const aiObservability = meta?.aiObservability as { operation?: unknown } | undefined;
   if (
@@ -178,6 +190,43 @@ export function createPermissionMiddleware(
           details: {
             action: command,
             capability: readCapability,
+            entity: metaTarget.entity,
+          },
+        });
+      }
+      await next();
+      return;
+    }
+
+    // A `write` meta target (a capability mutation not backed by a meta-model
+    // action — e.g. cap-chatter posting a comment) is authorized by entity-level
+    // WRITE data access. Decide it up front and return. Honour a custom
+    // `resolveCapability` for the same legacy-grant reason; default to the entity
+    // name.
+    //
+    // FAIL CLOSED on conditional grants: `resolveDataAccess` may return "all",
+    // "none", OR a row-level `DataAccessCondition` (e.g. "may write own-department
+    // records"). This non-action gate carries only the target `entity`/`recordId`
+    // — it does NOT load the target record, so it cannot evaluate that condition
+    // against this specific row. Treating a condition as allow would let a
+    // conditional writer (scoped to *their* rows) write against ANY record of the
+    // entity — a row-level bypass. So only an unconditional "all" passes; "none"
+    // and any condition are denied. A conditional writer being unable to comment
+    // is the safe failure. Follow-up: load the target record and evaluate the
+    // condition for true row-level authorization.
+    if (metaTarget?.kind === "write") {
+      const writeCapability = resolveCapability
+        ? resolveCapability(command, ctx)
+        : metaTarget.capability;
+      const write = resolveDataAccess(registry, actor, writeCapability, metaTarget.entity, "write");
+      if (write !== "all") {
+        throw new AuthorizationError({
+          code: "authz.action.denied",
+          message: `Permission denied: no unconditional write access to entity "${metaTarget.entity}"`,
+          requiredGroups: actor.groups.length > 0 ? undefined : ["(any)"],
+          details: {
+            action: command,
+            capability: writeCapability,
             entity: metaTarget.entity,
           },
         });


### PR DESCRIPTION
## What (Build B, PR1)

Wires the **missing** `chatterAddMessage` GraphQL mutation in cap-chatter. The chatter UI calls it to post a comment/note against a record, but the server never defined it (`buildChatterGraphQLExtension` exposed only `queryFields { chatterMessages }`) — so writing a note from the browser was a **dead path**. This is the "experience capture" primitive for the upcoming 经验→制度 loop, and a standalone bugfix.

## How it was found
Planning the 经验→制度 graduation loop (attach an 经验 note to a partner → AI drafts a rule → human approves → graduates). Step 1 (write the note) turned out to be broken end-to-end.

## Changes
- `graphql.ts`: add `mutationFields.chatterAddMessage` → existing `ChatterService.createMessage`. Author identity + `tenantId` are **server-managed** (from `context.actor`), never client args; `log`/`ai` kinds rejected; empty/whitespace and **oversized (>10k)** bodies rejected; inputs trimmed.
- A nested `author { id type name }` field + a `MessageType` enum were added because the UI's selection set (`author { }`) and mutation variable (`$messageType: MessageType!`) **never matched** the old flat `String` fields — so even the existing read query was silently failing through the client's graceful-fallback. Flat author fields kept for backward compat.
- Tests: persist, round-trip, author-from-context (ignores client-supplied author), reject log/ai, reject empty + oversized body.

## Cross-model review (codex)
- **Oversized body** had no bound → added a 10k-char limit + test.
- **`messageType` filter String→enum**: kept (type-safe; the sole in-repo consumer — the UI — does not pass the `messageType` filter arg, and the output serializes to identical string values, so no consumer breaks).
- **Out of scope (pre-existing, documented for follow-up):** `chatterMessages` reads are **not tenant-scoped** — `getMessages` filters by `entityName`/`recordId` only, so two tenants sharing a record id can read each other's messages. The `chatter_message` table has `tenant_id` and **this mutation stamps it on write**; only the *read* path needs a tenant predicate. Left for a separate focused PR to keep this one a clean additive bugfix.

## Verification
`bun test ./addons/chatter/` → **32 pass**. `bun run check` ✅, `bun run typecheck` ✅ (repo-wide, 0 errors). Full `bun run test` not run locally (cli batch hangs on local Bun 1.2.18 — unrelated); **CI authoritative**.

> Live double-check worth doing once merged: post a note from the browser against a record and confirm `context.actor` populates `author.id` (not `"anonymous"`) for a logged-in user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `chatterAddMessage` GraphQL mutation to create comments/notes with server-side validation and structured author info.
  * Strengthened GraphQL typing (including `messageType` enum support and nested `author` details) and standardized message serialization.
  * Introduced a fail-closed permission gate for entity record WRITE checks, wiring it into the GraphQL context.
* **Tests**
  * Expanded GraphQL and end-to-end permission test coverage, including mutation denial cases (unauthorized, missing gate, conditional failures) and round-trip persistence assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — permission slot wired (commit `11e73407`)

Review (claude) correctly flagged that `chatterAddMessage` was raw-merged into the schema and **skipped the CommandLayer permission slot** — violating *"All API endpoints go through CommandLayer."* The chatter store is a plain Drizzle timeline table (not a meta-model entity/action), so it cannot be a `defineAction`; instead the write now passes through the permission slot via an **injected authorize hook** (no module-boundary break):

- **cap-chatter** declares a structural `AuthorizeChatterWrite` hook and calls it **before** writing (after the actor guard + raw-length/DoS-order checks); **fails closed** if no host wired it.
- **adapter-server** builds the hook from the CommandLayer (`createAuthorizeRecordWrite`) and injects it on every GraphQL context — a non-action dispatch (`skipActionSlots: true`, `meta.recordWrite = { entity }`).
- **cap-permission** resolves that target to an entity-level WRITE data-access check (mirrors the existing `meta.onchange` read-target).

**Security (codex):** the WRITE gate **fails closed on conditional grants** — `resolveDataAccess` may return a row-level `DataAccessCondition`; this entity-level gate does not load the target record and cannot evaluate it, so only an unconditional `all` passes (`none` and any condition denied). Otherwise a row-scoped writer could comment on **any** record of the entity.

**New e2e:** `e2e-chatter-permission.test.ts` — real `createDevApp` + real cap-permission + cap-chatter, in-process `app.handle`: writer **ALLOWED**; read-only / conditional / stranger / anonymous all **DENIED** with nothing persisted.

### Documented follow-ups (separate focused PRs)
1. **Tenant-scoped chatter reads** — `getMessages` filters by `entityName`/`recordId` only, not `tenant_id`; two tenants sharing a record id can read each other's messages. The write path stamps `tenant_id`; only the read predicate is missing.
2. **Row-level chatter write authorization** — evaluate the `DataAccessCondition` against the target record (load it) so a conditional writer may comment on *their* records instead of being denied outright.
