### PR TITLE
chore(ci): auto-label cross-cutting PRs + Spec 21 §2.3 readiness snapshot (#84)

### DIFF
--- a/.github/workflows/label-cross-cutting.yml
+++ b/.github/workflows/label-cross-cutting.yml
@@ -1,0 +1,92 @@
+name: Label cross-cutting PRs
+
+# Implements the cross-cutting PR metric described in issue #84 (Spec 21 §2.3
+# split-readiness tracking): a PR that touches BOTH packages/ (core/cli/devtools)
+# AND addons/ (capabilities) is "cross-cutting" — it is the change shape that
+# would require cross-repo release choreography after a physical monorepo split.
+# Tracking them makes the "22% cross-cutting" anecdote a live, quantified metric.
+#
+# The `cross-cutting` label is applied when both directories are touched and
+# removed when an update to the PR eliminates the dual-touch (idempotent).
+#
+# Security: uses `pull_request` (not `pull_request_target`) so the restricted
+# GITHUB_TOKEN from fork PRs cannot perform write operations. Label addition
+# requires the `pull-requests: write` permission.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-cross-cutting:
+    name: Label cross-cutting PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect cross-cutting changes and sync label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'cross-cutting';
+            const LABEL_COLOR = 'e4e669';
+            const LABEL_DESC = 'Touches both packages/ and addons/ — split-readiness metric (Spec 21 §2.3, issue #84)';
+
+            // Paginate to handle PRs with >100 changed files.
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              },
+            );
+
+            const touchesPackages = files.some(f => f.filename.startsWith('packages/'));
+            const touchesAddons   = files.some(f => f.filename.startsWith('addons/'));
+            const isCrossCutting  = touchesPackages && touchesAddons;
+
+            if (isCrossCutting) {
+              // Ensure the label exists in the repo (idempotent).
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: LABEL,
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: LABEL,
+                  color: LABEL_COLOR,
+                  description: LABEL_DESC,
+                });
+                console.log(`Created label "${LABEL}".`);
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [LABEL],
+              });
+              console.log(`Added "${LABEL}" label — PR touches packages/ AND addons/.`);
+            } else {
+              // Remove the label when a force-push or subsequent commit means
+              // the PR no longer crosses both directories.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: LABEL,
+                });
+                console.log(`Removed "${LABEL}" label — PR no longer cross-cutting.`);
+              } catch {
+                // 404 = label was not present; ignore.
+              }
+            }

--- a/docs/specs/21_capability_ecosystem.md
+++ b/docs/specs/21_capability_ecosystem.md
@@ -137,6 +137,25 @@ linchkit-capabilities/            ← 官方能力仓库
 - CI 管道模板成熟，可独立运行
 - 版本兼容性校验工具就绪
 
+**分拆前置感知度量（split-readiness metrics, issue #84）：**
+
+每个 PR 若同时触碰 `packages/`（core/cli/devtools）和 `addons/`（Capabilities），则被自动打上 `cross-cutting` 标签（由 `.github/workflows/label-cross-cutting.yml` 执行）。该数字是分拆时机的核心信号：当 `cross-cutting` 占比持续走低，说明 core API 趋于稳定、能力与核心耦合减少，具备分拆条件。
+
+**就绪快照（2026-06）**
+
+| 指标 | 当前值 | 达标阈值 |
+|------|--------|---------|
+| core breaking-change 频率 | > 1次/月（近期 32 个未发布的 minor 变更积压） | < 1次/月，持续一个完整季度 |
+| `cross-cutting` PR 占比 | ~22%（60 个近期合并 PR 中 13 个跨目录） | —（量化基准，无硬阈值） |
+| 外部 Capability 作者数量 | 0 | ≥ 1 名真实外部作者（触发 Spec 21 §4.2 注册表） |
+
+**重新开启分拆决策的触发条件（满足任一即讨论）：**
+
+(a) core breaking-change 频率 < 1次/月，持续一个完整日历季度；
+(b) 出现第一位真实外部 Capability 作者（需要独立仓库 + manifest-PR 流程）。
+
+> 2026-06 决策：物理分拆 DEFER。以上三项指标均未达标；OCA 参考（Odoo 官方 addon 仍在主仓库）也支持延期。分拆准备就绪前，继续以上述度量跟踪进展，不做急于分拆的工程投入。
+
 ### 2.4 M3+：自建 Capability Hub
 
 在独立仓库的基础上，增加 Web UI 市场：


### PR DESCRIPTION
## Summary

Delivers two S-items from the 2026-06-10 repo-separation decision on #84 (the physical split is DEFERRED; these are the agreed preparedness items):

- **Cross-cutting PR label** — new `.github/workflows/label-cross-cutting.yml` auto-applies `cross-cutting` to any PR touching both `packages/` and `addons/`. Turns the "22% anecdote" into a live, quantified split-readiness metric.
- **Spec 21 §2.3 readiness snapshot** — records the 2026-06 measurements and the two re-open tripwires in the spec so they survive beyond the issue comment.

## Implementation notes

**`label-cross-cutting.yml`**
- Triggers on `pull_request` `opened/synchronize/reopened`.
- Uses `actions/github-script@v7` + `paginate` to handle PRs with >100 changed files.
- Idempotent: adds the label when BOTH `packages/` and `addons/` are touched; removes it when a subsequent force-push means the PR no longer qualifies.
- Auto-creates the `cross-cutting` label if it doesn't exist yet (color `e4e669`, description cites Spec 21 §2.3).
- Uses `pull_request` (not `pull_request_target`) — write permissions work for same-repo PRs; fork PRs have a restricted token and simply won't be labeled. Acceptable: the metric only needs to track first-party development.

**Spec 21 §2.3 update**
- Adds "split-readiness metrics" paragraph referencing the new workflow.
- Adds "就绪快照 (2026-06)" table: core breaking-change rate, cross-cutting %, external author count — each with current value and threshold.
- Documents the two tripwires verbatim from the decision comment.
- Adds a decision note (defer rationale, OCA reference).

## Spec alignment

- Spec 21 §2.3 (M2: 官方能力独立仓库) — the snapshot and metric are the preparedness tracking described in the 2026-06-10 decision comment on #84.
- Spec 21 §9.1 — the `capability-lint` CI job already enforces compliance; the cross-cutting label is a separate infra metric, not a lint gate.

## Quality gates

| Gate | Command | Status |
|------|---------|--------|
| Biome check | `BUN_REGISTRY=https://registry.npmjs.org bunx @biomejs/biome check .` | ✅ No errors (2 infos: biome config format migration — pre-existing, unrelated) |
| TypeScript | `BUN_REGISTRY=https://registry.npmjs.org bunx tsc --noEmit` | ✅ Exit 0 (pre-existing bun-types warning, not introduced here) |
| Tests | N/A — no TypeScript changed; YAML/Markdown only | ✅ Not applicable |
| `linch validate` | N/A — no meta-model files changed | ✅ Not applicable |

> Note: `registry.npmmirror.com` returns 403 in this sandbox environment (policy denial per proxy logs). Quality gates were run via `bunx` pointed at `registry.npmjs.org` (listed in the proxy's `noProxy` allow-list). Results are equivalent to `bun run check` / `bun run typecheck`.

## Retro

- **Why this approach:** The `actions/github-script` + `paginate` approach is the lightest path — no new Action dependencies, no separate config file, and handles large PRs correctly. The label remove-on-qualify logic makes it truly idempotent across force-pushes, which a one-shot add would miss.

- **Alternatives considered:**
  - `actions/labeler@v5` with a custom config: doesn't support AND conditions (only OR across file patterns), so it can't express "touches packages/ AND addons/" natively. Would need a workaround.
  - Shell script using `gh pr view --json files`: simpler but `gh` availability varies and adds a dep on the `gh` CLI being pre-installed in the runner image.
  - The `pull_request_target` event: would allow labeling fork PRs but introduces a supply-chain security risk (untrusted code running in privileged context). YAGNI — the metric only needs to track first-party development.

- **Security review:** no auth/tenant/input-trust surfaces touched. The workflow uses the least-privilege `GITHUB_TOKEN` with `pull-requests: write` only. The script reads `files[].filename` from the GitHub API (trusted source, not user-supplied input). No secrets, no eval, no injection vectors.

- **Other risks:** The workflow fires on every PR opened or updated. For repos with very high PR volume this could hit GitHub API rate limits, but the paginate call is capped at one per PR event and the label add/remove is a single API call — well within limits for a repo of this size.

- **Follow-ups:**
  - Promote the `capability-lint` CI job to a required branch-protection check (currently advisory) — needs a repo settings change, not a code change.
  - Revive the release train (#174) and publish `@linchkit/core@0.3.x` — the 32 unreleased core minors make the `>=0.3.0 <0.4.0` peer range declarations stale.
  - Stand up `capability-registry.json` skeleton (Spec 21 §4.2) when the first external author appears.

## Self-review checklist

- [x] Tests added/updated and passing (N/A — YAML + Markdown only)
- [x] `bun run check` green (via bunx, npm registry workaround; no errors)
- [x] `bun run typecheck` green (exit 0; no TypeScript changed)
- [x] `bun test` green (N/A — no TypeScript changed)
- [x] `linch validate` green (N/A — no meta-model files changed)
- [x] Spec referenced in PR body (Spec 21 §2.3 + §9.1)
- [x] Mandatory security review walked through (no auth/tenant/input-trust surfaces touched)
- [x] No new dependencies (uses `actions/github-script@v7`, already used by `claude-review.yml`)
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside the issue's scope
- [x] Branch name + commit messages follow convention (`chore/cross-cutting-label-84`)
- [x] Every comment posted has a real timestamp (no `<UTC time>` placeholder)
- [x] All commits have author = `claude-agent[bot]` (verified: `git log -1 --format='%ae'` → `claude-agent[bot]@users.noreply.github.com`)

Closes #84

---
_Generated by [Claude Code](https://claude.ai/code/session_01RficXBkPkv8Rc3sezAejU4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests are now automatically tagged as **cross-cutting** when they change files in both major areas of the project.
  * The label is added or removed automatically as PRs are updated.

* **Documentation**
  * Updated the ecosystem strategy notes with current readiness metrics and clear conditions for revisiting the split decision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->